### PR TITLE
docs: add mobile monorepo migration plan

### DIFF
--- a/docs/mobile-monorepo-plan.md
+++ b/docs/mobile-monorepo-plan.md
@@ -313,7 +313,11 @@ Exit criteria:
 ### Payment integration differences
 
 - Web uses `react-razorpay`
+- Mobile should use `react-native-razorpay`
 - Mobile cannot use the same UI entrypoint
+- `react-native-razorpay` requires native modules, so it works with Expo prebuild/dev client or bare workflow, but not Expo Go
+- Mobile checkout uses a different callback model than the web widget
+- Android will need explicit UPI deep-link handling and verification during checkout QA
 - Mitigation: isolate payment orchestration from UI invocation
 
 ### Auth/provider divergence

--- a/docs/mobile-monorepo-plan.md
+++ b/docs/mobile-monorepo-plan.md
@@ -1,0 +1,378 @@
+# Mobile Monorepo Migration Plan
+
+## Scope
+
+This plan adds a React Native mobile app to the repository while preserving the existing customer-facing product behavior and all backend flows.
+
+In scope:
+
+- Customer-facing mobile app parity for browse, course details, cart, checkout, account, enrollments, Mind Points, referrals, contact, and careers flows where practical
+- Shared backend contract across web and mobile
+- Shared environment-variable contract across web, mobile, and Convex
+- Monorepo restructuring needed to support multiple frontends
+
+Out of scope for the initial rollout:
+
+- Admin mobile parity
+- Rebuilding all web-only admin upload tooling for mobile
+- Major feature changes or backend workflow changes
+
+## Goals
+
+- Keep Convex as the single backend and source of business truth
+- Keep the existing environment-variable names stable
+- Minimize duplication between web and mobile
+- Preserve payment, email, Google Sheets, loyalty, and referral flows
+- Avoid a hard cutover by migrating in phases
+
+## Current Constraints
+
+The current backend is already centralized enough to support multiple frontends, but the frontend code is not.
+
+Main blockers:
+
+- Checkout depends on a Next API route and Next server action
+- Auth and Convex providers are tied to `@clerk/nextjs`
+- Shared domain logic is mixed into web components and `app/`
+- Convex generated types are imported through the web alias path
+- Several flows rely on browser-only APIs and web-only libraries
+
+Files that define the current coupling points:
+
+- [components/CartClient.tsx](/Users/ayushjuvekar/Work/mindpoint/components/CartClient.tsx)
+- [app/actions/payment.ts](/Users/ayushjuvekar/Work/mindpoint/app/actions/payment.ts)
+- [app/api/create-order/route.ts](/Users/ayushjuvekar/Work/mindpoint/app/api/create-order/route.ts)
+- [components/ClientProviders.tsx](/Users/ayushjuvekar/Work/mindpoint/components/ClientProviders.tsx)
+- [components/ConvexClientProvider.tsx](/Users/ayushjuvekar/Work/mindpoint/components/ConvexClientProvider.tsx)
+
+## Target Repository Shape
+
+```text
+mindpoint/
+├── apps/
+│   ├── web/                 # Next.js app
+│   └── mobile/              # Expo / React Native app
+├── packages/
+│   ├── backend/             # Shared Convex API/type entrypoints
+│   ├── domain/              # Shared business logic, schemas, helpers
+│   ├── config/              # Shared env parsing and platform-safe config
+│   └── ui-core/             # Optional non-platform-specific UI tokens/types
+├── convex/                  # Shared backend
+├── docs/
+└── package.json             # Workspace root
+```
+
+## Package Boundaries
+
+### `apps/web`
+
+- Keeps the existing Next.js product
+- Owns SSR, metadata, middleware, web routing, web-only analytics, and any browser-only implementation
+- Becomes a thin composition layer over shared packages where possible
+
+### `apps/mobile`
+
+- Expo-managed React Native app
+- Uses the same Convex functions and business rules as web
+- Owns mobile navigation, device storage, mobile auth bindings, and mobile payment entrypoints
+
+### `packages/backend`
+
+- Re-exports shared Convex generated types and API references
+- Gives both apps a stable import path instead of depending on web aliases
+
+Expected contents:
+
+- typed exports for `api`
+- typed exports for `Id`, `Doc`, and related Convex model helpers
+
+### `packages/domain`
+
+- Shared business logic only
+- No Next.js, Expo, DOM, or React Native imports
+
+Expected contents:
+
+- pricing and promotion helpers
+- cart item models
+- checkout request and result types
+- referral parsing helpers
+- date and time helpers
+- validation schemas
+
+### `packages/config`
+
+- Canonical env parsing and config helpers
+- Separates secret server config from client-safe public config
+- Keeps naming consistent across platforms
+
+## Environment Variable Strategy
+
+Environment-variable names remain stable at the repo level.
+
+Canonical names already in use:
+
+- `NEXT_PUBLIC_CONVEX_URL`
+- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
+- `CLERK_SECRET_KEY`
+- `CLERK_JWT_ISSUER_DOMAIN`
+- `NEXT_PUBLIC_RAZORPAY_KEY_ID`
+- `RAZORPAY_KEY_SECRET`
+- `RESEND_API_KEY`
+- `GOOGLE_APPLICATION_CREDENTIALS_JSON`
+- `GOOGLE_SHEETS_SPREADSHEET_ID`
+- `GOOGLE_SHEETS_SHEET_NAME`
+- `NEXT_PUBLIC_POSTHOG_KEY`
+- `NEXT_PUBLIC_POSTHOG_HOST`
+- `NEXT_PUBLIC_SITE_URL`
+
+Rules:
+
+- Do not rename backend or existing web env vars as part of this migration
+- Mobile reads from the same root env contract
+- Expo-specific public env exposure should happen in `app.config.ts`, not by changing the canonical env names
+- Only safe client values should be exposed to the mobile bundle
+
+Practical implication:
+
+- Root `.env.local` remains the source of truth for local development
+- `apps/mobile/app.config.ts` maps the canonical root envs into Expo `extra`
+- Convex dashboard secrets remain unchanged
+
+## Backend Compatibility Rules
+
+These flows must remain unchanged at the backend level:
+
+- Course browse and filtering
+- Enrollment creation
+- Guest checkout
+- Mind Points earn and redeem
+- Referral reward application
+- Email scheduling
+- Google Sheets sync
+- Admin-only mutations and queries
+
+What changes:
+
+- Frontends stop depending on web-only entrypoints to reach those flows
+
+What does not change:
+
+- Convex schema
+- Existing Convex public function names unless there is a compelling cleanup reason
+- Existing environment-variable names
+- Existing side effects such as emails and Sheets sync
+
+## Auth Strategy
+
+Web stays on `@clerk/nextjs`.
+
+Mobile uses Clerk’s Expo integration with secure token storage. Convex auth still uses the same Clerk-backed model and JWT template.
+
+Requirements:
+
+- Keep the Clerk `convex` JWT template
+- Ensure both apps can request a Convex-compatible token
+- Move shared auth-dependent logic out of Next-specific providers
+
+Implementation direction:
+
+- Web provider stays web-specific
+- Mobile provider uses Expo Clerk primitives
+- Shared app code consumes a platform-neutral auth interface where practical
+
+## Payment Strategy
+
+This is the most sensitive migration area.
+
+Current web flow:
+
+1. Web creates a Razorpay order through a Next API route
+2. Web opens the Razorpay checkout widget
+3. Web calls a Next server action after success
+4. The server action calls Convex mutations to create enrollments
+
+This cannot be reused directly by mobile.
+
+Planned direction:
+
+1. Move order creation behind a shared backend entrypoint that web and mobile can both call
+2. Move post-payment enrollment finalization behind shared backend-facing application code
+3. Keep the same Convex enrollment mutations
+4. Keep web behavior unchanged during the transition by having web routes call the new shared entrypoints
+
+Important constraint:
+
+- Payment UX will differ between web and mobile, but the business outcome must remain identical
+
+## Rollout Phases
+
+### Phase 0: Planning and guardrails
+
+- Add this migration plan
+- Freeze the initial scope to customer-facing parity only
+- Define acceptance criteria per flow
+
+### Phase 1: Convert the repo into a workspace monorepo
+
+- Add workspace configuration at the root
+- Move the current Next app into `apps/web`
+- Keep all root scripts working via workspace-aware commands
+- Preserve Convex at the repository root
+
+Exit criteria:
+
+- Web app still runs
+- Convex still runs
+- Typecheck and lint still work from the root
+
+### Phase 2: Extract shared packages
+
+- Create `packages/backend`
+- Create `packages/domain`
+- Create `packages/config`
+- Replace direct web alias imports for shared backend/domain concerns
+
+Priority extractions:
+
+- Convex generated API/type imports
+- checkout types
+- pricing and promotion logic
+- cart types
+- referral helpers
+- env parsing
+
+Exit criteria:
+
+- Web behavior unchanged
+- Shared package imports used from the web app
+- No domain package imports depend on Next APIs or browser globals
+
+### Phase 3: Decouple web-only backend entrypoints
+
+- Replace direct dependence on Next server actions for checkout finalization
+- Replace direct dependence on Next API routes for order creation where needed
+- Keep temporary web wrappers for compatibility
+
+Candidate targets:
+
+- payment order creation
+- contact submission
+- careers submission
+
+Exit criteria:
+
+- Web uses shared application services instead of app-local route assumptions
+- Mobile can call the same backend-facing services
+
+### Phase 4: Bootstrap the mobile app
+
+- Create `apps/mobile` with Expo
+- Add TypeScript, navigation, Convex, and Clerk integration
+- Add shared env/config plumbing
+- Verify authenticated and guest data access
+
+Exit criteria:
+
+- Mobile app can browse courses
+- Mobile app can sign in
+- Mobile app can query Convex with auth
+
+### Phase 5: Rebuild customer-facing product flows on mobile
+
+Priority order:
+
+1. Home and course listing
+2. Course detail
+3. Cart
+4. Checkout
+5. Account and enrollments
+6. Mind Points
+7. Referrals
+8. Contact and careers
+
+Notes:
+
+- Mobile UI does not need to match web one-to-one
+- Feature behavior must remain the same
+
+Exit criteria:
+
+- Customer-facing parity is achieved for the agreed flows
+
+### Phase 6: Hardening and release prep
+
+- End-to-end validation on web and mobile
+- Environment validation for local, preview, and production
+- Error reporting review
+- Analytics review
+- Documentation update
+
+## Risks
+
+### Payment integration differences
+
+- Web uses `react-razorpay`
+- Mobile cannot use the same UI entrypoint
+- Mitigation: isolate payment orchestration from UI invocation
+
+### Auth/provider divergence
+
+- Web and mobile will have different Clerk provider implementations
+- Mitigation: keep shared logic below the provider layer
+
+### Hidden browser-only logic
+
+- Referral cookies, clipboard APIs, DOM inspection, and local storage assumptions exist today
+- Mitigation: audit and move these behind platform-specific adapters
+
+### Shared package contamination
+
+- It is easy to accidentally import Next-only modules into shared code
+- Mitigation: keep package responsibilities narrow and enforce import discipline
+
+## Verification Checklist
+
+Each phase should be verified against these flows:
+
+- Browse courses and variants
+- Promotion pricing and BOGO logic
+- Add to cart and modify quantities
+- Guest checkout
+- Authenticated checkout
+- Enrollment creation
+- Mind Points accrual and redemption
+- Referral attribution
+- Contact form submission
+- Careers submission
+
+Non-functional checks:
+
+- Web build still passes
+- Mobile build runs locally
+- Root typecheck passes
+- Env names remain stable
+- Convex deployment contract remains unchanged
+
+## Initial Implementation Order
+
+This is the execution order for the first code changes after planning:
+
+1. Add workspace structure
+2. Move web app into `apps/web`
+3. Add `packages/backend` for Convex re-exports
+4. Add `packages/domain` for checkout, cart, and pricing logic
+5. Add `packages/config` for env access
+6. Repoint the web app to shared packages
+7. Extract checkout orchestration away from Next server actions
+8. Scaffold `apps/mobile`
+
+## Acceptance Criteria For The First Milestone
+
+The first milestone is complete when:
+
+- The repo is a working workspace monorepo
+- The web app still behaves the same
+- Shared backend and domain packages exist and are in active use
+- No customer-facing behavior has changed
+- The codebase is ready to add `apps/mobile` without redoing package boundaries

--- a/docs/mobile-monorepo-plan.md
+++ b/docs/mobile-monorepo-plan.md
@@ -39,11 +39,11 @@ Main blockers:
 
 Files that define the current coupling points:
 
-- [components/CartClient.tsx](/Users/ayushjuvekar/Work/mindpoint/components/CartClient.tsx)
-- [app/actions/payment.ts](/Users/ayushjuvekar/Work/mindpoint/app/actions/payment.ts)
-- [app/api/create-order/route.ts](/Users/ayushjuvekar/Work/mindpoint/app/api/create-order/route.ts)
-- [components/ClientProviders.tsx](/Users/ayushjuvekar/Work/mindpoint/components/ClientProviders.tsx)
-- [components/ConvexClientProvider.tsx](/Users/ayushjuvekar/Work/mindpoint/components/ConvexClientProvider.tsx)
+- [components/CartClient.tsx](../components/CartClient.tsx)
+- [app/actions/payment.ts](../app/actions/payment.ts)
+- [app/api/create-order/route.ts](../app/api/create-order/route.ts)
+- [components/ClientProviders.tsx](../components/ClientProviders.tsx)
+- [components/ConvexClientProvider.tsx](../components/ConvexClientProvider.tsx)
 
 ## Target Repository Shape
 


### PR DESCRIPTION
## Summary
- Add a new planning document at `docs/mobile-monorepo-plan.md` for migrating to a workspace monorepo with `apps/web` and `apps/mobile`.
- Define package boundaries for `packages/backend`, `packages/domain`, and `packages/config` to reduce web/mobile duplication.
- Document env var, auth, and payment migration strategies while preserving current Convex contracts and customer-facing behavior.
- Lay out phased rollout, risks, verification checklist, and first-milestone acceptance criteria.

## Testing
- Not run (documentation-only change; no code paths executed).
- Verified scope from diff: 1 new file added, `378` lines inserted in `docs/mobile-monorepo-plan.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation detailing the migration plan to introduce a React Native mobile app into the monorepo. Covers scope and goals, target repository shape and package boundaries, environment and backend compatibility strategies, auth and payment considerations, phased rollout with milestones, risks and verification checklist, initial implementation order, and acceptance criteria for the first milestone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a comprehensive planning document (`docs/mobile-monorepo-plan.md`) for migrating the existing Next.js monolith into a workspace monorepo that supports a new Expo/React Native mobile app. No code is changed — the deliverable is the plan itself. The document is well-organized (scope, goals, package boundaries, env strategy, auth/payment strategy, phased rollout, risks, and acceptance criteria) and correctly identifies the most sensitive migration areas (payment flow, Clerk provider divergence, and browser-only logic).

**Issues found:**

- `packages/ui-core` is included in the target repo tree but has no Package Boundaries section, leaving its purpose, allowed imports, and creation phase undefined.
- The workspace manager (npm, pnpm, or Yarn) is not specified in Phase 1, which matters for contamination enforcement — pnpm's strict isolation would directly reinforce the "import discipline" mitigation listed in Risks.
- `packages/config`'s definition ends after three high-level lines with no "Expected contents" list, unlike `packages/backend` and `packages/domain` — a gap that is security-relevant given its role separating server secrets from client-safe values.
- The "Hidden browser-only logic" risk does not name `react-use-cart` (currently in `package.json`), which persists cart state via `localStorage` and will throw at runtime in React Native — it's a concrete blocker for the Phase 2 cart extraction and Phase 4 bootstrap.
- File links to the five coupling-point files (lines 42–46) will become stale once Phase 1 moves the web app to `apps/web/`.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — documentation-only change with no code execution risk; gaps identified are planning-level concerns, not blockers for merging the doc.
- The plan is thorough and the migration strategy is sound. The deductions are for four documentation gaps that could cause implementer confusion or surface as blockers during Phase 2–4: unspecified workspace manager, missing `packages/ui-core` boundary, incomplete `packages/config` definition, and the unnamed `react-use-cart` localStorage dependency. None of these prevent merging the planning document, but they should be addressed before Phase 1 work begins.
- docs/mobile-monorepo-plan.md — see comments on `packages/ui-core` boundary, workspace manager choice, `packages/config` Expected Contents, and `react-use-cart` callout.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/mobile-monorepo-plan.md | New 382-line migration plan for adding a React Native mobile app to the monorepo. The plan is well-structured with phased rollout, risks, and acceptance criteria. Four gaps found: `packages/ui-core` listed in the repo tree has no Package Boundaries section; the workspace manager (npm/pnpm/yarn) is unspecified despite the choice affecting contamination enforcement; `packages/config` lacks an Expected Contents list unlike its sibling packages; and `react-use-cart`'s localStorage dependency is not called out by name in the browser-only risks section, leaving a concrete Phase 2/4 blocker undocumented. File links to coupling points will also become stale after Phase 1 moves the web app to `apps/web/`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    P0["Phase 0: Planning & guardrails\n(this document)"]
    P1["Phase 1: Workspace monorepo\nMove web → apps/web\nPreserve convex at root"]
    P2["Phase 2: Extract shared packages\npackages/backend\npackages/domain\npackages/config"]
    P3["Phase 3: Decouple web-only entrypoints\nReplace Next server actions\nReplace Next API routes"]
    P4["Phase 4: Bootstrap apps/mobile\nExpo + Clerk + Convex\nShared env/config plumbing"]
    P5["Phase 5: Rebuild customer flows\nCourses → Cart → Checkout\nAccount → MindPoints → Referrals"]
    P6["Phase 6: Hardening & release prep\nE2E validation, analytics,\nerror reporting, docs"]

    P0 --> P1
    P1 --> P2
    P2 --> P3
    P3 --> P4
    P4 --> P5
    P5 --> P6

    subgraph SharedPackages["Shared packages (Phase 2)"]
        BE["packages/backend\nConvex api + Id/Doc re-exports"]
        DOM["packages/domain\nPricing, cart, checkout, referral"]
        CFG["packages/config\nEnv parsing, server vs client split"]
    end

    P2 -.-> SharedPackages

    subgraph Apps["Target apps"]
        WEB["apps/web (Next.js)\n@clerk/nextjs\nreact-razorpay"]
        MOB["apps/mobile (Expo)\n@clerk/expo\nreact-native-razorpay"]
    end

    P4 -.-> MOB
    P1 -.-> WEB

    SharedPackages --> WEB
    SharedPackages --> MOB

    CONVEX["convex/\nSingle shared backend"]
    WEB --> CONVEX
    MOB --> CONVEX
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A59%0A**%60packages%2Fui-core%60%20has%20no%20Package%20Boundaries%20section**%0A%0A%60packages%2Fui-core%60%20is%20listed%20in%20the%20target%20repo%20shape%20%28line%2059%29%20but%20the%20%22Package%20Boundaries%22%20section%20that%20follows%20defines%20boundaries%20for%20%60apps%2Fweb%60%2C%20%60apps%2Fmobile%60%2C%20%60packages%2Fbackend%60%2C%20%60packages%2Fdomain%60%2C%20and%20%60packages%2Fconfig%60%20%E2%80%94%20with%20no%20corresponding%20entry%20for%20%60packages%2Fui-core%60.%0A%0AWithout%20a%20defined%20boundary%2C%20implementers%20won't%20know%3A%0A-%20Whether%20to%20create%20it%20upfront%20or%20defer%20it%0A-%20What%20it%20may%20vs.%20may%20not%20import%20%28e.g.%20can%20it%20import%20React%3F%20Tailwind%20tokens%3F%20CSS%20variables%3F%29%0A-%20Which%20phase%20it%20belongs%20to%20%28it's%20absent%20from%20the%20Phase%202%20extraction%20list%20as%20well%29%0A%0AConsider%20either%20adding%20a%20Package%20Boundaries%20subsection%20for%20it%20or%20removing%20it%20from%20the%20tree%20and%20noting%20it%20as%20a%20potential%20future%20package.%0A%0A%23%23%23%20Issue%202%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A216-221%0A**Workspace%20manager%20not%20specified**%0A%0APhase%201%20says%20%22Add%20workspace%20configuration%20at%20the%20root%22%20but%20doesn't%20name%20the%20workspace%20manager%20%28npm%2C%20pnpm%2C%20or%20Yarn%29.%20The%20current%20repo%20already%20uses%20npm%20%28%60npm-run-all%60%20in%20%60package.json%60%2C%20no%20%60pnpm-lock.yaml%60%29%2C%20but%20the%20choice%20has%20real%20consequences%20for%20the%20monorepo%3A%0A%0A-%20**npm%20workspaces**%20%E2%80%94%20simplest%20migration%20path%20from%20the%20current%20setup%2C%20but%20no%20module%20isolation%20enforcement%0A-%20**pnpm%20workspaces**%20%E2%80%94%20strict%20symlink%20isolation%20catches%20%60packages%2Fdomain%60%20accidentally%20importing%20Next.js%20through%20hoisting%2C%20which%20directly%20supports%20the%20%22Shared%20package%20contamination%22%20mitigation%20listed%20in%20Risks%0A-%20**Yarn%20Berry**%20%E2%80%94%20more%20complex%20adoption%20overhead%0A%0AGiven%20that%20the%20plan%20explicitly%20calls%20out%20%22enforce%20import%20discipline%22%20as%20the%20shared%20package%20contamination%20mitigation%2C%20documenting%20the%20workspace%20manager%20here%20%28and%20noting%20whether%20a%20lockfile%20change%20is%20expected%29%20would%20prevent%20ambiguity%20when%20Phase%201%20work%20starts.%0A%0A%23%23%23%20Issue%203%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A42-46%0A**Links%20will%20become%20stale%20after%20Phase%201**%0A%0AThe%20five%20coupling-point%20links%20currently%20resolve%20correctly%20from%20%60docs%2F%60%20%28e.g.%20%60..%2Fcomponents%2FCartClient.tsx%60%20%E2%86%92%20%60components%2FCartClient.tsx%60%20at%20the%20repo%20root%29.%20However%2C%20Phase%201%20moves%20the%20web%20app%20into%20%60apps%2Fweb%2F%60%2C%20relocating%20each%20of%20these%20files%3A%0A%0A%7C%20Current%20path%20%28valid%20now%29%20%7C%20Post-Phase-1%20path%20%7C%0A%7C---%7C---%7C%0A%7C%20%60..%2Fcomponents%2FCartClient.tsx%60%20%7C%20%60..%2Fapps%2Fweb%2Fcomponents%2FCartClient.tsx%60%20%7C%0A%7C%20%60..%2Fapp%2Factions%2Fpayment.ts%60%20%7C%20%60..%2Fapps%2Fweb%2Fapp%2Factions%2Fpayment.ts%60%20%7C%0A%7C%20%60..%2Fapp%2Fapi%2Fcreate-order%2Froute.ts%60%20%7C%20%60..%2Fapps%2Fweb%2Fapp%2Fapi%2Fcreate-order%2Froute.ts%60%20%7C%0A%7C%20%60..%2Fcomponents%2FClientProviders.tsx%60%20%7C%20%60..%2Fapps%2Fweb%2Fcomponents%2FClientProviders.tsx%60%20%7C%0A%7C%20%60..%2Fcomponents%2FConvexClientProvider.tsx%60%20%7C%20%60..%2Fapps%2Fweb%2Fcomponents%2FConvexClientProvider.tsx%60%20%7C%0A%0AAdding%20a%20note%20here%20%28or%20updating%20the%20links%20as%20part%20of%20Phase%201's%20exit%20criteria%29%20would%20keep%20the%20doc%20accurate%20after%20the%20move.%0A%0A%23%23%23%20Issue%204%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A103-107%0A**%60packages%2Fconfig%60%20missing%20Expected%20Contents%20section**%0A%0A%60packages%2Fbackend%60%20%28lines%2084%E2%80%9387%29%20and%20%60packages%2Fdomain%60%20%28lines%2094%E2%80%93101%29%20both%20have%20explicit%20%22Expected%20contents%22%20bullet%20lists%2C%20but%20%60packages%2Fconfig%60%20ends%20after%20three%20high-level%20description%20lines%20with%20no%20equivalent%20list.%0A%0AThis%20matters%20because%20%60packages%2Fconfig%60%20straddles%20the%20server%2Fclient%20boundary%20in%20a%20security-sensitive%20way%20%28secrets%20vs.%20public%20values%29.%20Without%20a%20concrete%20list%2C%20it's%20easy%20for%20implementers%20to%20accidentally%20put%20%60CLERK_SECRET_KEY%60%20or%20%60RAZORPAY_KEY_SECRET%60%20parsing%20in%20the%20client-safe%20export.%0A%0AConsider%20adding%20an%20Expected%20Contents%20section%20similar%20to%20the%20other%20packages%2C%20for%20example%3A%0A%0A-%20%60serverConfig%60%20%E2%80%94%20parses%20and%20validates%20server-only%20secrets%20%28%60CLERK_SECRET_KEY%60%2C%20%60RAZORPAY_KEY_SECRET%60%2C%20%60RESEND_API_KEY%60%2C%20etc.%29%20%E2%80%94%20never%20imported%20by%20client%20bundles%0A-%20%60publicConfig%60%20%E2%80%94%20parses%20only%20%60NEXT_PUBLIC_*%60%20%2F%20Expo-safe%20values%20safe%20for%20the%20client%20bundle%0A-%20Platform-specific%20helpers%20%28e.g.%20Expo%20%60extra%60%20accessor%29%0A%0A%23%23%23%20Issue%205%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A328-331%0A**%60react-use-cart%60%20is%20a%20localStorage-dependent%20web-only%20library**%0A%0AThe%20%22Hidden%20browser-only%20logic%22%20risk%20mentions%20%22local%20storage%20assumptions%22%20generically%2C%20but%20the%20current%20%60package.json%60%20depends%20on%20%60react-use-cart%60%2C%20which%20persists%20cart%20state%20exclusively%20via%20%60localStorage%60.%20This%20is%20a%20concrete%2C%20named%20dependency%20that%3A%0A%0A1.%20Cannot%20be%20used%20in%20React%20Native%20at%20all%20%E2%80%94%20it%20will%20throw%20at%20runtime%20because%20%60localStorage%60%20is%20undefined%0A2.%20Must%20be%20replaced%20or%20wrapped%20before%20cart%20state%20can%20be%20shared%20in%20%60packages%2Fdomain%60%20%28Phase%202%20priority%20extraction%20includes%20%22cart%20types%22%20and%20%22cart%20item%20models%22%29%0A%0ANaming%20%60react-use-cart%60%20here%20alongside%20the%20mitigation%20strategy%20%28e.g.%20%22replace%20with%20a%20platform-neutral%20cart%20store%20or%20an%20adapter%20that%20uses%20%60AsyncStorage%60%20on%20mobile%20and%20%60localStorage%60%20on%20web%22%29%20would%20make%20the%20Phase%202%20extraction%20scope%20concrete%20and%20avoid%20a%20surprise%20blocker%20in%20Phase%204.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A59%0A**%60packages%2Fui-core%60%20has%20no%20Package%20Boundaries%20section**%0A%0A%60packages%2Fui-core%60%20is%20listed%20in%20the%20target%20repo%20shape%20%28line%2059%29%20but%20the%20%22Package%20Boundaries%22%20section%20that%20follows%20defines%20boundaries%20for%20%60apps%2Fweb%60%2C%20%60apps%2Fmobile%60%2C%20%60packages%2Fbackend%60%2C%20%60packages%2Fdomain%60%2C%20and%20%60packages%2Fconfig%60%20%E2%80%94%20with%20no%20corresponding%20entry%20for%20%60packages%2Fui-core%60.%0A%0AWithout%20a%20defined%20boundary%2C%20implementers%20won't%20know%3A%0A-%20Whether%20to%20create%20it%20upfront%20or%20defer%20it%0A-%20What%20it%20may%20vs.%20may%20not%20import%20%28e.g.%20can%20it%20import%20React%3F%20Tailwind%20tokens%3F%20CSS%20variables%3F%29%0A-%20Which%20phase%20it%20belongs%20to%20%28it's%20absent%20from%20the%20Phase%202%20extraction%20list%20as%20well%29%0A%0AConsider%20either%20adding%20a%20Package%20Boundaries%20subsection%20for%20it%20or%20removing%20it%20from%20the%20tree%20and%20noting%20it%20as%20a%20potential%20future%20package.%0A%0A%23%23%23%20Issue%202%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A216-221%0A**Workspace%20manager%20not%20specified**%0A%0APhase%201%20says%20%22Add%20workspace%20configuration%20at%20the%20root%22%20but%20doesn't%20name%20the%20workspace%20manager%20%28npm%2C%20pnpm%2C%20or%20Yarn%29.%20The%20current%20repo%20already%20uses%20npm%20%28%60npm-run-all%60%20in%20%60package.json%60%2C%20no%20%60pnpm-lock.yaml%60%29%2C%20but%20the%20choice%20has%20real%20consequences%20for%20the%20monorepo%3A%0A%0A-%20**npm%20workspaces**%20%E2%80%94%20simplest%20migration%20path%20from%20the%20current%20setup%2C%20but%20no%20module%20isolation%20enforcement%0A-%20**pnpm%20workspaces**%20%E2%80%94%20strict%20symlink%20isolation%20catches%20%60packages%2Fdomain%60%20accidentally%20importing%20Next.js%20through%20hoisting%2C%20which%20directly%20supports%20the%20%22Shared%20package%20contamination%22%20mitigation%20listed%20in%20Risks%0A-%20**Yarn%20Berry**%20%E2%80%94%20more%20complex%20adoption%20overhead%0A%0AGiven%20that%20the%20plan%20explicitly%20calls%20out%20%22enforce%20import%20discipline%22%20as%20the%20shared%20package%20contamination%20mitigation%2C%20documenting%20the%20workspace%20manager%20here%20%28and%20noting%20whether%20a%20lockfile%20change%20is%20expected%29%20would%20prevent%20ambiguity%20when%20Phase%201%20work%20starts.%0A%0A%23%23%23%20Issue%203%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A42-46%0A**Links%20will%20become%20stale%20after%20Phase%201**%0A%0AThe%20five%20coupling-point%20links%20currently%20resolve%20correctly%20from%20%60docs%2F%60%20%28e.g.%20%60..%2Fcomponents%2FCartClient.tsx%60%20%E2%86%92%20%60components%2FCartClient.tsx%60%20at%20the%20repo%20root%29.%20However%2C%20Phase%201%20moves%20the%20web%20app%20into%20%60apps%2Fweb%2F%60%2C%20relocating%20each%20of%20these%20files%3A%0A%0A%7C%20Current%20path%20%28valid%20now%29%20%7C%20Post-Phase-1%20path%20%7C%0A%7C---%7C---%7C%0A%7C%20%60..%2Fcomponents%2FCartClient.tsx%60%20%7C%20%60..%2Fapps%2Fweb%2Fcomponents%2FCartClient.tsx%60%20%7C%0A%7C%20%60..%2Fapp%2Factions%2Fpayment.ts%60%20%7C%20%60..%2Fapps%2Fweb%2Fapp%2Factions%2Fpayment.ts%60%20%7C%0A%7C%20%60..%2Fapp%2Fapi%2Fcreate-order%2Froute.ts%60%20%7C%20%60..%2Fapps%2Fweb%2Fapp%2Fapi%2Fcreate-order%2Froute.ts%60%20%7C%0A%7C%20%60..%2Fcomponents%2FClientProviders.tsx%60%20%7C%20%60..%2Fapps%2Fweb%2Fcomponents%2FClientProviders.tsx%60%20%7C%0A%7C%20%60..%2Fcomponents%2FConvexClientProvider.tsx%60%20%7C%20%60..%2Fapps%2Fweb%2Fcomponents%2FConvexClientProvider.tsx%60%20%7C%0A%0AAdding%20a%20note%20here%20%28or%20updating%20the%20links%20as%20part%20of%20Phase%201's%20exit%20criteria%29%20would%20keep%20the%20doc%20accurate%20after%20the%20move.%0A%0A%23%23%23%20Issue%204%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A103-107%0A**%60packages%2Fconfig%60%20missing%20Expected%20Contents%20section**%0A%0A%60packages%2Fbackend%60%20%28lines%2084%E2%80%9387%29%20and%20%60packages%2Fdomain%60%20%28lines%2094%E2%80%93101%29%20both%20have%20explicit%20%22Expected%20contents%22%20bullet%20lists%2C%20but%20%60packages%2Fconfig%60%20ends%20after%20three%20high-level%20description%20lines%20with%20no%20equivalent%20list.%0A%0AThis%20matters%20because%20%60packages%2Fconfig%60%20straddles%20the%20server%2Fclient%20boundary%20in%20a%20security-sensitive%20way%20%28secrets%20vs.%20public%20values%29.%20Without%20a%20concrete%20list%2C%20it's%20easy%20for%20implementers%20to%20accidentally%20put%20%60CLERK_SECRET_KEY%60%20or%20%60RAZORPAY_KEY_SECRET%60%20parsing%20in%20the%20client-safe%20export.%0A%0AConsider%20adding%20an%20Expected%20Contents%20section%20similar%20to%20the%20other%20packages%2C%20for%20example%3A%0A%0A-%20%60serverConfig%60%20%E2%80%94%20parses%20and%20validates%20server-only%20secrets%20%28%60CLERK_SECRET_KEY%60%2C%20%60RAZORPAY_KEY_SECRET%60%2C%20%60RESEND_API_KEY%60%2C%20etc.%29%20%E2%80%94%20never%20imported%20by%20client%20bundles%0A-%20%60publicConfig%60%20%E2%80%94%20parses%20only%20%60NEXT_PUBLIC_*%60%20%2F%20Expo-safe%20values%20safe%20for%20the%20client%20bundle%0A-%20Platform-specific%20helpers%20%28e.g.%20Expo%20%60extra%60%20accessor%29%0A%0A%23%23%23%20Issue%205%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A328-331%0A**%60react-use-cart%60%20is%20a%20localStorage-dependent%20web-only%20library**%0A%0AThe%20%22Hidden%20browser-only%20logic%22%20risk%20mentions%20%22local%20storage%20assumptions%22%20generically%2C%20but%20the%20current%20%60package.json%60%20depends%20on%20%60react-use-cart%60%2C%20which%20persists%20cart%20state%20exclusively%20via%20%60localStorage%60.%20This%20is%20a%20concrete%2C%20named%20dependency%20that%3A%0A%0A1.%20Cannot%20be%20used%20in%20React%20Native%20at%20all%20%E2%80%94%20it%20will%20throw%20at%20runtime%20because%20%60localStorage%60%20is%20undefined%0A2.%20Must%20be%20replaced%20or%20wrapped%20before%20cart%20state%20can%20be%20shared%20in%20%60packages%2Fdomain%60%20%28Phase%202%20priority%20extraction%20includes%20%22cart%20types%22%20and%20%22cart%20item%20models%22%29%0A%0ANaming%20%60react-use-cart%60%20here%20alongside%20the%20mitigation%20strategy%20%28e.g.%20%22replace%20with%20a%20platform-neutral%20cart%20store%20or%20an%20adapter%20that%20uses%20%60AsyncStorage%60%20on%20mobile%20and%20%60localStorage%60%20on%20web%22%29%20would%20make%20the%20Phase%202%20extraction%20scope%20concrete%20and%20avoid%20a%20surprise%20blocker%20in%20Phase%204.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A59%0A**%60packages%2Fui-core%60%20has%20no%20Package%20Boundaries%20section**%0A%0A%60packages%2Fui-core%60%20is%20listed%20in%20the%20target%20repo%20shape%20%28line%2059%29%20but%20the%20%22Package%20Boundaries%22%20section%20that%20follows%20defines%20boundaries%20for%20%60apps%2Fweb%60%2C%20%60apps%2Fmobile%60%2C%20%60packages%2Fbackend%60%2C%20%60packages%2Fdomain%60%2C%20and%20%60packages%2Fconfig%60%20%E2%80%94%20with%20no%20corresponding%20entry%20for%20%60packages%2Fui-core%60.%0A%0AWithout%20a%20defined%20boundary%2C%20implementers%20won't%20know%3A%0A-%20Whether%20to%20create%20it%20upfront%20or%20defer%20it%0A-%20What%20it%20may%20vs.%20may%20not%20import%20%28e.g.%20can%20it%20import%20React%3F%20Tailwind%20tokens%3F%20CSS%20variables%3F%29%0A-%20Which%20phase%20it%20belongs%20to%20%28it's%20absent%20from%20the%20Phase%202%20extraction%20list%20as%20well%29%0A%0AConsider%20either%20adding%20a%20Package%20Boundaries%20subsection%20for%20it%20or%20removing%20it%20from%20the%20tree%20and%20noting%20it%20as%20a%20potential%20future%20package.%0A%0A%23%23%23%20Issue%202%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A216-221%0A**Workspace%20manager%20not%20specified**%0A%0APhase%201%20says%20%22Add%20workspace%20configuration%20at%20the%20root%22%20but%20doesn't%20name%20the%20workspace%20manager%20%28npm%2C%20pnpm%2C%20or%20Yarn%29.%20The%20current%20repo%20already%20uses%20npm%20%28%60npm-run-all%60%20in%20%60package.json%60%2C%20no%20%60pnpm-lock.yaml%60%29%2C%20but%20the%20choice%20has%20real%20consequences%20for%20the%20monorepo%3A%0A%0A-%20**npm%20workspaces**%20%E2%80%94%20simplest%20migration%20path%20from%20the%20current%20setup%2C%20but%20no%20module%20isolation%20enforcement%0A-%20**pnpm%20workspaces**%20%E2%80%94%20strict%20symlink%20isolation%20catches%20%60packages%2Fdomain%60%20accidentally%20importing%20Next.js%20through%20hoisting%2C%20which%20directly%20supports%20the%20%22Shared%20package%20contamination%22%20mitigation%20listed%20in%20Risks%0A-%20**Yarn%20Berry**%20%E2%80%94%20more%20complex%20adoption%20overhead%0A%0AGiven%20that%20the%20plan%20explicitly%20calls%20out%20%22enforce%20import%20discipline%22%20as%20the%20shared%20package%20contamination%20mitigation%2C%20documenting%20the%20workspace%20manager%20here%20%28and%20noting%20whether%20a%20lockfile%20change%20is%20expected%29%20would%20prevent%20ambiguity%20when%20Phase%201%20work%20starts.%0A%0A%23%23%23%20Issue%203%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A42-46%0A**Links%20will%20become%20stale%20after%20Phase%201**%0A%0AThe%20five%20coupling-point%20links%20currently%20resolve%20correctly%20from%20%60docs%2F%60%20%28e.g.%20%60..%2Fcomponents%2FCartClient.tsx%60%20%E2%86%92%20%60components%2FCartClient.tsx%60%20at%20the%20repo%20root%29.%20However%2C%20Phase%201%20moves%20the%20web%20app%20into%20%60apps%2Fweb%2F%60%2C%20relocating%20each%20of%20these%20files%3A%0A%0A%7C%20Current%20path%20%28valid%20now%29%20%7C%20Post-Phase-1%20path%20%7C%0A%7C---%7C---%7C%0A%7C%20%60..%2Fcomponents%2FCartClient.tsx%60%20%7C%20%60..%2Fapps%2Fweb%2Fcomponents%2FCartClient.tsx%60%20%7C%0A%7C%20%60..%2Fapp%2Factions%2Fpayment.ts%60%20%7C%20%60..%2Fapps%2Fweb%2Fapp%2Factions%2Fpayment.ts%60%20%7C%0A%7C%20%60..%2Fapp%2Fapi%2Fcreate-order%2Froute.ts%60%20%7C%20%60..%2Fapps%2Fweb%2Fapp%2Fapi%2Fcreate-order%2Froute.ts%60%20%7C%0A%7C%20%60..%2Fcomponents%2FClientProviders.tsx%60%20%7C%20%60..%2Fapps%2Fweb%2Fcomponents%2FClientProviders.tsx%60%20%7C%0A%7C%20%60..%2Fcomponents%2FConvexClientProvider.tsx%60%20%7C%20%60..%2Fapps%2Fweb%2Fcomponents%2FConvexClientProvider.tsx%60%20%7C%0A%0AAdding%20a%20note%20here%20%28or%20updating%20the%20links%20as%20part%20of%20Phase%201's%20exit%20criteria%29%20would%20keep%20the%20doc%20accurate%20after%20the%20move.%0A%0A%23%23%23%20Issue%204%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A103-107%0A**%60packages%2Fconfig%60%20missing%20Expected%20Contents%20section**%0A%0A%60packages%2Fbackend%60%20%28lines%2084%E2%80%9387%29%20and%20%60packages%2Fdomain%60%20%28lines%2094%E2%80%93101%29%20both%20have%20explicit%20%22Expected%20contents%22%20bullet%20lists%2C%20but%20%60packages%2Fconfig%60%20ends%20after%20three%20high-level%20description%20lines%20with%20no%20equivalent%20list.%0A%0AThis%20matters%20because%20%60packages%2Fconfig%60%20straddles%20the%20server%2Fclient%20boundary%20in%20a%20security-sensitive%20way%20%28secrets%20vs.%20public%20values%29.%20Without%20a%20concrete%20list%2C%20it's%20easy%20for%20implementers%20to%20accidentally%20put%20%60CLERK_SECRET_KEY%60%20or%20%60RAZORPAY_KEY_SECRET%60%20parsing%20in%20the%20client-safe%20export.%0A%0AConsider%20adding%20an%20Expected%20Contents%20section%20similar%20to%20the%20other%20packages%2C%20for%20example%3A%0A%0A-%20%60serverConfig%60%20%E2%80%94%20parses%20and%20validates%20server-only%20secrets%20%28%60CLERK_SECRET_KEY%60%2C%20%60RAZORPAY_KEY_SECRET%60%2C%20%60RESEND_API_KEY%60%2C%20etc.%29%20%E2%80%94%20never%20imported%20by%20client%20bundles%0A-%20%60publicConfig%60%20%E2%80%94%20parses%20only%20%60NEXT_PUBLIC_*%60%20%2F%20Expo-safe%20values%20safe%20for%20the%20client%20bundle%0A-%20Platform-specific%20helpers%20%28e.g.%20Expo%20%60extra%60%20accessor%29%0A%0A%23%23%23%20Issue%205%20of%205%0Adocs%2Fmobile-monorepo-plan.md%3A328-331%0A**%60react-use-cart%60%20is%20a%20localStorage-dependent%20web-only%20library**%0A%0AThe%20%22Hidden%20browser-only%20logic%22%20risk%20mentions%20%22local%20storage%20assumptions%22%20generically%2C%20but%20the%20current%20%60package.json%60%20depends%20on%20%60react-use-cart%60%2C%20which%20persists%20cart%20state%20exclusively%20via%20%60localStorage%60.%20This%20is%20a%20concrete%2C%20named%20dependency%20that%3A%0A%0A1.%20Cannot%20be%20used%20in%20React%20Native%20at%20all%20%E2%80%94%20it%20will%20throw%20at%20runtime%20because%20%60localStorage%60%20is%20undefined%0A2.%20Must%20be%20replaced%20or%20wrapped%20before%20cart%20state%20can%20be%20shared%20in%20%60packages%2Fdomain%60%20%28Phase%202%20priority%20extraction%20includes%20%22cart%20types%22%20and%20%22cart%20item%20models%22%29%0A%0ANaming%20%60react-use-cart%60%20here%20alongside%20the%20mitigation%20strategy%20%28e.g.%20%22replace%20with%20a%20platform-neutral%20cart%20store%20or%20an%20adapter%20that%20uses%20%60AsyncStorage%60%20on%20mobile%20and%20%60localStorage%60%20on%20web%22%29%20would%20make%20the%20Phase%202%20extraction%20scope%20concrete%20and%20avoid%20a%20surprise%20blocker%20in%20Phase%204.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix All in Cursor" src="https://img.shields.io/badge/Fix_All_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/mobile-monorepo-plan.md
Line: 59

Comment:
**`packages/ui-core` has no Package Boundaries section**

`packages/ui-core` is listed in the target repo shape (line 59) but the "Package Boundaries" section that follows defines boundaries for `apps/web`, `apps/mobile`, `packages/backend`, `packages/domain`, and `packages/config` — with no corresponding entry for `packages/ui-core`.

Without a defined boundary, implementers won't know:
- Whether to create it upfront or defer it
- What it may vs. may not import (e.g. can it import React? Tailwind tokens? CSS variables?)
- Which phase it belongs to (it's absent from the Phase 2 extraction list as well)

Consider either adding a Package Boundaries subsection for it or removing it from the tree and noting it as a potential future package.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/mobile-monorepo-plan.md
Line: 216-221

Comment:
**Workspace manager not specified**

Phase 1 says "Add workspace configuration at the root" but doesn't name the workspace manager (npm, pnpm, or Yarn). The current repo already uses npm (`npm-run-all` in `package.json`, no `pnpm-lock.yaml`), but the choice has real consequences for the monorepo:

- **npm workspaces** — simplest migration path from the current setup, but no module isolation enforcement
- **pnpm workspaces** — strict symlink isolation catches `packages/domain` accidentally importing Next.js through hoisting, which directly supports the "Shared package contamination" mitigation listed in Risks
- **Yarn Berry** — more complex adoption overhead

Given that the plan explicitly calls out "enforce import discipline" as the shared package contamination mitigation, documenting the workspace manager here (and noting whether a lockfile change is expected) would prevent ambiguity when Phase 1 work starts.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/mobile-monorepo-plan.md
Line: 42-46

Comment:
**Links will become stale after Phase 1**

The five coupling-point links currently resolve correctly from `docs/` (e.g. `../components/CartClient.tsx` → `components/CartClient.tsx` at the repo root). However, Phase 1 moves the web app into `apps/web/`, relocating each of these files:

| Current path (valid now) | Post-Phase-1 path |
|---|---|
| `../components/CartClient.tsx` | `../apps/web/components/CartClient.tsx` |
| `../app/actions/payment.ts` | `../apps/web/app/actions/payment.ts` |
| `../app/api/create-order/route.ts` | `../apps/web/app/api/create-order/route.ts` |
| `../components/ClientProviders.tsx` | `../apps/web/components/ClientProviders.tsx` |
| `../components/ConvexClientProvider.tsx` | `../apps/web/components/ConvexClientProvider.tsx` |

Adding a note here (or updating the links as part of Phase 1's exit criteria) would keep the doc accurate after the move.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/mobile-monorepo-plan.md
Line: 103-107

Comment:
**`packages/config` missing Expected Contents section**

`packages/backend` (lines 84–87) and `packages/domain` (lines 94–101) both have explicit "Expected contents" bullet lists, but `packages/config` ends after three high-level description lines with no equivalent list.

This matters because `packages/config` straddles the server/client boundary in a security-sensitive way (secrets vs. public values). Without a concrete list, it's easy for implementers to accidentally put `CLERK_SECRET_KEY` or `RAZORPAY_KEY_SECRET` parsing in the client-safe export.

Consider adding an Expected Contents section similar to the other packages, for example:

- `serverConfig` — parses and validates server-only secrets (`CLERK_SECRET_KEY`, `RAZORPAY_KEY_SECRET`, `RESEND_API_KEY`, etc.) — never imported by client bundles
- `publicConfig` — parses only `NEXT_PUBLIC_*` / Expo-safe values safe for the client bundle
- Platform-specific helpers (e.g. Expo `extra` accessor)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/mobile-monorepo-plan.md
Line: 328-331

Comment:
**`react-use-cart` is a localStorage-dependent web-only library**

The "Hidden browser-only logic" risk mentions "local storage assumptions" generically, but the current `package.json` depends on `react-use-cart`, which persists cart state exclusively via `localStorage`. This is a concrete, named dependency that:

1. Cannot be used in React Native at all — it will throw at runtime because `localStorage` is undefined
2. Must be replaced or wrapped before cart state can be shared in `packages/domain` (Phase 2 priority extraction includes "cart types" and "cart item models")

Naming `react-use-cart` here alongside the mitigation strategy (e.g. "replace with a platform-neutral cart store or an adapter that uses `AsyncStorage` on mobile and `localStorage` on web") would make the Phase 2 extraction scope concrete and avoid a surprise blocker in Phase 4.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 26e029a</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->