### PR TITLE
feat(admin): add reviews manager and timezone-aware admin timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
 
+      - name: Setup npm
+        run: npm install --global npm@11.11.0
+
       - name: Install dependencies
         run: npm ci
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# convex generated files
+/convex/_generated/
+
 # Ignored for the template, you probably want to remove it:
 
 # clerk configuration (can include secrets)

--- a/.gitignore
+++ b/.gitignore
@@ -47,9 +47,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# convex generated files
-/convex/_generated/
-
 # Ignored for the template, you probably want to remove it:
 
 # clerk configuration (can include secrets)

--- a/apps/web/app/admin/audit-log/page.tsx
+++ b/apps/web/app/admin/audit-log/page.tsx
@@ -4,12 +4,14 @@ import { useMemo, useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@mindpoint/backend/api";
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { downloadCsv, toCsv } from "@/lib/csv";
 
 export default function AdminAuditLogPage() {
   const [search, setSearch] = useState("");
+  const { formatTimestamp } = useAdminTimeZone();
 
   const logs = useQuery(api.adminAudit.listAuditLogs, {
     search: search || undefined,
@@ -85,7 +87,7 @@ export default function AdminAuditLogPage() {
               logs.map((row) => (
                 <tr key={row._id} className="border-t">
                   <td className="px-3 py-2 text-xs text-slate-600">
-                    {new Date(row.createdAt).toLocaleString()}
+                    {formatTimestamp(row.createdAt)}
                   </td>
                   <td className="px-3 py-2 font-medium text-slate-900">
                     {row.action}

--- a/apps/web/app/admin/courses/[courseId]/page.tsx
+++ b/apps/web/app/admin/courses/[courseId]/page.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { showRupees } from "@/lib/utils";
 import { getUserFacingErrorMessage } from "@/lib/convex-error";
+import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
 
 export default function AdminEditCoursePage() {
   const params = useParams<{ courseId: string }>();
@@ -24,6 +25,7 @@ export default function AdminEditCoursePage() {
     "all" | "active" | "cancelled" | "transferred"
   >("all");
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const { timeZoneLabel, formatDate, formatTimestamp } = useAdminTimeZone();
 
   const course = useQuery(api.adminCourses.getCourseById, { courseId });
   const transition = useMutation(api.adminCourses.transitionCourseLifecycle);
@@ -97,6 +99,11 @@ export default function AdminEditCoursePage() {
             >
               Archive
             </Button>
+            <Button variant="outline" asChild>
+              <Link href={`/admin/reviews?courseId=${courseId}`}>
+                Manage Reviews
+              </Link>
+            </Button>
           </>
         }
       />
@@ -150,11 +157,15 @@ export default function AdminEditCoursePage() {
             <p>
               Schedule:{" "}
               <strong>
-                {course.startDate} to {course.endDate}
+                {formatDate(course.startDate) || course.startDate} to{" "}
+                {formatDate(course.endDate) || course.endDate}
               </strong>
             </p>
             <p>
               Type: <strong>{course.type || "-"}</strong>
+            </p>
+            <p>
+              Time zone: <strong>{timeZoneLabel}</strong>
             </p>
           </CardContent>
         </Card>
@@ -257,7 +268,7 @@ export default function AdminEditCoursePage() {
                         ) : null}
                       </td>
                       <td className="px-3 py-2 text-xs text-slate-600">
-                        {new Date(row._creationTime).toLocaleString()}
+                        {formatTimestamp(row._creationTime)}
                       </td>
                       <td className="px-3 py-2">
                         <Button variant="outline" size="sm" asChild>

--- a/apps/web/app/admin/enrollments/[enrollmentId]/page.tsx
+++ b/apps/web/app/admin/enrollments/[enrollmentId]/page.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery } from "convex/react";
 import { api } from "@mindpoint/backend/api";
 import type { Id } from "@mindpoint/backend/data-model";
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -29,6 +30,7 @@ export default function AdminEnrollmentDetailPage() {
     "transfer" | "cancel" | null
   >(null);
   const [actionReason, setActionReason] = useState("Cancelled by admin");
+  const { formatTimestamp } = useAdminTimeZone();
 
   const detail = useQuery(api.adminEnrollments.getEnrollmentDetail, {
     enrollmentId,
@@ -126,8 +128,7 @@ export default function AdminEnrollmentDetailPage() {
             <strong>Type:</strong> {detail.courseType || "-"}
           </p>
           <p>
-            <strong>Created:</strong>{" "}
-            {new Date(detail._creationTime).toLocaleString()}
+            <strong>Created:</strong> {formatTimestamp(detail._creationTime)}
           </p>
           <p>
             <strong>Paid:</strong>{" "}

--- a/apps/web/app/admin/enrollments/page.tsx
+++ b/apps/web/app/admin/enrollments/page.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery } from "convex/react";
 import { api } from "@mindpoint/backend/api";
 import type { Id } from "@mindpoint/backend/data-model";
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -43,6 +44,7 @@ export default function AdminEnrollmentsPage() {
   >("");
   const [isCreatingEnrollment, setIsCreatingEnrollment] = useState(false);
   const manualUserIdLooksLikeEmail = manualUserId.includes("@");
+  const { formatTimestamp } = useAdminTimeZone();
 
   const enrollments = useQuery(api.adminEnrollments.listEnrollments, {
     search: search || undefined,
@@ -383,7 +385,7 @@ export default function AdminEnrollmentsPage() {
                     )}
                   </td>
                   <td className="px-3 py-2 text-xs text-slate-600">
-                    {new Date(row._creationTime).toLocaleString()}
+                    {formatTimestamp(row._creationTime)}
                   </td>
                   <td className="px-3 py-2">
                     <div className="flex gap-2">

--- a/apps/web/app/admin/offers/page.tsx
+++ b/apps/web/app/admin/offers/page.tsx
@@ -21,6 +21,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
 import { toast } from "sonner";
 import { isBogoActive, isDiscountActive, showRupees } from "@/lib/utils";
 
@@ -76,6 +77,21 @@ const courseTypeOptions: CourseTypeFilter[] = [
 
 const MAX_COURSES_PER_APPLY = 150;
 
+function formatDateWindow(
+  startDate: string,
+  endDate: string,
+  formatDate: (value?: string) => string | null,
+): string | null {
+  const start = formatDate(startDate);
+  const end = formatDate(endDate);
+
+  if (start && end) {
+    return `${start} to ${end}`;
+  }
+
+  return start || end;
+}
+
 export default function AdminOffersPage() {
   const [search, setSearch] = useState("");
   const [courseType, setCourseType] = useState<CourseTypeFilter>("all");
@@ -102,6 +118,7 @@ export default function AdminOffersPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [campaignActionId, setCampaignActionId] = useState<string | null>(null);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const { timeZoneLabel, formatDate, formatTimestamp } = useAdminTimeZone();
 
   const courses = useQuery(api.adminCourses.listCourses, {
     search: search || undefined,
@@ -128,6 +145,16 @@ export default function AdminOffersPage() {
   const campaignRows = useMemo(() => campaigns ?? [], [campaigns]);
   const selectedCount = selectedCourseIds.length;
   const exceedsApplyLimit = selectedCount > MAX_COURSES_PER_APPLY;
+  const offerWindowPreview = formatDateWindow(
+    offerStartDate,
+    offerEndDate,
+    formatDate,
+  );
+  const bogoWindowPreview = formatDateWindow(
+    bogoStartDate,
+    bogoEndDate,
+    formatDate,
+  );
   const selectedIdSet = useMemo(
     () => new Set(selectedCourseIds),
     [selectedCourseIds],
@@ -496,16 +523,11 @@ export default function AdminOffersPage() {
                           ) : null}
                         </div>
                         <div className="space-y-1 text-xs text-slate-500">
-                          <p>
-                            Updated{" "}
-                            {new Date(campaign.updatedAt).toLocaleString()}
-                          </p>
+                          <p>Updated {formatTimestamp(campaign.updatedAt)}</p>
                           {campaign.lastAppliedAt ? (
                             <p>
                               Last applied{" "}
-                              {new Date(
-                                campaign.lastAppliedAt,
-                              ).toLocaleString()}
+                              {formatTimestamp(campaign.lastAppliedAt)}
                             </p>
                           ) : null}
                         </div>
@@ -620,6 +642,11 @@ export default function AdminOffersPage() {
                     onChange={(e) => setOfferEndDate(e.target.value)}
                   />
                 </div>
+                {offerWindowPreview ? (
+                  <p className="text-xs text-slate-500">
+                    Offer window: {offerWindowPreview} ({timeZoneLabel})
+                  </p>
+                ) : null}
               </div>
 
               <div className="space-y-3 rounded-2xl border border-emerald-200/70 bg-emerald-50/60 p-4">
@@ -650,6 +677,11 @@ export default function AdminOffersPage() {
                     onChange={(e) => setBogoEndDate(e.target.value)}
                   />
                 </div>
+                {bogoWindowPreview ? (
+                  <p className="text-xs text-slate-500">
+                    BOGO window: {bogoWindowPreview} ({timeZoneLabel})
+                  </p>
+                ) : null}
               </div>
             </div>
 

--- a/apps/web/app/admin/offers/page.tsx
+++ b/apps/web/app/admin/offers/page.tsx
@@ -104,7 +104,7 @@ export default function AdminOffersPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [campaignActionId, setCampaignActionId] = useState<string | null>(null);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
-  const { timeZoneLabel, formatDate, formatTimestamp } = useAdminTimeZone();
+  const { formatDate, formatTimestamp } = useAdminTimeZone();
 
   const courses = useQuery(api.adminCourses.listCourses, {
     search: search || undefined,
@@ -630,7 +630,7 @@ export default function AdminOffersPage() {
                 </div>
                 {offerWindowPreview ? (
                   <p className="text-xs text-slate-500">
-                    Offer window: {offerWindowPreview} ({timeZoneLabel})
+                    Offer window: {offerWindowPreview}
                   </p>
                 ) : null}
               </div>
@@ -665,7 +665,7 @@ export default function AdminOffersPage() {
                 </div>
                 {bogoWindowPreview ? (
                   <p className="text-xs text-slate-500">
-                    BOGO window: {bogoWindowPreview} ({timeZoneLabel})
+                    BOGO window: {bogoWindowPreview}
                   </p>
                 ) : null}
               </div>

--- a/apps/web/app/admin/offers/page.tsx
+++ b/apps/web/app/admin/offers/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
 import { toast } from "sonner";
+import { formatDateWindow } from "@/lib/admin-timezone";
 import { isBogoActive, isDiscountActive, showRupees } from "@/lib/utils";
 
 type CourseTypeFilter =
@@ -76,21 +77,6 @@ const courseTypeOptions: CourseTypeFilter[] = [
 ];
 
 const MAX_COURSES_PER_APPLY = 150;
-
-function formatDateWindow(
-  startDate: string,
-  endDate: string,
-  formatDate: (value?: string) => string | null,
-): string | null {
-  const start = formatDate(startDate);
-  const end = formatDate(endDate);
-
-  if (start && end) {
-    return `${start} to ${end}`;
-  }
-
-  return start || end;
-}
 
 export default function AdminOffersPage() {
   const [search, setSearch] = useState("");

--- a/apps/web/app/admin/reviews/page.tsx
+++ b/apps/web/app/admin/reviews/page.tsx
@@ -48,6 +48,11 @@ type ReviewRow = {
   courseType: string | null;
 };
 
+type ReviewsResponse = {
+  reviews: ReviewRow[];
+  hasMore: boolean;
+};
+
 type ReviewFormState = {
   courseId: string;
   userName: string;
@@ -94,7 +99,7 @@ export default function AdminReviewsPage() {
     sortOrder: "asc",
   }) as Doc<"courses">[] | undefined;
 
-  const reviews = useQuery(api.adminReviews.listReviews, {
+  const reviewsResult = useQuery(api.adminReviews.listReviews, {
     search: search || undefined,
     courseId:
       selectedCourseId !== "all"
@@ -103,13 +108,14 @@ export default function AdminReviewsPage() {
     rating: selectedRating !== "all" ? Number(selectedRating) : undefined,
     sortBy,
     limit: 500,
-  }) as ReviewRow[] | undefined;
+  }) as ReviewsResponse | undefined;
 
   const createReview = useMutation(api.adminReviews.createReview);
   const updateReview = useMutation(api.adminReviews.updateReview);
   const deleteReview = useMutation(api.adminReviews.deleteReview);
 
-  const rows = reviews ?? [];
+  const rows = reviewsResult?.reviews ?? [];
+  const hasMore = reviewsResult?.hasMore ?? false;
   const hasActiveFilters =
     !!search.trim() || selectedCourseId !== "all" || selectedRating !== "all";
   const averageRating =
@@ -324,6 +330,13 @@ export default function AdminReviewsPage() {
             </select>
           </div>
 
+          {hasMore ? (
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+              Showing the first 500 reviews from the current scan. Narrow the
+              filters for a complete result set.
+            </div>
+          ) : null}
+
           <div className="overflow-hidden rounded-lg border bg-white">
             <table className="w-full text-left text-sm">
               <thead className="bg-slate-50 text-xs tracking-wide text-slate-600 uppercase">
@@ -337,7 +350,7 @@ export default function AdminReviewsPage() {
                 </tr>
               </thead>
               <tbody>
-                {reviews === undefined ? (
+                {reviewsResult === undefined ? (
                   <tr>
                     <td className="px-3 py-4 text-slate-600" colSpan={6}>
                       Loading reviews...

--- a/apps/web/app/admin/reviews/page.tsx
+++ b/apps/web/app/admin/reviews/page.tsx
@@ -1,0 +1,557 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@mindpoint/backend/api";
+import type { Doc, Id } from "@mindpoint/backend/data-model";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+import { getUserFacingErrorMessage } from "@/lib/convex-error";
+
+type ReviewRow = {
+  _id: Id<"reviews">;
+  _creationTime: number;
+  course: Id<"courses">;
+  userId: string;
+  userName: string;
+  rating: number;
+  content: string;
+  isEdited?: boolean;
+  courseName: string;
+  courseCode: string;
+  courseType: string | null;
+};
+
+type ReviewFormState = {
+  courseId: string;
+  userName: string;
+  userId: string;
+  rating: string;
+  content: string;
+};
+
+const emptyFormState: ReviewFormState = {
+  courseId: "",
+  userName: "",
+  userId: "",
+  rating: "5",
+  content: "",
+};
+
+export default function AdminReviewsPage() {
+  const searchParams = useSearchParams();
+  const preselectedCourseId = searchParams.get("courseId") ?? "all";
+
+  const [search, setSearch] = useState("");
+  const [selectedCourseId, setSelectedCourseId] = useState(preselectedCourseId);
+  const [selectedRating, setSelectedRating] = useState("all");
+  const [sortBy, setSortBy] = useState<"newest" | "oldest" | "rating">(
+    "newest",
+  );
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [deleteReviewId, setDeleteReviewId] = useState<string | null>(null);
+  const [editingReview, setEditingReview] = useState<ReviewRow | null>(null);
+  const [formState, setFormState] = useState<ReviewFormState>(emptyFormState);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const { timeZoneLabel, formatTimestamp } = useAdminTimeZone();
+
+  useEffect(() => {
+    setSelectedCourseId(preselectedCourseId);
+  }, [preselectedCourseId]);
+
+  const courses = useQuery(api.adminCourses.listCourses, {
+    limit: 500,
+    sortBy: "name",
+    sortOrder: "asc",
+  }) as Doc<"courses">[] | undefined;
+
+  const reviews = useQuery(api.adminReviews.listReviews, {
+    search: search || undefined,
+    courseId:
+      selectedCourseId !== "all"
+        ? (selectedCourseId as Id<"courses">)
+        : undefined,
+    rating: selectedRating !== "all" ? Number(selectedRating) : undefined,
+    sortBy,
+    limit: 500,
+  }) as ReviewRow[] | undefined;
+
+  const createReview = useMutation(api.adminReviews.createReview);
+  const updateReview = useMutation(api.adminReviews.updateReview);
+  const deleteReview = useMutation(api.adminReviews.deleteReview);
+
+  const rows = reviews ?? [];
+  const averageRating =
+    rows.length > 0
+      ? (
+          rows.reduce((total, review) => total + review.rating, 0) / rows.length
+        ).toFixed(1)
+      : "0.0";
+
+  const courseOptions = useMemo(() => courses ?? [], [courses]);
+
+  const resetForm = () => {
+    setEditingReview(null);
+    setFormState({
+      ...emptyFormState,
+      courseId:
+        selectedCourseId !== "all"
+          ? selectedCourseId
+          : courseOptions[0]?._id
+            ? String(courseOptions[0]._id)
+            : "",
+    });
+  };
+
+  const openCreateDialog = () => {
+    resetForm();
+    setDialogOpen(true);
+  };
+
+  const openEditDialog = (review: ReviewRow) => {
+    setEditingReview(review);
+    setFormState({
+      courseId: String(review.course),
+      userName: review.userName,
+      userId: review.userId.startsWith("admin-managed:") ? "" : review.userId,
+      rating: String(review.rating),
+      content: review.content,
+    });
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    const numericRating = Number(formState.rating);
+
+    if (!formState.courseId) {
+      toast.error("Select a course for this review");
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+
+      if (editingReview) {
+        await updateReview({
+          reviewId: editingReview._id,
+          courseId: formState.courseId as Id<"courses">,
+          userName: formState.userName,
+          userId: formState.userId || undefined,
+          rating: numericRating,
+          content: formState.content,
+        });
+        toast.success("Review updated");
+      } else {
+        await createReview({
+          courseId: formState.courseId as Id<"courses">,
+          userName: formState.userName,
+          userId: formState.userId || undefined,
+          rating: numericRating,
+          content: formState.content,
+        });
+        toast.success("Review created");
+      }
+
+      setDialogOpen(false);
+      resetForm();
+    } catch (error) {
+      toast.error(getUserFacingErrorMessage(error, "Failed to save review"));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteReviewId) {
+      return;
+    }
+
+    try {
+      setIsDeleting(true);
+      await deleteReview({ reviewId: deleteReviewId as Id<"reviews"> });
+      toast.success("Review deleted");
+      setDeleteReviewId(null);
+    } catch (error) {
+      toast.error(getUserFacingErrorMessage(error, "Failed to delete review"));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        title="Reviews"
+        description="Manage course reviews across the catalog and see review timestamps in your selected admin time zone."
+        actions={<Button onClick={openCreateDialog}>Add Review</Button>}
+      />
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm text-slate-600">
+              Visible Reviews
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-slate-900">
+              {rows.length}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm text-slate-600">
+              Average Rating
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-slate-900">
+              {averageRating}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm text-slate-600">
+              Working Time Zone
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm font-medium text-slate-900">
+              {timeZoneLabel}
+            </p>
+            <p className="mt-1 text-xs text-slate-500">
+              Review timestamps on this page follow the selector in the admin
+              header.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Review Manager</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 lg:grid-cols-[1.4fr_240px_180px_180px]">
+            <Input
+              placeholder="Search by reviewer, content, course, code"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+
+            <select
+              className="h-10 rounded-md border bg-white px-3 text-sm"
+              value={selectedCourseId}
+              onChange={(event) => setSelectedCourseId(event.target.value)}
+            >
+              <option value="all">All courses</option>
+              {courseOptions.map((course) => (
+                <option key={course._id} value={course._id}>
+                  {course.name} ({course.code})
+                </option>
+              ))}
+            </select>
+
+            <select
+              className="h-10 rounded-md border bg-white px-3 text-sm"
+              value={selectedRating}
+              onChange={(event) => setSelectedRating(event.target.value)}
+            >
+              <option value="all">All ratings</option>
+              <option value="5">5.0</option>
+              <option value="4.5">4.5</option>
+              <option value="4">4.0</option>
+              <option value="3.5">3.5</option>
+              <option value="3">3.0</option>
+              <option value="2.5">2.5</option>
+              <option value="2">2.0</option>
+              <option value="1.5">1.5</option>
+              <option value="1">1.0</option>
+              <option value="0.5">0.5</option>
+            </select>
+
+            <select
+              className="h-10 rounded-md border bg-white px-3 text-sm"
+              value={sortBy}
+              onChange={(event) =>
+                setSortBy(event.target.value as "newest" | "oldest" | "rating")
+              }
+            >
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+              <option value="rating">Highest rated</option>
+            </select>
+          </div>
+
+          <div className="overflow-hidden rounded-lg border bg-white">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-slate-50 text-xs tracking-wide text-slate-600 uppercase">
+                <tr>
+                  <th className="px-3 py-2">Course</th>
+                  <th className="px-3 py-2">Reviewer</th>
+                  <th className="px-3 py-2">Rating</th>
+                  <th className="px-3 py-2">Review</th>
+                  <th className="px-3 py-2">Created</th>
+                  <th className="px-3 py-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {reviews === undefined ? (
+                  <tr>
+                    <td className="px-3 py-4 text-slate-600" colSpan={6}>
+                      Loading reviews...
+                    </td>
+                  </tr>
+                ) : rows.length === 0 ? (
+                  <tr>
+                    <td className="px-3 py-4 text-slate-600" colSpan={6}>
+                      No reviews matched the current filters.
+                    </td>
+                  </tr>
+                ) : (
+                  rows.map((review) => (
+                    <tr key={review._id} className="border-t align-top">
+                      <td className="px-3 py-3">
+                        <p className="font-medium text-slate-900">
+                          {review.courseName}
+                        </p>
+                        <p className="text-xs text-slate-500">
+                          {review.courseCode}
+                          {review.courseType ? ` • ${review.courseType}` : ""}
+                        </p>
+                      </td>
+                      <td className="px-3 py-3">
+                        <p className="font-medium text-slate-900">
+                          {review.userName}
+                        </p>
+                        <p className="text-xs text-slate-500">
+                          {review.userId}
+                        </p>
+                      </td>
+                      <td className="px-3 py-3">
+                        <Badge variant="outline">
+                          {review.rating.toFixed(1)} / 5
+                        </Badge>
+                      </td>
+                      <td className="max-w-md px-3 py-3 text-slate-700">
+                        <p>{review.content}</p>
+                        {review.isEdited ? (
+                          <p className="mt-1 text-xs text-amber-700">Edited</p>
+                        ) : null}
+                      </td>
+                      <td className="px-3 py-3 text-xs text-slate-500">
+                        {formatTimestamp(review._creationTime)}
+                      </td>
+                      <td className="px-3 py-3">
+                        <div className="flex gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openEditDialog(review)}
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            onClick={() =>
+                              setDeleteReviewId(String(review._id))
+                            }
+                          >
+                            Delete
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) {
+            resetForm();
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>
+              {editingReview ? "Edit Review" : "Add Review"}
+            </DialogTitle>
+            <DialogDescription>
+              Create or update a course review. Ratings accept 0.5 increments.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2 md:col-span-2">
+              <Label>Course</Label>
+              <select
+                className="h-10 w-full rounded-md border bg-white px-3 text-sm"
+                value={formState.courseId}
+                onChange={(event) =>
+                  setFormState((current) => ({
+                    ...current,
+                    courseId: event.target.value,
+                  }))
+                }
+              >
+                <option value="">Select a course</option>
+                {courseOptions.map((course) => (
+                  <option key={course._id} value={course._id}>
+                    {course.name} ({course.code})
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Reviewer Name</Label>
+              <Input
+                value={formState.userName}
+                onChange={(event) =>
+                  setFormState((current) => ({
+                    ...current,
+                    userName: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Reviewer ID</Label>
+              <Input
+                placeholder="Optional. Defaults to admin-managed."
+                value={formState.userId}
+                onChange={(event) =>
+                  setFormState((current) => ({
+                    ...current,
+                    userId: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Rating</Label>
+              <Input
+                type="number"
+                min={0.5}
+                max={5}
+                step={0.5}
+                value={formState.rating}
+                onChange={(event) =>
+                  setFormState((current) => ({
+                    ...current,
+                    rating: event.target.value,
+                  }))
+                }
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Review Content</Label>
+            <Textarea
+              rows={6}
+              value={formState.content}
+              onChange={(event) =>
+                setFormState((current) => ({
+                  ...current,
+                  content: event.target.value,
+                }))
+              }
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setDialogOpen(false);
+                resetForm();
+              }}
+            >
+              Cancel
+            </Button>
+            <Button disabled={isSaving} onClick={() => void handleSave()}>
+              {isSaving
+                ? "Saving..."
+                : editingReview
+                  ? "Update Review"
+                  : "Create Review"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={!!deleteReviewId}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteReviewId(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete review?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the selected review from the course and the public
+              course page.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 hover:bg-red-700"
+              disabled={isDeleting}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDelete();
+              }}
+            >
+              {isDeleting ? "Deleting..." : "Delete Review"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/web/app/admin/reviews/page.tsx
+++ b/apps/web/app/admin/reviews/page.tsx
@@ -34,6 +34,8 @@ import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { getUserFacingErrorMessage } from "@/lib/convex-error";
 
+export const dynamic = "force-dynamic";
+
 type ReviewRow = {
   _id: Id<"reviews">;
   _creationTime: number;

--- a/apps/web/app/admin/reviews/page.tsx
+++ b/apps/web/app/admin/reviews/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@mindpoint/backend/api";
-import type { Doc, Id } from "@mindpoint/backend/data-model";
+import type { Id } from "@mindpoint/backend/data-model";
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
 import { Button } from "@/components/ui/button";
@@ -71,7 +71,7 @@ const emptyFormState: ReviewFormState = {
   content: "",
 };
 
-export default function AdminReviewsPage() {
+function AdminReviewsPageInner() {
   const searchParams = useSearchParams();
   const preselectedCourseId = searchParams.get("courseId") ?? "all";
 
@@ -99,7 +99,7 @@ export default function AdminReviewsPage() {
     limit: 500,
     sortBy: "name",
     sortOrder: "asc",
-  }) as Doc<"courses">[] | undefined;
+  });
   const courseOptions = useMemo(() => courses ?? [], [courses]);
   const knownCourseIds = useMemo(
     () => new Set(courseOptions.map((course) => String(course._id))),
@@ -356,8 +356,9 @@ export default function AdminReviewsPage() {
 
           {hasMore ? (
             <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-              Showing the first 500 reviews from the current scan. Narrow the
-              filters for a complete result set.
+              Showing {rows.length} review{rows.length !== 1 ? "s" : ""} — the
+              scan window may not include all matches. Narrow the filters for a
+              more complete result set.
             </div>
           ) : null}
 
@@ -600,5 +601,13 @@ export default function AdminReviewsPage() {
         </AlertDialogContent>
       </AlertDialog>
     </div>
+  );
+}
+
+export default function AdminReviewsPage() {
+  return (
+    <Suspense>
+      <AdminReviewsPageInner />
+    </Suspense>
   );
 }

--- a/apps/web/app/admin/reviews/page.tsx
+++ b/apps/web/app/admin/reviews/page.tsx
@@ -38,7 +38,7 @@ type ReviewRow = {
   _id: Id<"reviews">;
   _creationTime: number;
   course: Id<"courses">;
-  userId: string;
+  userId?: string;
   userName: string;
   rating: number;
   content: string;
@@ -154,7 +154,10 @@ export default function AdminReviewsPage() {
     setFormState({
       courseId: String(review.course),
       userName: review.userName,
-      userId: review.userId.startsWith("admin-managed:") ? "" : review.userId,
+      userId:
+        (review.userId ?? "").startsWith("admin-managed:")
+          ? ""
+          : (review.userId ?? ""),
       rating: String(review.rating),
       content: review.content,
     });

--- a/apps/web/app/admin/reviews/page.tsx
+++ b/apps/web/app/admin/reviews/page.tsx
@@ -75,7 +75,9 @@ export default function AdminReviewsPage() {
     "newest",
   );
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [deleteReviewId, setDeleteReviewId] = useState<string | null>(null);
+  const [deleteReviewId, setDeleteReviewId] = useState<Id<"reviews"> | null>(
+    null,
+  );
   const [editingReview, setEditingReview] = useState<ReviewRow | null>(null);
   const [formState, setFormState] = useState<ReviewFormState>(emptyFormState);
   const [isSaving, setIsSaving] = useState(false);
@@ -108,6 +110,8 @@ export default function AdminReviewsPage() {
   const deleteReview = useMutation(api.adminReviews.deleteReview);
 
   const rows = reviews ?? [];
+  const hasActiveFilters =
+    !!search.trim() || selectedCourseId !== "all" || selectedRating !== "all";
   const averageRating =
     rows.length > 0
       ? (
@@ -154,6 +158,14 @@ export default function AdminReviewsPage() {
       toast.error("Select a course for this review");
       return;
     }
+    if (!formState.userName.trim()) {
+      toast.error("Reviewer name is required");
+      return;
+    }
+    if (!formState.content.trim()) {
+      toast.error("Review content is required");
+      return;
+    }
 
     try {
       setIsSaving(true);
@@ -195,7 +207,7 @@ export default function AdminReviewsPage() {
 
     try {
       setIsDeleting(true);
-      await deleteReview({ reviewId: deleteReviewId as Id<"reviews"> });
+      await deleteReview({ reviewId: deleteReviewId });
       toast.success("Review deleted");
       setDeleteReviewId(null);
     } catch (error) {
@@ -229,7 +241,7 @@ export default function AdminReviewsPage() {
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm text-slate-600">
-              Average Rating
+              {hasActiveFilters ? "Average (filtered)" : "Average Rating"}
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -383,9 +395,7 @@ export default function AdminReviewsPage() {
                           <Button
                             variant="destructive"
                             size="sm"
-                            onClick={() =>
-                              setDeleteReviewId(String(review._id))
-                            }
+                            onClick={() => setDeleteReviewId(review._id)}
                           >
                             Delete
                           </Button>

--- a/apps/web/app/admin/reviews/page.tsx
+++ b/apps/web/app/admin/reviews/page.tsx
@@ -98,13 +98,19 @@ export default function AdminReviewsPage() {
     sortBy: "name",
     sortOrder: "asc",
   }) as Doc<"courses">[] | undefined;
+  const courseOptions = useMemo(() => courses ?? [], [courses]);
+  const knownCourseIds = useMemo(
+    () => new Set(courseOptions.map((course) => String(course._id))),
+    [courseOptions],
+  );
+  const selectedCourseIdValue =
+    selectedCourseId !== "all" && knownCourseIds.has(selectedCourseId)
+      ? (selectedCourseId as Id<"courses">)
+      : undefined;
 
   const reviewsResult = useQuery(api.adminReviews.listReviews, {
     search: search || undefined,
-    courseId:
-      selectedCourseId !== "all"
-        ? (selectedCourseId as Id<"courses">)
-        : undefined,
+    courseId: selectedCourseIdValue,
     rating: selectedRating !== "all" ? Number(selectedRating) : undefined,
     sortBy,
     limit: 500,
@@ -124,8 +130,6 @@ export default function AdminReviewsPage() {
           rows.reduce((total, review) => total + review.rating, 0) / rows.length
         ).toFixed(1)
       : "0.0";
-
-  const courseOptions = useMemo(() => courses ?? [], [courses]);
 
   const resetForm = () => {
     setEditingReview(null);
@@ -159,9 +163,16 @@ export default function AdminReviewsPage() {
 
   const handleSave = async () => {
     const numericRating = Number(formState.rating);
+    const selectedFormCourseId = knownCourseIds.has(formState.courseId)
+      ? (formState.courseId as Id<"courses">)
+      : null;
 
     if (!formState.courseId) {
       toast.error("Select a course for this review");
+      return;
+    }
+    if (!selectedFormCourseId) {
+      toast.error("Select a valid course for this review");
       return;
     }
     if (!formState.userName.trim()) {
@@ -172,6 +183,14 @@ export default function AdminReviewsPage() {
       toast.error("Review content is required");
       return;
     }
+    if (
+      !Number.isFinite(numericRating) ||
+      numericRating < 0.5 ||
+      numericRating > 5
+    ) {
+      toast.error("Rating must be between 0.5 and 5");
+      return;
+    }
 
     try {
       setIsSaving(true);
@@ -179,7 +198,7 @@ export default function AdminReviewsPage() {
       if (editingReview) {
         await updateReview({
           reviewId: editingReview._id,
-          courseId: formState.courseId as Id<"courses">,
+          courseId: selectedFormCourseId,
           userName: formState.userName,
           userId: formState.userId || undefined,
           rating: numericRating,
@@ -188,7 +207,7 @@ export default function AdminReviewsPage() {
         toast.success("Review updated");
       } else {
         await createReview({
-          courseId: formState.courseId as Id<"courses">,
+          courseId: selectedFormCourseId,
           userName: formState.userName,
           userId: formState.userId || undefined,
           rating: numericRating,

--- a/apps/web/app/admin/reviews/page.tsx
+++ b/apps/web/app/admin/reviews/page.tsx
@@ -205,7 +205,7 @@ function AdminReviewsPageInner() {
           reviewId: editingReview._id,
           courseId: selectedFormCourseId,
           userName: formState.userName,
-          userId: formState.userId || undefined,
+          userId: formState.userId,
           rating: numericRating,
           content: formState.content,
         });

--- a/apps/web/components/admin/AdminSidebar.tsx
+++ b/apps/web/components/admin/AdminSidebar.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { AdminTimeZoneProvider } from "@/components/admin/AdminTimeZoneProvider";
+import { AdminTimeZoneSelect } from "@/components/admin/AdminTimeZoneSelect";
 import {
   Sidebar,
   SidebarContent,
@@ -24,12 +26,14 @@ import {
   ClipboardList,
   Settings,
   Shield,
+  MessageSquareQuote,
 } from "lucide-react";
 
 const items = [
   { href: "/admin", label: "Dashboard", icon: LayoutDashboard },
   { href: "/admin/courses", label: "Courses", icon: BookOpen },
   { href: "/admin/offers", label: "Offer Manager", icon: TicketPercent },
+  { href: "/admin/reviews", label: "Reviews", icon: MessageSquareQuote },
   { href: "/admin/enrollments", label: "Enrollments", icon: GraduationCap },
   { href: "/admin/users", label: "Users", icon: Users },
   { href: "/admin/loyalty", label: "Loyalty", icon: Gift },
@@ -42,49 +46,54 @@ export function AdminSidebar({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
 
   return (
-    <SidebarProvider>
-      <div className="flex min-h-screen w-full bg-[radial-gradient(circle_at_top_left,oklch(0.96_0.02_220),transparent_45%),radial-gradient(circle_at_top_right,oklch(0.93_0.03_160),transparent_40%)]">
-        <Sidebar className="top-16 h-[calc(100svh-4rem)]">
-          <SidebarContent>
-            <SidebarGroup>
-              <SidebarGroupLabel>Admin Panel</SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {items.map((item) => {
-                    const Icon = item.icon;
-                    const isActive =
-                      item.href === "/admin"
-                        ? pathname === "/admin"
-                        : pathname.startsWith(item.href);
-                    return (
-                      <SidebarMenuItem key={item.href}>
-                        <SidebarMenuButton asChild isActive={isActive}>
-                          <Link href={item.href}>
-                            <Icon className="h-4 w-4" />
-                            <span>{item.label}</span>
-                          </Link>
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                    );
-                  })}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-          </SidebarContent>
-        </Sidebar>
+    <AdminTimeZoneProvider>
+      <SidebarProvider>
+        <div className="flex min-h-screen w-full bg-[radial-gradient(circle_at_top_left,oklch(0.96_0.02_220),transparent_45%),radial-gradient(circle_at_top_right,oklch(0.93_0.03_160),transparent_40%)]">
+          <Sidebar className="top-16 h-[calc(100svh-4rem)]">
+            <SidebarContent>
+              <SidebarGroup>
+                <SidebarGroupLabel>Admin Panel</SidebarGroupLabel>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    {items.map((item) => {
+                      const Icon = item.icon;
+                      const isActive =
+                        item.href === "/admin"
+                          ? pathname === "/admin"
+                          : pathname.startsWith(item.href);
+                      return (
+                        <SidebarMenuItem key={item.href}>
+                          <SidebarMenuButton asChild isActive={isActive}>
+                            <Link href={item.href}>
+                              <Icon className="h-4 w-4" />
+                              <span>{item.label}</span>
+                            </Link>
+                          </SidebarMenuButton>
+                        </SidebarMenuItem>
+                      );
+                    })}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </SidebarGroup>
+            </SidebarContent>
+          </Sidebar>
 
-        <main className="flex-1 pb-10">
-          <div className="border-border/80 sticky top-0 z-20 border-b bg-white/85 backdrop-blur">
-            <div className="flex h-14 items-center gap-2 px-4">
-              <SidebarTrigger />
-              <span className="text-sm font-semibold tracking-wide text-slate-700">
-                MindPoint Admin
-              </span>
+          <main className="flex-1 pb-10">
+            <div className="border-border/80 sticky top-0 z-20 border-b bg-white/85 backdrop-blur">
+              <div className="flex min-h-14 flex-wrap items-center gap-3 px-4 py-2">
+                <SidebarTrigger />
+                <span className="text-sm font-semibold tracking-wide text-slate-700">
+                  MindPoint Admin
+                </span>
+                <div className="ml-auto">
+                  <AdminTimeZoneSelect />
+                </div>
+              </div>
             </div>
-          </div>
-          <div className="p-4 md:p-6">{children}</div>
-        </main>
-      </div>
-    </SidebarProvider>
+            <div className="p-4 md:p-6">{children}</div>
+          </main>
+        </div>
+      </SidebarProvider>
+    </AdminTimeZoneProvider>
   );
 }

--- a/apps/web/components/admin/AdminTimeZoneProvider.tsx
+++ b/apps/web/components/admin/AdminTimeZoneProvider.tsx
@@ -52,6 +52,8 @@ export function AdminTimeZoneProvider({
         window.localStorage.setItem(ADMIN_TIME_ZONE_STORAGE_KEY, nextTimeZone);
       },
       formatTimestamp: (input) => formatTimestampInTimeZone(input, timeZone),
+      // Plain YYYY-MM-DD values are intentionally formatted in UTC so the day
+      // never shifts with the selected edit zone.
       formatDate: (input) => formatPlainDateForAdmin(input),
       formatDateTime: (dateValue, timeValue) =>
         formatPlainDateTimeForAdmin(dateValue, timeValue, timeZone),

--- a/apps/web/components/admin/AdminTimeZoneProvider.tsx
+++ b/apps/web/components/admin/AdminTimeZoneProvider.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { createContext, useContext, useMemo, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import {
   ADMIN_TIME_ZONE_STORAGE_KEY,
   formatPlainDateForAdmin,
   formatPlainDateTimeForAdmin,
   formatTimestampInTimeZone,
   getAdminTimeZoneLabel,
+  isSupportedAdminTimeZone,
   resolveDefaultAdminTimeZone,
 } from "@/lib/admin-timezone";
 
@@ -28,22 +29,25 @@ export function AdminTimeZoneProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [timeZone, setTimeZoneState] = useState<string>(() => {
-    if (typeof window === "undefined") {
-      return "America/New_York";
-    }
+  const [timeZone, setTimeZoneState] = useState<string>("America/New_York");
 
-    return (
-      window.localStorage.getItem(ADMIN_TIME_ZONE_STORAGE_KEY) ||
-      resolveDefaultAdminTimeZone()
+  useEffect(() => {
+    const stored = window.localStorage.getItem(ADMIN_TIME_ZONE_STORAGE_KEY);
+    setTimeZoneState(
+      stored && isSupportedAdminTimeZone(stored)
+        ? stored
+        : resolveDefaultAdminTimeZone(),
     );
-  });
+  }, []);
 
   const value = useMemo<AdminTimeZoneContextValue>(
     () => ({
       timeZone,
       timeZoneLabel: getAdminTimeZoneLabel(timeZone),
       setTimeZone: (nextTimeZone) => {
+        if (!isSupportedAdminTimeZone(nextTimeZone)) {
+          return;
+        }
         setTimeZoneState(nextTimeZone);
         window.localStorage.setItem(ADMIN_TIME_ZONE_STORAGE_KEY, nextTimeZone);
       },

--- a/apps/web/components/admin/AdminTimeZoneProvider.tsx
+++ b/apps/web/components/admin/AdminTimeZoneProvider.tsx
@@ -14,6 +14,7 @@ import {
 type AdminTimeZoneContextValue = {
   timeZone: string;
   timeZoneLabel: string;
+  isHydrated: boolean;
   setTimeZone: (value: string) => void;
   formatTimestamp: (value: number | string | Date) => string;
   formatDate: (value?: string) => string | null;
@@ -30,6 +31,7 @@ export function AdminTimeZoneProvider({
   children: React.ReactNode;
 }) {
   const [timeZone, setTimeZoneState] = useState<string>("America/New_York");
+  const [isHydrated, setIsHydrated] = useState(false);
 
   useEffect(() => {
     const stored = window.localStorage.getItem(ADMIN_TIME_ZONE_STORAGE_KEY);
@@ -38,12 +40,14 @@ export function AdminTimeZoneProvider({
         ? stored
         : resolveDefaultAdminTimeZone(),
     );
+    setIsHydrated(true);
   }, []);
 
   const value = useMemo<AdminTimeZoneContextValue>(
     () => ({
       timeZone,
       timeZoneLabel: getAdminTimeZoneLabel(timeZone),
+      isHydrated,
       setTimeZone: (nextTimeZone) => {
         if (!isSupportedAdminTimeZone(nextTimeZone)) {
           return;
@@ -58,7 +62,7 @@ export function AdminTimeZoneProvider({
       formatDateTime: (dateValue, timeValue) =>
         formatPlainDateTimeForAdmin(dateValue, timeValue, timeZone),
     }),
-    [timeZone],
+    [isHydrated, timeZone],
   );
 
   return (

--- a/apps/web/components/admin/AdminTimeZoneProvider.tsx
+++ b/apps/web/components/admin/AdminTimeZoneProvider.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { createContext, useContext, useMemo, useState } from "react";
+import {
+  ADMIN_TIME_ZONE_STORAGE_KEY,
+  formatPlainDateForAdmin,
+  formatPlainDateTimeForAdmin,
+  formatTimestampInTimeZone,
+  getAdminTimeZoneLabel,
+  resolveDefaultAdminTimeZone,
+} from "@/lib/admin-timezone";
+
+type AdminTimeZoneContextValue = {
+  timeZone: string;
+  timeZoneLabel: string;
+  setTimeZone: (value: string) => void;
+  formatTimestamp: (value: number | string | Date) => string;
+  formatDate: (value?: string) => string | null;
+  formatDateTime: (dateValue?: string, timeValue?: string) => string | null;
+};
+
+const AdminTimeZoneContext = createContext<AdminTimeZoneContextValue | null>(
+  null,
+);
+
+export function AdminTimeZoneProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [timeZone, setTimeZoneState] = useState<string>(() => {
+    if (typeof window === "undefined") {
+      return "America/New_York";
+    }
+
+    return (
+      window.localStorage.getItem(ADMIN_TIME_ZONE_STORAGE_KEY) ||
+      resolveDefaultAdminTimeZone()
+    );
+  });
+
+  const value = useMemo<AdminTimeZoneContextValue>(
+    () => ({
+      timeZone,
+      timeZoneLabel: getAdminTimeZoneLabel(timeZone),
+      setTimeZone: (nextTimeZone) => {
+        setTimeZoneState(nextTimeZone);
+        window.localStorage.setItem(ADMIN_TIME_ZONE_STORAGE_KEY, nextTimeZone);
+      },
+      formatTimestamp: (input) => formatTimestampInTimeZone(input, timeZone),
+      formatDate: (input) => formatPlainDateForAdmin(input),
+      formatDateTime: (dateValue, timeValue) =>
+        formatPlainDateTimeForAdmin(dateValue, timeValue, timeZone),
+    }),
+    [timeZone],
+  );
+
+  return (
+    <AdminTimeZoneContext.Provider value={value}>
+      {children}
+    </AdminTimeZoneContext.Provider>
+  );
+}
+
+export function useAdminTimeZone() {
+  const context = useContext(AdminTimeZoneContext);
+
+  if (!context) {
+    throw new Error(
+      "useAdminTimeZone must be used inside AdminTimeZoneProvider",
+    );
+  }
+
+  return context;
+}

--- a/apps/web/components/admin/AdminTimeZoneSelect.tsx
+++ b/apps/web/components/admin/AdminTimeZoneSelect.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import {
+  ADMIN_TIME_ZONE_OPTIONS,
+  getAdminTimeZoneLabel,
+} from "@/lib/admin-timezone";
+import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export function AdminTimeZoneSelect() {
+  const { timeZone, setTimeZone } = useAdminTimeZone();
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="hidden text-xs font-medium tracking-wide text-slate-500 uppercase md:inline">
+        Edit Zone
+      </span>
+      <Select value={timeZone} onValueChange={setTimeZone}>
+        <SelectTrigger className="w-[120px] bg-white">
+          <SelectValue placeholder="Time zone" />
+        </SelectTrigger>
+        <SelectContent>
+          {ADMIN_TIME_ZONE_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {getAdminTimeZoneLabel(option.value)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/web/components/admin/CourseEditor.tsx
+++ b/apps/web/components/admin/CourseEditor.tsx
@@ -266,9 +266,10 @@ export function CourseEditor({
   const courseVersion = course
     ? `${course._id}:${course.updatedAt ?? course._creationTime}`
     : "new";
-  const { timeZone, timeZoneLabel, formatDate, formatDateTime } =
+  const { timeZone, timeZoneLabel, formatDate, formatDateTime, isHydrated } =
     useAdminTimeZone();
   const previousTimeZoneRef = useRef(timeZone);
+  const hasHydratedTimeZoneRef = useRef(false);
 
   const campaigns = useQuery(api.adminOffers.listCampaigns, {
     includeArchived: false,
@@ -287,6 +288,16 @@ export function CourseEditor({
   }, [course, courseVersion]);
 
   useEffect(() => {
+    if (!isHydrated) {
+      return;
+    }
+
+    if (!hasHydratedTimeZoneRef.current) {
+      previousTimeZoneRef.current = timeZone;
+      hasHydratedTimeZoneRef.current = true;
+      return;
+    }
+
     const previousTimeZone = previousTimeZoneRef.current;
     if (previousTimeZone === timeZone) {
       return;
@@ -321,7 +332,7 @@ export function CourseEditor({
 
       return nextState;
     });
-  }, [timeZone]);
+  }, [isHydrated, timeZone]);
 
   const isWorksheet = state.type === "worksheet";
   const isInternship = state.type === "internship";

--- a/apps/web/components/admin/CourseEditor.tsx
+++ b/apps/web/components/admin/CourseEditor.tsx
@@ -13,7 +13,10 @@ import { toast } from "sonner";
 import { UploadDropzone } from "@/lib/uploadthing";
 import { getUserFacingErrorMessage } from "@/lib/convex-error";
 import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
-import { convertPlainDateTimeBetweenTimeZones } from "@/lib/admin-timezone";
+import {
+  convertPlainDateTimeBetweenTimeZones,
+  formatDateWindow,
+} from "@/lib/admin-timezone";
 
 type CourseLifecycleStatus = "draft" | "published" | "archived";
 type CourseType =
@@ -176,21 +179,6 @@ function defaultSessionVariants(): SessionVariantInput[] {
 
 function hasText(value: string | undefined | null): boolean {
   return typeof value === "string" && value.trim().length > 0;
-}
-
-function formatDateWindow(
-  startDate: string,
-  endDate: string,
-  formatDate: (value?: string) => string | null,
-): string | null {
-  const start = formatDate(startDate);
-  const end = formatDate(endDate);
-
-  if (start && end) {
-    return `${start} to ${end}`;
-  }
-
-  return start || end;
 }
 
 function toInitialState(course?: Doc<"courses">): CourseFormState {

--- a/apps/web/components/admin/CourseEditor.tsx
+++ b/apps/web/components/admin/CourseEditor.tsx
@@ -709,7 +709,7 @@ export function CourseEditor({
 
       validateForPublish();
 
-      if (state.lifecycleStatus === "published" && !hasText(state.content)) {
+      if (!hasText(state.content)) {
         toast.warning(
           "Publishing without course content. The public course page may look incomplete.",
         );

--- a/apps/web/components/admin/CourseEditor.tsx
+++ b/apps/web/components/admin/CourseEditor.tsx
@@ -698,6 +698,12 @@ export function CourseEditor({
 
       validateForPublish();
 
+      if (state.lifecycleStatus === "published" && !hasText(state.content)) {
+        toast.warning(
+          "Publishing without course content. The public course page may look incomplete.",
+        );
+      }
+
       if (isSessionBatchCreate) {
         if (state.sessionVariants.length === 0) {
           throw new Error("Add at least one session variant");

--- a/apps/web/components/admin/CourseEditor.tsx
+++ b/apps/web/components/admin/CourseEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@mindpoint/backend/api";
 import type { Doc, Id } from "@mindpoint/backend/data-model";
@@ -12,6 +12,8 @@ import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { UploadDropzone } from "@/lib/uploadthing";
 import { getUserFacingErrorMessage } from "@/lib/convex-error";
+import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
+import { convertPlainDateTimeBetweenTimeZones } from "@/lib/admin-timezone";
 
 type CourseLifecycleStatus = "draft" | "published" | "archived";
 type CourseType =
@@ -176,6 +178,21 @@ function hasText(value: string | undefined | null): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function formatDateWindow(
+  startDate: string,
+  endDate: string,
+  formatDate: (value?: string) => string | null,
+): string | null {
+  const start = formatDate(startDate);
+  const end = formatDate(endDate);
+
+  if (start && end) {
+    return `${start} to ${end}`;
+  }
+
+  return start || end;
+}
+
 function toInitialState(course?: Doc<"courses">): CourseFormState {
   const type = (course?.type as CourseType) || "certificate";
   const defaultVariants =
@@ -261,6 +278,9 @@ export function CourseEditor({
   const courseVersion = course
     ? `${course._id}:${course.updatedAt ?? course._creationTime}`
     : "new";
+  const { timeZone, timeZoneLabel, formatDate, formatDateTime } =
+    useAdminTimeZone();
+  const previousTimeZoneRef = useRef(timeZone);
 
   const campaigns = useQuery(api.adminOffers.listCampaigns, {
     includeArchived: false,
@@ -277,6 +297,43 @@ export function CourseEditor({
     setInitialSnapshot(JSON.stringify(nextInitialState));
     setSelectedCampaignId("");
   }, [course, courseVersion]);
+
+  useEffect(() => {
+    const previousTimeZone = previousTimeZoneRef.current;
+    if (previousTimeZone === timeZone) {
+      return;
+    }
+
+    previousTimeZoneRef.current = timeZone;
+
+    setState((current) => {
+      const nextState = { ...current };
+      const convertedStart = convertPlainDateTimeBetweenTimeZones(
+        current.startDate,
+        current.startTime,
+        previousTimeZone,
+        timeZone,
+      );
+      const convertedEnd = convertPlainDateTimeBetweenTimeZones(
+        current.endDate,
+        current.endTime,
+        previousTimeZone,
+        timeZone,
+      );
+
+      if (convertedStart) {
+        nextState.startDate = convertedStart.dateValue;
+        nextState.startTime = convertedStart.timeValue;
+      }
+
+      if (convertedEnd) {
+        nextState.endDate = convertedEnd.dateValue;
+        nextState.endTime = convertedEnd.timeValue;
+      }
+
+      return nextState;
+    });
+  }, [timeZone]);
 
   const isWorksheet = state.type === "worksheet";
   const isInternship = state.type === "internship";
@@ -355,6 +412,22 @@ export function CourseEditor({
   const isDirty = useMemo(
     () => JSON.stringify(state) !== initialSnapshot,
     [initialSnapshot, state],
+  );
+  const scheduleStartPreview = showSchedule
+    ? formatDateTime(state.startDate, state.startTime)
+    : null;
+  const scheduleEndPreview = showSchedule
+    ? formatDateTime(state.endDate, state.endTime)
+    : null;
+  const offerWindowPreview = formatDateWindow(
+    state.offerStartDate,
+    state.offerEndDate,
+    formatDate,
+  );
+  const bogoWindowPreview = formatDateWindow(
+    state.bogoStartDate,
+    state.bogoEndDate,
+    formatDate,
   );
   const saveStateLabel = !course
     ? "New draft"
@@ -585,9 +658,6 @@ export function CourseEditor({
 
     if (!hasText(state.description)) {
       throw new Error("Description is required before publishing");
-    }
-    if (!hasText(state.content)) {
-      throw new Error("Content is required before publishing");
     }
 
     if (supportsLearningOutcomes && parsedLearningOutcomes.length === 0) {
@@ -891,7 +961,12 @@ export function CourseEditor({
       </div>
 
       <div className="space-y-2">
-        <Label>Content (Markdown/Text)</Label>
+        <div className="flex items-center justify-between gap-3">
+          <Label>Content (Markdown/Text, optional)</Label>
+          <span className="text-xs text-slate-500">
+            Defaults to an empty string if left blank.
+          </span>
+        </div>
         <Textarea
           rows={8}
           value={state.content}
@@ -948,6 +1023,20 @@ export function CourseEditor({
               />
             </div>
           </div>
+
+          {scheduleStartPreview || scheduleEndPreview ? (
+            <div className="rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-900">
+              <p className="font-medium">Schedule preview in {timeZoneLabel}</p>
+              <p className="text-xs text-sky-700">
+                Switching CT, ET, or IST shifts these fields into that edit
+                zone.
+              </p>
+              {scheduleStartPreview ? (
+                <p>Starts: {scheduleStartPreview}</p>
+              ) : null}
+              {scheduleEndPreview ? <p>Ends: {scheduleEndPreview}</p> : null}
+            </div>
+          ) : null}
 
           <div className="grid gap-4 md:grid-cols-3">
             <div className="space-y-2">
@@ -1412,6 +1501,11 @@ export function CourseEditor({
               }
             />
           </div>
+          {offerWindowPreview ? (
+            <p className="text-xs text-slate-500">
+              Offer window: {offerWindowPreview} ({timeZoneLabel})
+            </p>
+          ) : null}
         </div>
 
         <div className="space-y-2 rounded-lg border bg-white p-4">
@@ -1449,6 +1543,11 @@ export function CourseEditor({
               }
             />
           </div>
+          {bogoWindowPreview ? (
+            <p className="text-xs text-slate-500">
+              BOGO window: {bogoWindowPreview} ({timeZoneLabel})
+            </p>
+          ) : null}
         </div>
       </div>
 

--- a/apps/web/components/admin/CourseEditor.tsx
+++ b/apps/web/components/admin/CourseEditor.tsx
@@ -1508,7 +1508,7 @@ export function CourseEditor({
           </div>
           {offerWindowPreview ? (
             <p className="text-xs text-slate-500">
-              Offer window: {offerWindowPreview} ({timeZoneLabel})
+              Offer window: {offerWindowPreview}
             </p>
           ) : null}
         </div>
@@ -1550,7 +1550,7 @@ export function CourseEditor({
           </div>
           {bogoWindowPreview ? (
             <p className="text-xs text-slate-500">
-              BOGO window: {bogoWindowPreview} ({timeZoneLabel})
+              BOGO window: {bogoWindowPreview}
             </p>
           ) : null}
         </div>

--- a/apps/web/lib/admin-timezone.ts
+++ b/apps/web/lib/admin-timezone.ts
@@ -139,6 +139,21 @@ export function formatPlainDateTimeForAdmin(
     : formatted;
 }
 
+export function formatDateWindow(
+  startDate: string,
+  endDate: string,
+  formatDate: (value?: string) => string | null,
+): string | null {
+  const start = formatDate(startDate);
+  const end = formatDate(endDate);
+
+  if (start && end) {
+    return `${start} to ${end}`;
+  }
+
+  return start || end;
+}
+
 function getTimeZoneOffsetMinutes(timeZone: string, date: Date): number {
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone,

--- a/apps/web/lib/admin-timezone.ts
+++ b/apps/web/lib/admin-timezone.ts
@@ -126,6 +126,9 @@ export function formatPlainDateTimeForAdmin(
     return null;
   }
 
+  // Date/time form fields already hold wall-clock values in the currently
+  // selected edit zone, so this formatter intentionally preserves those raw
+  // values instead of converting them again.
   const formatted = new Intl.DateTimeFormat("en-US", {
     dateStyle: "medium",
     timeStyle: timeValue ? "short" : undefined,

--- a/apps/web/lib/admin-timezone.ts
+++ b/apps/web/lib/admin-timezone.ts
@@ -22,21 +22,28 @@ export function isSupportedAdminTimeZone(
 export function resolveDefaultAdminTimeZone(): AdminTimeZoneOption {
   if (typeof Intl !== "undefined") {
     const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    if (detected === "Asia/Kolkata") {
-      return "Asia/Kolkata";
+    if (isSupportedAdminTimeZone(detected)) {
+      return detected;
     }
-    if (
-      detected === "America/Chicago" ||
-      detected === "America/Winnipeg" ||
-      detected === "America/Matamoros"
-    ) {
-      return "America/Chicago";
-    }
-    if (
-      detected === "America/New_York" ||
-      detected === "America/Detroit" ||
-      detected === "America/Indiana/Indianapolis"
-    ) {
+
+    try {
+      const now = new Date();
+      const detectedOffset = getTimeZoneOffsetMinutes(detected, now);
+      let nearestOption: AdminTimeZoneOption = "America/New_York";
+      let smallestDifference = Number.POSITIVE_INFINITY;
+
+      for (const option of ADMIN_TIME_ZONE_OPTIONS) {
+        const optionOffset = getTimeZoneOffsetMinutes(option.value, now);
+        const difference = Math.abs(optionOffset - detectedOffset);
+
+        if (difference < smallestDifference) {
+          smallestDifference = difference;
+          nearestOption = option.value;
+        }
+      }
+
+      return nearestOption;
+    } catch {
       return "America/New_York";
     }
   }

--- a/apps/web/lib/admin-timezone.ts
+++ b/apps/web/lib/admin-timezone.ts
@@ -1,0 +1,231 @@
+"use client";
+
+export const ADMIN_TIME_ZONE_STORAGE_KEY = "mindpoint.admin.timeZone";
+
+export const ADMIN_TIME_ZONE_OPTIONS = [
+  { value: "America/Chicago", label: "CT" },
+  { value: "America/New_York", label: "ET" },
+  { value: "Asia/Kolkata", label: "IST" },
+] as const;
+
+export type AdminTimeZoneOption =
+  (typeof ADMIN_TIME_ZONE_OPTIONS)[number]["value"];
+
+const ADMIN_TIME_ZONE_LABELS = Object.fromEntries(
+  ADMIN_TIME_ZONE_OPTIONS.map((option) => [option.value, option.label]),
+) as Record<AdminTimeZoneOption, string>;
+
+export function isSupportedAdminTimeZone(
+  value: string,
+): value is AdminTimeZoneOption {
+  return ADMIN_TIME_ZONE_OPTIONS.some((option) => option.value === value);
+}
+
+export function resolveDefaultAdminTimeZone(): AdminTimeZoneOption {
+  if (typeof Intl !== "undefined") {
+    const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (detected === "Asia/Kolkata") {
+      return "Asia/Kolkata";
+    }
+    if (
+      detected === "America/Chicago" ||
+      detected === "America/Winnipeg" ||
+      detected === "America/Matamoros"
+    ) {
+      return "America/Chicago";
+    }
+    if (
+      detected === "America/New_York" ||
+      detected === "America/Detroit" ||
+      detected === "America/Indiana/Indianapolis"
+    ) {
+      return "America/New_York";
+    }
+  }
+
+  return "America/New_York";
+}
+
+export function getAdminTimeZoneLabel(timeZone: string): string {
+  return ADMIN_TIME_ZONE_LABELS[timeZone as AdminTimeZoneOption] ?? timeZone;
+}
+
+export function formatTimestampInTimeZone(
+  value: number | string | Date,
+  timeZone: string,
+): string {
+  const date = value instanceof Date ? value : new Date(value);
+
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+      timeZone,
+    }).format(date);
+  } catch {
+    return date.toLocaleString();
+  }
+}
+
+function parsePlainDate(dateValue?: string): Date | null {
+  if (!dateValue) {
+    return null;
+  }
+
+  const [year, month, day] = dateValue.split("-").map(Number);
+  if (
+    !Number.isFinite(year) ||
+    !Number.isFinite(month) ||
+    !Number.isFinite(day)
+  ) {
+    return null;
+  }
+
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function parsePlainDateTime(
+  dateValue?: string,
+  timeValue?: string,
+): Date | null {
+  const date = parsePlainDate(dateValue);
+  if (!date) {
+    return null;
+  }
+
+  if (!timeValue) {
+    return date;
+  }
+
+  const [hours, minutes] = timeValue.split(":").map(Number);
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+    return date;
+  }
+
+  date.setUTCHours(hours, minutes, 0, 0);
+  return date;
+}
+
+export function formatPlainDateForAdmin(dateValue?: string): string | null {
+  const date = parsePlainDate(dateValue);
+  if (!date) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeZone: "UTC",
+  }).format(date);
+}
+
+export function formatPlainDateTimeForAdmin(
+  dateValue?: string,
+  timeValue?: string,
+  timeZone?: string,
+): string | null {
+  const date = parsePlainDateTime(dateValue, timeValue);
+  if (!date) {
+    return null;
+  }
+
+  const formatted = new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: timeValue ? "short" : undefined,
+    timeZone: "UTC",
+  }).format(date);
+
+  return timeZone
+    ? `${formatted} • ${getAdminTimeZoneLabel(timeZone)}`
+    : formatted;
+}
+
+function getTimeZoneOffsetMinutes(timeZone: string, date: Date): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+
+  const values = Object.fromEntries(
+    parts
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  );
+
+  const zonedTimestamp = Date.UTC(
+    Number(values.year),
+    Number(values.month) - 1,
+    Number(values.day),
+    Number(values.hour),
+    Number(values.minute),
+    Number(values.second),
+  );
+
+  return (zonedTimestamp - date.getTime()) / 60000;
+}
+
+function formatWallTimeParts(timestamp: number, timeZone: string) {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(new Date(timestamp));
+
+  const values = Object.fromEntries(
+    parts
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  );
+
+  return {
+    dateValue: `${values.year}-${values.month}-${values.day}`,
+    timeValue: `${values.hour}:${values.minute}`,
+  };
+}
+
+export function convertPlainDateTimeBetweenTimeZones(
+  dateValue: string,
+  timeValue: string,
+  fromTimeZone: string,
+  toTimeZone: string,
+): { dateValue: string; timeValue: string } | null {
+  if (!dateValue || !timeValue || fromTimeZone === toTimeZone) {
+    return dateValue && timeValue ? { dateValue, timeValue } : null;
+  }
+
+  const [year, month, day] = dateValue.split("-").map(Number);
+  const [hours, minutes] = timeValue.split(":").map(Number);
+
+  if (
+    !Number.isFinite(year) ||
+    !Number.isFinite(month) ||
+    !Number.isFinite(day) ||
+    !Number.isFinite(hours) ||
+    !Number.isFinite(minutes)
+  ) {
+    return null;
+  }
+
+  const wallClockTimestamp = Date.UTC(year, month - 1, day, hours, minutes);
+  let utcTimestamp =
+    wallClockTimestamp -
+    getTimeZoneOffsetMinutes(fromTimeZone, new Date(wallClockTimestamp)) *
+      60_000;
+
+  const adjustedOffset = getTimeZoneOffsetMinutes(
+    fromTimeZone,
+    new Date(utcTimestamp),
+  );
+  utcTimestamp = wallClockTimestamp - adjustedOffset * 60_000;
+
+  return formatWallTimeParts(utcTimestamp, toTimeZone);
+}

--- a/apps/web/lib/admin-timezone.ts
+++ b/apps/web/lib/admin-timezone.ts
@@ -126,7 +126,7 @@ export function formatPlainDateForAdmin(dateValue?: string): string | null {
 export function formatPlainDateTimeForAdmin(
   dateValue?: string,
   timeValue?: string,
-  timeZone?: string,
+  editZone?: string,
 ): string | null {
   const date = parsePlainDateTime(dateValue, timeValue);
   if (!date) {
@@ -142,8 +142,8 @@ export function formatPlainDateTimeForAdmin(
     timeZone: "UTC",
   }).format(date);
 
-  return timeZone
-    ? `${formatted} • ${getAdminTimeZoneLabel(timeZone)}`
+  return editZone
+    ? `${formatted} • ${getAdminTimeZoneLabel(editZone)}`
     : formatted;
 }
 

--- a/apps/web/lib/admin-timezone.ts
+++ b/apps/web/lib/admin-timezone.ts
@@ -1,5 +1,3 @@
-"use client";
-
 export const ADMIN_TIME_ZONE_STORAGE_KEY = "mindpoint.admin.timeZone";
 
 export const ADMIN_TIME_ZONE_OPTIONS = [

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as adminEnrollments from "../adminEnrollments.js";
 import type * as adminLoyalty from "../adminLoyalty.js";
 import type * as adminManagers from "../adminManagers.js";
 import type * as adminOffers from "../adminOffers.js";
+import type * as adminReviews from "../adminReviews.js";
 import type * as adminUsers from "../adminUsers.js";
 import type * as adminUtils from "../adminUtils.js";
 import type * as courses from "../courses.js";
@@ -47,6 +48,7 @@ declare const fullApi: ApiFromModules<{
   adminLoyalty: typeof adminLoyalty;
   adminManagers: typeof adminManagers;
   adminOffers: typeof adminOffers;
+  adminReviews: typeof adminReviews;
   adminUsers: typeof adminUsers;
   adminUtils: typeof adminUtils;
   courses: typeof courses;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,11 @@
  * @module
  */
 
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
 import type * as _publicCourse from "../_publicCourse.js";
 import type * as adminAudit from "../adminAudit.js";
 import type * as adminAuth from "../adminAuth.js";
@@ -32,12 +37,14 @@ import type * as rateLimit from "../rateLimit.js";
 import type * as testOffer from "../testOffer.js";
 import type * as viewer from "../viewer.js";
 
-import type {
-  ApiFromModules,
-  FilterApi,
-  FunctionReference,
-} from "convex/server";
-
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
 declare const fullApi: ApiFromModules<{
   _publicCourse: typeof _publicCourse;
   adminAudit: typeof adminAudit;
@@ -63,31 +70,11 @@ declare const fullApi: ApiFromModules<{
   testOffer: typeof testOffer;
   viewer: typeof viewer;
 }>;
-
-/**
- * A utility for referencing Convex functions in your app's public API.
- *
- * Usage:
- * ```js
- * const myFunctionReference = api.myModule.myFunction;
- * ```
- */
 export declare const api: FilterApi<
   typeof fullApi,
   FunctionReference<any, "public">
 >;
-
-/**
- * A utility for referencing Convex functions in your app's internal API.
- *
- * Usage:
- * ```js
- * const myFunctionReference = internal.myModule.myFunction;
- * ```
- */
 export declare const internal: FilterApi<
   typeof fullApi,
   FunctionReference<any, "internal">
 >;
-
-export declare const components: {};

--- a/convex/_generated/api.js
+++ b/convex/_generated/api.js
@@ -8,7 +8,7 @@
  * @module
  */
 
-import { anyApi, componentsGeneric } from "convex/server";
+import { anyApi } from "convex/server";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -20,4 +20,3 @@ import { anyApi, componentsGeneric } from "convex/server";
  */
 export const api = anyApi;
 export const internal = anyApi;
-export const components = componentsGeneric();

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -38,7 +38,7 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  * Convex documents are uniquely identified by their `Id`, which is accessible
  * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
  *
- * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ * Documents can be loaded using `db.get(id)` in query and mutation functions.
  *
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.

--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -85,12 +85,11 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
 /**
  * Define an HTTP action.
  *
- * The wrapped function will be used to respond to HTTP requests received
- * by a Convex deployment if the requests matches the path and method where
- * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ * This function will be used to respond to HTTP requests received by a Convex
+ * deployment if the requests matches the path and method where this action
+ * is routed. Be sure to route your action in `convex/http.js`.
  *
- * @param func - The function. It receives an {@link ActionCtx} as its first argument
- * and a Fetch API `Request` object as its second.
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -80,14 +80,10 @@ export const action = actionGeneric;
 export const internalAction = internalActionGeneric;
 
 /**
- * Define an HTTP action.
+ * Define a Convex HTTP action.
  *
- * The wrapped function will be used to respond to HTTP requests received
- * by a Convex deployment if the requests matches the path and method where
- * this action is routed. Be sure to route your httpAction in `convex/http.js`.
- *
- * @param func - The function. It receives an {@link ActionCtx} as its first argument
- * and a Fetch API `Request` object as its second.
- * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument, and a `Request` object
+ * as its second.
+ * @returns The wrapped endpoint function. Route a URL path to this function in `convex/http.js`.
  */
 export const httpAction = httpActionGeneric;

--- a/convex/adminCourses.ts
+++ b/convex/adminCourses.ts
@@ -141,9 +141,6 @@ function validatePublishableCourse(course: {
   if (!hasText(course.description)) {
     throw new Error("Course description is required before publishing");
   }
-  if (!hasText(course.content)) {
-    throw new Error("Course content is required before publishing");
-  }
 
   switch (course.type) {
     case "certificate":
@@ -534,7 +531,12 @@ export const deleteCourse = mutation({
       throw new Error("Cannot delete a course with enrollments");
     }
 
-    if ((existing.reviews ?? []).length > 0) {
+    const linkedReview = await ctx.db
+      .query("reviews")
+      .withIndex("by_course", (q) => q.eq("course", args.courseId))
+      .first();
+
+    if (linkedReview) {
       throw new Error("Cannot delete a course with reviews");
     }
 

--- a/convex/adminReviews.ts
+++ b/convex/adminReviews.ts
@@ -35,11 +35,7 @@ function normalizeOptionalUserId(value?: string): string | undefined {
 
 function isCourseDoc(value: unknown): value is Doc<"courses"> {
   return (
-    !!value &&
-    typeof value === "object" &&
-    "name" in value &&
-    "code" in value &&
-    "reviews" in value
+    !!value && typeof value === "object" && "name" in value && "code" in value
   );
 }
 
@@ -53,7 +49,7 @@ async function syncCourseReviewReference(
 ) {
   const course = await ctx.db.get(args.courseId);
   if (!course) {
-    return;
+    return false;
   }
 
   const existingIds = course.reviews ?? [];
@@ -67,6 +63,8 @@ async function syncCourseReviewReference(
   await ctx.db.patch(args.courseId, {
     reviews: nextIds,
   });
+
+  return true;
 }
 
 export const listReviews = query({
@@ -157,6 +155,7 @@ export const listReviews = query({
     }
 
     const limitedRows = rows.slice(0, limit);
+    const hasMore = hitScanLimit && rows.length > limitedRows.length;
 
     return {
       reviews: await Promise.all(
@@ -170,7 +169,7 @@ export const listReviews = query({
           };
         }),
       ),
-      hasMore: hitScanLimit,
+      hasMore,
     };
   },
 });
@@ -202,7 +201,7 @@ export const createReview = mutation({
     };
 
     const reviewId = await ctx.db.insert("reviews", review);
-    await syncCourseReviewReference(ctx, {
+    const addedCourseReference = await syncCourseReviewReference(ctx, {
       courseId: args.courseId,
       reviewId,
       action: "add",
@@ -219,6 +218,7 @@ export const createReview = mutation({
       metadata: {
         courseId: String(args.courseId),
         courseName: course.name,
+        courseReferenceSynced: addedCourseReference,
       },
     });
 
@@ -263,8 +263,9 @@ export const updateReview = mutation({
 
     await ctx.db.patch(args.reviewId, patch);
 
+    let previousCourseReferenceRemoved = true;
     if (String(existing.course) !== String(args.courseId)) {
-      await syncCourseReviewReference(ctx, {
+      previousCourseReferenceRemoved = await syncCourseReviewReference(ctx, {
         courseId: existing.course,
         reviewId: args.reviewId,
         action: "remove",
@@ -285,6 +286,9 @@ export const updateReview = mutation({
       entityId: String(args.reviewId),
       before: existing,
       after: updated,
+      metadata: {
+        previousCourseReferenceRemoved,
+      },
     });
 
     return updated;
@@ -304,7 +308,7 @@ export const deleteReview = mutation({
     }
 
     await ctx.db.delete(args.reviewId);
-    await syncCourseReviewReference(ctx, {
+    const removedCourseReference = await syncCourseReviewReference(ctx, {
       courseId: existing.course,
       reviewId: args.reviewId,
       action: "remove",
@@ -317,6 +321,9 @@ export const deleteReview = mutation({
       entityType: "review",
       entityId: String(args.reviewId),
       before: existing,
+      metadata: {
+        removedCourseReference,
+      },
     });
 
     return { success: true };

--- a/convex/adminReviews.ts
+++ b/convex/adminReviews.ts
@@ -263,7 +263,7 @@ export const updateReview = mutation({
 
     await ctx.db.patch(args.reviewId, patch);
 
-    let previousCourseReferenceRemoved = true;
+    let previousCourseReferenceRemoved: boolean | null = null;
     if (String(existing.course) !== String(args.courseId)) {
       previousCourseReferenceRemoved = await syncCourseReviewReference(ctx, {
         courseId: existing.course,

--- a/convex/adminReviews.ts
+++ b/convex/adminReviews.ts
@@ -225,7 +225,7 @@ export const updateReview = mutation({
     reviewId: v.id("reviews"),
     courseId: v.id("courses"),
     userName: v.string(),
-    userId: v.optional(v.string()),
+    userId: v.string(),
     rating: v.number(),
     content: v.string(),
   },
@@ -246,10 +246,8 @@ export const updateReview = mutation({
       course: args.courseId,
       userName: normalizeRequiredText(args.userName, "Reviewer name"),
       userId:
-        normalizeOptionalUserId(args.userId) ||
-        (existing.userId?.trim()
-          ? existing.userId
-          : `admin-managed:${admin.userId}`),
+        normalizeOptionalUserId(args.userId) ??
+        `admin-managed:${admin.userId}`,
       rating: normalizeRating(args.rating),
       content: normalizeRequiredText(args.content, "Review content"),
       isEdited: true,

--- a/convex/adminReviews.ts
+++ b/convex/adminReviews.ts
@@ -92,13 +92,15 @@ export const listReviews = query({
       return course;
     };
 
+    const dbOrder = args.sortBy === "oldest" ? "asc" : "desc";
+
     let rows = args.courseId
       ? await ctx.db
           .query("reviews")
           .withIndex("by_course", (q) => q.eq("course", args.courseId!))
-          .order("desc")
+          .order(dbOrder)
           .take(scanLimit)
-      : await ctx.db.query("reviews").order("desc").take(scanLimit);
+      : await ctx.db.query("reviews").order(dbOrder).take(scanLimit);
     const hitScanLimit = rows.length === scanLimit;
 
     if (typeof args.rating === "number") {

--- a/convex/adminReviews.ts
+++ b/convex/adminReviews.ts
@@ -1,0 +1,292 @@
+import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
+import { mutation, query } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
+import { requireAdmin } from "./adminAuth";
+import { createAdminAuditLog } from "./adminAudit";
+
+function normalizeRating(value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new Error("Rating must be a valid number");
+  }
+
+  const rounded = Math.round(value * 2) / 2;
+  const clamped = Math.max(0.5, Math.min(5, rounded));
+
+  if (!Number.isFinite(clamped)) {
+    throw new Error("Rating must be between 0.5 and 5");
+  }
+
+  return clamped;
+}
+
+function normalizeRequiredText(value: string, field: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${field} is required`);
+  }
+  return trimmed;
+}
+
+function normalizeOptionalUserId(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+async function syncCourseReviewReference(
+  ctx: MutationCtx,
+  args: {
+    courseId: Id<"courses">;
+    reviewId: Id<"reviews">;
+    action: "add" | "remove";
+  },
+) {
+  const course = await ctx.db.get(args.courseId);
+  if (!course) {
+    return;
+  }
+
+  const reviewIds = new Set((course.reviews ?? []).map((id) => String(id)));
+  if (args.action === "add") {
+    reviewIds.add(String(args.reviewId));
+  } else {
+    reviewIds.delete(String(args.reviewId));
+  }
+
+  await ctx.db.patch(args.courseId, {
+    reviews: Array.from(reviewIds).map((id) => id as Id<"reviews">),
+  });
+}
+
+export const listReviews = query({
+  args: {
+    search: v.optional(v.string()),
+    courseId: v.optional(v.id("courses")),
+    rating: v.optional(v.number()),
+    limit: v.optional(v.number()),
+    sortBy: v.optional(
+      v.union(v.literal("newest"), v.literal("oldest"), v.literal("rating")),
+    ),
+  },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const limit = Math.min(args.limit ?? 200, 500);
+    const scanLimit = args.search
+      ? Math.min(Math.max(limit * 10, 500), 2500)
+      : Math.min(Math.max(limit * 5, 250), 1500);
+
+    let rows = args.courseId
+      ? await ctx.db
+          .query("reviews")
+          .withIndex("by_course", (q) => q.eq("course", args.courseId!))
+          .order("desc")
+          .take(scanLimit)
+      : await ctx.db.query("reviews").order("desc").take(scanLimit);
+
+    if (typeof args.rating === "number") {
+      rows = rows.filter((row) => row.rating === args.rating);
+    }
+
+    const courseIds = Array.from(
+      new Set(rows.map((row) => String(row.course))),
+    ).map((id) => id as Id<"courses">);
+    const courseDocs = await Promise.all(
+      courseIds.map(async (courseId) => ({
+        courseId: String(courseId),
+        course: await ctx.db.get(courseId),
+      })),
+    );
+    const coursesById = new Map(
+      courseDocs.map(({ courseId, course }) => [courseId, course] as const),
+    );
+
+    let enriched = rows.map((row) => {
+      const course = coursesById.get(String(row.course));
+      return {
+        ...row,
+        courseName: course?.name ?? "Unknown course",
+        courseCode: course?.code ?? "—",
+        courseType: course?.type ?? null,
+      };
+    });
+
+    if (args.search) {
+      const search = args.search.toLowerCase();
+      enriched = enriched.filter((row) =>
+        [
+          row.userName,
+          row.userId,
+          row.content,
+          row.courseName,
+          row.courseCode,
+          row.courseType ?? "",
+        ].some((part) => part.toLowerCase().includes(search)),
+      );
+    }
+
+    switch (args.sortBy) {
+      case "oldest":
+        enriched.sort((a, b) => a._creationTime - b._creationTime);
+        break;
+      case "rating":
+        enriched.sort(
+          (a, b) => b.rating - a.rating || b._creationTime - a._creationTime,
+        );
+        break;
+      default:
+        enriched.sort((a, b) => b._creationTime - a._creationTime);
+        break;
+    }
+
+    return enriched.slice(0, limit);
+  },
+});
+
+export const createReview = mutation({
+  args: {
+    courseId: v.id("courses"),
+    userName: v.string(),
+    userId: v.optional(v.string()),
+    rating: v.number(),
+    content: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const admin = await requireAdmin(ctx);
+    const course = await ctx.db.get(args.courseId);
+
+    if (!course) {
+      throw new Error("Course not found");
+    }
+
+    const review = {
+      course: args.courseId,
+      userName: normalizeRequiredText(args.userName, "Reviewer name"),
+      userId:
+        normalizeOptionalUserId(args.userId) || `admin-managed:${admin.userId}`,
+      rating: normalizeRating(args.rating),
+      content: normalizeRequiredText(args.content, "Review content"),
+      isEdited: false,
+    };
+
+    const reviewId = await ctx.db.insert("reviews", review);
+    await syncCourseReviewReference(ctx, {
+      courseId: args.courseId,
+      reviewId,
+      action: "add",
+    });
+
+    const created = await ctx.db.get(reviewId);
+    await createAdminAuditLog(ctx, {
+      actorAdminId: admin.userId,
+      actorEmail: admin.email,
+      action: "review.create",
+      entityType: "review",
+      entityId: String(reviewId),
+      after: created,
+      metadata: {
+        courseId: String(args.courseId),
+        courseName: course.name,
+      },
+    });
+
+    return created;
+  },
+});
+
+export const updateReview = mutation({
+  args: {
+    reviewId: v.id("reviews"),
+    courseId: v.id("courses"),
+    userName: v.string(),
+    userId: v.optional(v.string()),
+    rating: v.number(),
+    content: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const admin = await requireAdmin(ctx);
+    const existing = await ctx.db.get(args.reviewId);
+
+    if (!existing) {
+      throw new Error("Review not found");
+    }
+
+    const course = await ctx.db.get(args.courseId);
+    if (!course) {
+      throw new Error("Course not found");
+    }
+
+    const patch = {
+      course: args.courseId,
+      userName: normalizeRequiredText(args.userName, "Reviewer name"),
+      userId:
+        normalizeOptionalUserId(args.userId) ||
+        (existing.userId?.trim()
+          ? existing.userId
+          : `admin-managed:${admin.userId}`),
+      rating: normalizeRating(args.rating),
+      content: normalizeRequiredText(args.content, "Review content"),
+      isEdited: true,
+    };
+
+    await ctx.db.patch(args.reviewId, patch);
+
+    if (String(existing.course) !== String(args.courseId)) {
+      await syncCourseReviewReference(ctx, {
+        courseId: existing.course,
+        reviewId: args.reviewId,
+        action: "remove",
+      });
+      await syncCourseReviewReference(ctx, {
+        courseId: args.courseId,
+        reviewId: args.reviewId,
+        action: "add",
+      });
+    }
+
+    const updated = await ctx.db.get(args.reviewId);
+    await createAdminAuditLog(ctx, {
+      actorAdminId: admin.userId,
+      actorEmail: admin.email,
+      action: "review.update",
+      entityType: "review",
+      entityId: String(args.reviewId),
+      before: existing,
+      after: updated,
+    });
+
+    return updated;
+  },
+});
+
+export const deleteReview = mutation({
+  args: {
+    reviewId: v.id("reviews"),
+  },
+  handler: async (ctx, args) => {
+    const admin = await requireAdmin(ctx);
+    const existing = await ctx.db.get(args.reviewId);
+
+    if (!existing) {
+      throw new Error("Review not found");
+    }
+
+    await ctx.db.delete(args.reviewId);
+    await syncCourseReviewReference(ctx, {
+      courseId: existing.course,
+      reviewId: args.reviewId,
+      action: "remove",
+    });
+
+    await createAdminAuditLog(ctx, {
+      actorAdminId: admin.userId,
+      actorEmail: admin.email,
+      action: "review.delete",
+      entityType: "review",
+      entityId: String(args.reviewId),
+      before: existing,
+    });
+
+    return { success: true };
+  },
+});

--- a/convex/adminReviews.ts
+++ b/convex/adminReviews.ts
@@ -155,7 +155,7 @@ export const listReviews = query({
     }
 
     const limitedRows = rows.slice(0, limit);
-    const hasMore = hitScanLimit && rows.length > limitedRows.length;
+    const hasMore = hitScanLimit;
 
     return {
       reviews: await Promise.all(

--- a/convex/adminReviews.ts
+++ b/convex/adminReviews.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import type { Id } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
 import { mutation, query } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import { requireAdmin } from "./adminAuth";
@@ -33,6 +33,16 @@ function normalizeOptionalUserId(value?: string): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function isCourseDoc(value: unknown): value is Doc<"courses"> {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    "name" in value &&
+    "code" in value &&
+    "reviews" in value
+  );
+}
+
 async function syncCourseReviewReference(
   ctx: MutationCtx,
   args: {
@@ -46,15 +56,16 @@ async function syncCourseReviewReference(
     return;
   }
 
-  const reviewIds = new Set((course.reviews ?? []).map((id) => String(id)));
-  if (args.action === "add") {
-    reviewIds.add(String(args.reviewId));
-  } else {
-    reviewIds.delete(String(args.reviewId));
-  }
+  const existingIds = course.reviews ?? [];
+  const nextIds =
+    args.action === "add"
+      ? existingIds.some((id) => id === args.reviewId)
+        ? existingIds
+        : [...existingIds, args.reviewId]
+      : existingIds.filter((id) => id !== args.reviewId);
 
   await ctx.db.patch(args.courseId, {
-    reviews: Array.from(reviewIds).map((id) => id as Id<"reviews">),
+    reviews: nextIds,
   });
 }
 
@@ -75,10 +86,7 @@ export const listReviews = query({
     const scanLimit = args.search
       ? Math.min(Math.max(limit * 10, 500), 2500)
       : Math.min(Math.max(limit * 5, 250), 1500);
-    const courseCache = new Map<
-      string,
-      Awaited<ReturnType<typeof ctx.db.get>>
-    >();
+    const courseCache = new Map<string, Doc<"courses"> | null>();
 
     const getCourse = async (courseId: Id<"courses">) => {
       const key = String(courseId);
@@ -86,7 +94,8 @@ export const listReviews = query({
         return courseCache.get(key) ?? null;
       }
 
-      const course = await ctx.db.get(courseId);
+      const result = await ctx.db.get(courseId);
+      const course = isCourseDoc(result) ? result : null;
       courseCache.set(key, course);
       return course;
     };
@@ -98,6 +107,7 @@ export const listReviews = query({
           .order("desc")
           .take(scanLimit)
       : await ctx.db.query("reviews").order("desc").take(scanLimit);
+    const hitScanLimit = rows.length === scanLimit;
 
     if (typeof args.rating === "number") {
       rows = rows.filter((row) => row.rating === args.rating);
@@ -108,9 +118,9 @@ export const listReviews = query({
       const filteredRows = [];
 
       for (const row of rows) {
-        const matchesBaseFields = [row.userName, row.userId, row.content].some(
-          (part) => part.toLowerCase().includes(search),
-        );
+        const matchesBaseFields = [row.userName, row.userId, row.content]
+          .filter((part): part is string => typeof part === "string")
+          .some((part) => part.toLowerCase().includes(search));
 
         if (matchesBaseFields) {
           filteredRows.push(row);
@@ -148,17 +158,20 @@ export const listReviews = query({
 
     const limitedRows = rows.slice(0, limit);
 
-    return await Promise.all(
-      limitedRows.map(async (row) => {
-        const course = await getCourse(row.course);
-        return {
-          ...row,
-          courseName: course?.name ?? "Unknown course",
-          courseCode: course?.code ?? "—",
-          courseType: course?.type ?? null,
-        };
-      }),
-    );
+    return {
+      reviews: await Promise.all(
+        limitedRows.map(async (row) => {
+          const course = await getCourse(row.course);
+          return {
+            ...row,
+            courseName: course?.name ?? "Unknown course",
+            courseCode: course?.code ?? "—",
+            courseType: course?.type ?? null,
+          };
+        }),
+      ),
+      hasMore: hitScanLimit,
+    };
   },
 });
 

--- a/convex/adminReviews.ts
+++ b/convex/adminReviews.ts
@@ -11,13 +11,7 @@ function normalizeRating(value: number): number {
   }
 
   const rounded = Math.round(value * 2) / 2;
-  const clamped = Math.max(0.5, Math.min(5, rounded));
-
-  if (!Number.isFinite(clamped)) {
-    throw new Error("Rating must be between 0.5 and 5");
-  }
-
-  return clamped;
+  return Math.max(0.5, Math.min(5, rounded));
 }
 
 function normalizeRequiredText(value: string, field: string): string {

--- a/convex/adminReviews.ts
+++ b/convex/adminReviews.ts
@@ -155,7 +155,7 @@ export const listReviews = query({
     }
 
     const limitedRows = rows.slice(0, limit);
-    const hasMore = hitScanLimit;
+    const hasMore = hitScanLimit && rows.length >= limit;
 
     return {
       reviews: await Promise.all(

--- a/convex/adminReviews.ts
+++ b/convex/adminReviews.ts
@@ -155,7 +155,7 @@ export const listReviews = query({
     }
 
     const limitedRows = rows.slice(0, limit);
-    const hasMore = hitScanLimit && rows.length >= limit;
+    const hasMore = hitScanLimit;
 
     return {
       reviews: await Promise.all(

--- a/convex/adminReviews.ts
+++ b/convex/adminReviews.ts
@@ -75,6 +75,21 @@ export const listReviews = query({
     const scanLimit = args.search
       ? Math.min(Math.max(limit * 10, 500), 2500)
       : Math.min(Math.max(limit * 5, 250), 1500);
+    const courseCache = new Map<
+      string,
+      Awaited<ReturnType<typeof ctx.db.get>>
+    >();
+
+    const getCourse = async (courseId: Id<"courses">) => {
+      const key = String(courseId);
+      if (courseCache.has(key)) {
+        return courseCache.get(key) ?? null;
+      }
+
+      const course = await ctx.db.get(courseId);
+      courseCache.set(key, course);
+      return course;
+    };
 
     let rows = args.courseId
       ? await ctx.db
@@ -88,58 +103,62 @@ export const listReviews = query({
       rows = rows.filter((row) => row.rating === args.rating);
     }
 
-    const courseIds = Array.from(
-      new Set(rows.map((row) => String(row.course))),
-    ).map((id) => id as Id<"courses">);
-    const courseDocs = await Promise.all(
-      courseIds.map(async (courseId) => ({
-        courseId: String(courseId),
-        course: await ctx.db.get(courseId),
-      })),
-    );
-    const coursesById = new Map(
-      courseDocs.map(({ courseId, course }) => [courseId, course] as const),
-    );
-
-    let enriched = rows.map((row) => {
-      const course = coursesById.get(String(row.course));
-      return {
-        ...row,
-        courseName: course?.name ?? "Unknown course",
-        courseCode: course?.code ?? "—",
-        courseType: course?.type ?? null,
-      };
-    });
-
     if (args.search) {
       const search = args.search.toLowerCase();
-      enriched = enriched.filter((row) =>
-        [
-          row.userName,
-          row.userId,
-          row.content,
-          row.courseName,
-          row.courseCode,
-          row.courseType ?? "",
-        ].some((part) => part.toLowerCase().includes(search)),
-      );
+      const filteredRows = [];
+
+      for (const row of rows) {
+        const matchesBaseFields = [row.userName, row.userId, row.content].some(
+          (part) => part.toLowerCase().includes(search),
+        );
+
+        if (matchesBaseFields) {
+          filteredRows.push(row);
+          continue;
+        }
+
+        const course = await getCourse(row.course);
+        const courseParts = [
+          course?.name ?? "",
+          course?.code ?? "",
+          course?.type ?? "",
+        ];
+
+        if (courseParts.some((part) => part.toLowerCase().includes(search))) {
+          filteredRows.push(row);
+        }
+      }
+
+      rows = filteredRows;
     }
 
     switch (args.sortBy) {
       case "oldest":
-        enriched.sort((a, b) => a._creationTime - b._creationTime);
+        rows.sort((a, b) => a._creationTime - b._creationTime);
         break;
       case "rating":
-        enriched.sort(
+        rows.sort(
           (a, b) => b.rating - a.rating || b._creationTime - a._creationTime,
         );
         break;
       default:
-        enriched.sort((a, b) => b._creationTime - a._creationTime);
+        rows.sort((a, b) => b._creationTime - a._creationTime);
         break;
     }
 
-    return enriched.slice(0, limit);
+    const limitedRows = rows.slice(0, limit);
+
+    return await Promise.all(
+      limitedRows.map(async (row) => {
+        const course = await getCourse(row.course);
+        return {
+          ...row,
+          courseName: course?.name ?? "Unknown course",
+          courseCode: course?.code ?? "—",
+          courseType: course?.type ?? null,
+        };
+      }),
+    );
   },
 });
 

--- a/convex/courses.ts
+++ b/convex/courses.ts
@@ -1,9 +1,12 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
 import { CourseType, PublicCourseDocumentValue } from "./schema";
 import { pickPublicCourse, type PublicCourse } from "./_publicCourse";
 
-function isPublishedCourse(course: { lifecycleStatus?: "draft" | "published" | "archived" }) {
+function isPublishedCourse(course: {
+  lifecycleStatus?: "draft" | "published" | "archived";
+}) {
   return !course.lifecycleStatus || course.lifecycleStatus === "published";
 }
 
@@ -20,7 +23,9 @@ export const listCourses = query({
     const [publishedViaIndex, publishedLegacy] = await Promise.all([
       ctx.db
         .query("courses")
-        .withIndex("by_lifecycleStatus", (q) => q.eq("lifecycleStatus", "published"))
+        .withIndex("by_lifecycleStatus", (q) =>
+          q.eq("lifecycleStatus", "published"),
+        )
         .order("desc")
         .take(limit),
       ctx.db
@@ -57,14 +62,18 @@ export const listCoursesByType = query({
       .order("desc")
       .collect();
 
-    const publishedCourses = courses.filter((course) => isPublishedCourse(course));
+    const publishedCourses = courses.filter((course) =>
+      isPublishedCourse(course),
+    );
     const filteredCourses = args.count
       ? publishedCourses.slice(0, args.count)
       : publishedCourses;
 
     return {
       viewer: (await ctx.auth.getUserIdentity())?.name ?? null,
-      courses: filteredCourses.reverse().map((course) => pickPublicCourse(course)),
+      courses: filteredCourses
+        .reverse()
+        .map((course) => pickPublicCourse(course)),
     };
   },
 });
@@ -94,7 +103,9 @@ export const getRelatedVariants = query({
       .query("courses")
       .withIndex("by_name_and_type", (q) => q.eq("name", name).eq("type", type))
       .collect();
-    const publishedVariants = variants.filter((course) => isPublishedCourse(course));
+    const publishedVariants = variants.filter((course) =>
+      isPublishedCourse(course),
+    );
     // Ensure stable order by price ascending, then _creationTime
     publishedVariants.sort(
       (a, b) =>
@@ -155,8 +166,14 @@ export const createReview = mutation({
       isEdited: false,
     });
 
-    // Optionally attach to course document if needed in the future
-    // await ctx.db.patch(args.courseId, { reviews: [...(course.reviews ?? []), reviewId] });
+    const nextReviewIds = Array.from(
+      new Set([
+        ...(course.reviews ?? []).map((id) => String(id)),
+        String(reviewId),
+      ]),
+    ).map((id) => id as Id<"reviews">);
+
+    await ctx.db.patch(args.courseId, { reviews: nextReviewIds });
 
     return reviewId;
   },
@@ -214,8 +231,17 @@ export const deleteReview = mutation({
       throw new Error("You can only delete your own reviews");
     }
 
+    const course = await ctx.db.get(review.course);
     // Delete the review
     await ctx.db.delete(args.reviewId);
+
+    if (course) {
+      await ctx.db.patch(review.course, {
+        reviews: (course.reviews ?? []).filter(
+          (reviewId) => String(reviewId) !== String(args.reviewId),
+        ),
+      });
+    }
 
     return args.reviewId;
   },

--- a/convex/courses.ts
+++ b/convex/courses.ts
@@ -167,6 +167,15 @@ export const createReview = mutation({
     const userId = identity?.subject ?? "anonymous";
     const userName = identity?.name ?? "Anonymous";
 
+    const existingReview = await ctx.db
+      .query("reviews")
+      .withIndex("by_course", (q) => q.eq("course", args.courseId))
+      .filter((q) => q.eq(q.field("userId"), userId))
+      .first();
+    if (existingReview) {
+      throw new Error("You have already reviewed this course");
+    }
+
     const reviewId = await ctx.db.insert("reviews", {
       course: args.courseId,
       userId,

--- a/convex/courses.ts
+++ b/convex/courses.ts
@@ -167,11 +167,13 @@ export const createReview = mutation({
     const userId = identity?.subject ?? "anonymous";
     const userName = identity?.name ?? "Anonymous";
 
-    const existingReview = await ctx.db
-      .query("reviews")
-      .withIndex("by_course", (q) => q.eq("course", args.courseId))
-      .filter((q) => q.eq(q.field("userId"), userId))
-      .first();
+    const existingReview = identity
+      ? await ctx.db
+          .query("reviews")
+          .withIndex("by_course", (q) => q.eq("course", args.courseId))
+          .filter((q) => q.eq(q.field("userId"), userId))
+          .first()
+      : null;
     if (existingReview) {
       throw new Error("You have already reviewed this course");
     }

--- a/convex/courses.ts
+++ b/convex/courses.ts
@@ -10,6 +10,15 @@ function isPublishedCourse(course: {
   return !course.lifecycleStatus || course.lifecycleStatus === "published";
 }
 
+function normalizeReviewRating(value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new Error("Rating must be a valid number");
+  }
+
+  const rounded = Math.round(value * 2) / 2;
+  return Math.max(0.5, Math.min(5, rounded));
+}
+
 export const listCourses = query({
   // Validators for arguments.
   args: {
@@ -147,8 +156,7 @@ export const createReview = mutation({
     content: v.string(),
   },
   handler: async (ctx, args) => {
-    // Basic validation
-    const rating = Math.max(1, Math.min(5, Math.round(args.rating)));
+    const rating = normalizeReviewRating(args.rating);
     // Ensure course exists
     const course = await ctx.db.get(args.courseId);
     if (!course) throw new Error("Course not found");
@@ -188,8 +196,7 @@ export const updateReview = mutation({
     content: v.string(),
   },
   handler: async (ctx, args) => {
-    // Basic validation
-    const rating = Math.max(1, Math.min(5, Math.round(args.rating)));
+    const rating = normalizeReviewRating(args.rating);
 
     // Get the review
     const review = await ctx.db.get(args.reviewId);

--- a/convex/courses.ts
+++ b/convex/courses.ts
@@ -170,8 +170,9 @@ export const createReview = mutation({
     const existingReview = identity
       ? await ctx.db
           .query("reviews")
-          .withIndex("by_course", (q) => q.eq("course", args.courseId))
-          .filter((q) => q.eq(q.field("userId"), userId))
+          .withIndex("by_course_and_user", (q) =>
+            q.eq("course", args.courseId).eq("userId", userId),
+          )
           .first()
       : null;
     if (existingReview) {

--- a/convex/courses.ts
+++ b/convex/courses.ts
@@ -166,14 +166,15 @@ export const createReview = mutation({
       isEdited: false,
     });
 
-    const nextReviewIds = Array.from(
-      new Set([
-        ...(course.reviews ?? []).map((id) => String(id)),
-        String(reviewId),
-      ]),
-    ).map((id) => id as Id<"reviews">);
+    const existingIdStrings = new Set(
+      (course.reviews ?? []).map((id) => String(id)),
+    );
 
-    await ctx.db.patch(args.courseId, { reviews: nextReviewIds });
+    if (!existingIdStrings.has(String(reviewId))) {
+      await ctx.db.patch(args.courseId, {
+        reviews: [...(course.reviews ?? []), reviewId],
+      });
+    }
 
     return reviewId;
   },

--- a/convex/courses.ts
+++ b/convex/courses.ts
@@ -10,11 +10,13 @@ function isPublishedCourse(course: {
   return !course.lifecycleStatus || course.lifecycleStatus === "published";
 }
 
-function normalizeReviewRating(value: number): number {
+function normalizePublicReviewRating(value: number): number {
   if (!Number.isFinite(value)) {
     throw new Error("Rating must be a valid number");
   }
 
+  // The public review form uses interactive half-star input, so public
+  // mutations accept the same 0.5-step range as admin-managed reviews.
   const rounded = Math.round(value * 2) / 2;
   return Math.max(0.5, Math.min(5, rounded));
 }
@@ -156,7 +158,7 @@ export const createReview = mutation({
     content: v.string(),
   },
   handler: async (ctx, args) => {
-    const rating = normalizeReviewRating(args.rating);
+    const rating = normalizePublicReviewRating(args.rating);
     // Ensure course exists
     const course = await ctx.db.get(args.courseId);
     if (!course) throw new Error("Course not found");
@@ -174,15 +176,9 @@ export const createReview = mutation({
       isEdited: false,
     });
 
-    const existingIdStrings = new Set(
-      (course.reviews ?? []).map((id) => String(id)),
-    );
-
-    if (!existingIdStrings.has(String(reviewId))) {
-      await ctx.db.patch(args.courseId, {
-        reviews: [...(course.reviews ?? []), reviewId],
-      });
-    }
+    await ctx.db.patch(args.courseId, {
+      reviews: [...(course.reviews ?? []), reviewId],
+    });
 
     return reviewId;
   },
@@ -196,7 +192,7 @@ export const updateReview = mutation({
     content: v.string(),
   },
   handler: async (ctx, args) => {
-    const rating = normalizeReviewRating(args.rating);
+    const rating = normalizePublicReviewRating(args.rating);
 
     // Get the review
     const review = await ctx.db.get(args.reviewId);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -200,7 +200,9 @@ export default defineSchema({
     content: v.string(),
     course: v.id("courses"),
     isEdited: v.optional(v.boolean()),
-  }).index("by_course", ["course"]),
+  })
+    .index("by_course", ["course"])
+    .index("by_course_and_user", ["course", "userId"]),
 
   guestUsers: defineTable({
     name: v.string(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,31 +1968,6 @@
         }
       }
     },
-    "node_modules/@clerk/types/node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@clerk/types/node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
     "node_modules/@coinbase/wallet-sdk": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-4.3.0.tgz",


### PR DESCRIPTION
## Summary
- Add a new `/admin/reviews` page with search, filtering, sorting, and CRUD flows for course reviews.
- Introduce admin time zone infrastructure (`AdminTimeZoneProvider`, selector UI, shared formatting helpers, localStorage persistence).
- Apply timezone-aware timestamp/date formatting across admin audit logs, enrollments, courses, and offers.
- Add admin navigation entry for Reviews and link from course detail to review management.
- Add backend support for admin review management via new Convex `adminReviews` functions and API typings.
- Update `.gitignore` to exclude generated Convex artifacts (`/convex/_generated/`).

## Testing
- Not run (no test execution output provided in this diff context).
- Verify `AdminTimeZoneSelect` updates display timestamps consistently across admin pages.
- Verify review CRUD in `/admin/reviews`: create, edit, delete, filter by course/rating, and sort modes.
- Verify course detail "Manage Reviews" button deep-links with `courseId` query param and pre-filters reviews.
- Verify offers page date-window previews and campaign timestamps render with selected admin timezone.
- Verify Convex `adminReviews` functions compile and are accessible via generated API types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin Review Manager: search, filters, create/edit/delete reviews and per-review actions.
  * Admin time zone selector and provider in the admin UI.

* **Improvements**
  * Time zone–aware timestamp and date displays across admin pages (audit log, courses, enrollments, offers, reviews).
  * Course editor: schedule/offer/BOGO previews reflect admin time zone; switching zones converts schedule inputs.
  * Publishing proceeds with empty content but shows a warning.
  * Course deletion now blocked when linked reviews exist.

* **Other**
  * Reviews added to admin navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a full admin Reviews Manager (`/admin/reviews`) with search, filtering, sorting, and CRUD dialogs, alongside a timezone-aware display infrastructure (`AdminTimeZoneProvider`, `AdminTimeZoneSelect`, `admin-timezone.ts`) that is applied across audit-log, enrollments, courses, and offers admin pages. It also activates `course.reviews` array maintenance on the public `createReview`/`deleteReview` mutations and adds a duplicate-review guard for authenticated users.

**Notable changes:**
- All issues flagged in the previous review round (type safety on `deleteReviewId`, client-side validation, hydration mismatch, `userId` null guard, `hasMore` scan-limit flag, `"use client"` on the utility module, average-rating label) are addressed in this iteration.
- Admin `createReview` (`convex/adminReviews.ts`) has no duplicate-review check — an admin who supplies a real user's Clerk subject as `userId` can produce a second review that appears alongside the user's own on the public course page.
- `listReviews` queries the DB newest-first even when `sortBy` is `"rating"`, meaning the scan window is biased toward recent reviews; older high-rated reviews beyond `scanLimit` are excluded before the in-memory sort runs.
- `course.reviews` array is now maintained by two separate paths (`courses.ts` with a spread append, `adminReviews.ts` with `syncCourseReviewReference` deduplication) — consider unifying into a single internal helper to prevent future drift.
- The `ci.yml` change pins npm to `11.11.0` globally, which is unusual and will require manual updates to stay in sync with the project's intended npm version.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the admin duplicate-review gap; remaining issues are low-risk for an internal admin tool.
- The PR is a well-scoped feature addition and all previous review concerns are resolved. The one P1 issue — the missing uniqueness check in the admin `createReview` path — can silently produce duplicate public reviews if an admin enters a real user ID. The `sortBy: "rating"` scan-direction concern is a correctness edge case at scale but harmless for small review sets. The dual `course.reviews` maintenance strategies are a code-quality concern rather than an immediate bug.
- convex/adminReviews.ts (duplicate-review gap and rating-sort scan direction), convex/courses.ts (divergent array-maintenance strategy)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| convex/adminReviews.ts | New backend module for admin review CRUD. Two issues: admin `createReview` bypasses the per-user-per-course uniqueness constraint added in `courses.ts`, and `sortBy: "rating"` uses a newest-first DB scan that can exclude older high-rated reviews from the results window. |
| convex/courses.ts | Public review mutations improved: duplicate review guard added via `by_course_and_user` index, rating normalisation shared with admin path, and `course.reviews` array now kept in sync on create/delete. Two separate strategies (spread vs. syncCourseReviewReference) now co-own the same array, which could diverge over time. |
| convex/adminCourses.ts | Course deletion guard improved to query the `reviews` table directly instead of relying on the potentially stale `course.reviews` array. Content validation downgraded from hard error to soft warning. |
| convex/schema.ts | Adds `by_course_and_user` composite index on the `reviews` table — a clean addition that enables the duplicate-review guard in the public mutation. |
| apps/web/app/admin/reviews/page.tsx | New admin Reviews Manager page with search/filter/sort, CRUD dialogs, and a `hasMore` truncation banner. Previous review issues (type safety, client-side validation, average-rating labelling) are all addressed in this iteration. |
| apps/web/components/admin/AdminTimeZoneProvider.tsx | Timezone context provider. Correctly initialises with a fixed SSR-safe default and hydrates from `localStorage` in `useEffect`, avoiding the hydration mismatch flagged in the prior review cycle. |
| apps/web/lib/admin-timezone.ts | Pure utility module for timezone formatting and conversion. The `"use client"` directive has been removed compared to the earlier review concern. DST-safe `convertPlainDateTimeBetweenTimeZones` uses a two-pass offset calculation which is correct. |
| apps/web/components/admin/CourseEditor.tsx | Adds timezone-aware schedule conversion on zone change using refs to track the previous zone and hydration state, preventing spurious conversions on initial render. Content validation downgraded to a toast warning. |
| apps/web/components/admin/AdminSidebar.tsx | Wraps the entire admin layout with `AdminTimeZoneProvider` and adds the `AdminTimeZoneSelect` widget to the header. Reviews navigation entry added. |
| apps/web/app/admin/offers/page.tsx | Replaces `toLocaleString()` calls with `formatTimestamp` from the timezone context and adds offer/BOGO date-window previews. No new issues. |
| apps/web/app/admin/courses/[courseId]/page.tsx | Adds timezone-aware date/timestamp display and a "Manage Reviews" deep-link button. Minimal, clean changes. |
| .github/workflows/ci.yml | Pins npm to version 11.11.0 before `npm ci`. This is an unusual step — it means CI behaviour diverges from whatever npm version ships with the Node.js runner image unless this is kept up to date manually. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Admin as Admin UI (/admin/reviews)
    participant ConvexAdmin as adminReviews.ts
    participant ConvexPublic as courses.ts
    participant DB as Convex DB (reviews + courses)

    Note over Admin,DB: Create Review (Admin Path)
    Admin->>ConvexAdmin: createReview(courseId, userName, userId?, rating, content)
    ConvexAdmin->>DB: requireAdmin(ctx)
    ConvexAdmin->>DB: db.get(courseId) — verify course exists
    ConvexAdmin->>DB: db.insert("reviews", {...})
    ConvexAdmin->>DB: syncCourseReviewReference(add) → db.patch(courseId, {reviews: [...ids, reviewId]})
    ConvexAdmin->>DB: createAdminAuditLog(...)
    ConvexAdmin-->>Admin: created review doc

    Note over Admin,DB: Create Review (Public Path)
    Admin->>ConvexPublic: createReview(courseId, rating, content)
    ConvexPublic->>DB: db.query("reviews").withIndex("by_course_and_user") — duplicate check
    ConvexPublic->>DB: db.insert("reviews", {...})
    ConvexPublic->>DB: db.patch(courseId, {reviews: [...existing, reviewId]})
    ConvexPublic-->>Admin: reviewId

    Note over Admin,DB: Update Review (Admin Path — course change)
    Admin->>ConvexAdmin: updateReview(reviewId, courseId, ...)
    ConvexAdmin->>DB: db.get(reviewId) — load existing
    ConvexAdmin->>DB: syncCourseReviewReference(remove) on old course
    ConvexAdmin->>DB: syncCourseReviewReference(add) on new course
    ConvexAdmin->>DB: db.patch(reviewId, patch)
    ConvexAdmin->>DB: createAdminAuditLog(...)
    ConvexAdmin-->>Admin: updated review doc

    Note over Admin,DB: Delete Review (Admin Path)
    Admin->>ConvexAdmin: deleteReview(reviewId)
    ConvexAdmin->>DB: db.get(reviewId)
    ConvexAdmin->>DB: db.delete(reviewId)
    ConvexAdmin->>DB: syncCourseReviewReference(remove) → db.patch(courseId, {reviews: filtered})
    ConvexAdmin->>DB: createAdminAuditLog(...)
    ConvexAdmin-->>Admin: {success: true}
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (45)</h3></summary>

1. `apps/web/app/admin/offers/page.tsx`, line 178-190 ([link](https://github.com/ayushj1001/mindpoint/blob/be2b05a21dce0531a3b1bc3fb4e22d2616fa339e/apps/web/app/admin/offers/page.tsx#L178-L190)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Duplicate `formatDateWindow` helper**

   This `formatDateWindow` function is identical to the one defined at the module level in `apps/web/components/admin/CourseEditor.tsx` (lines ~1101–1114 of the diff). Having two copies means any future change to the formatting logic must be made in two places.

   Consider extracting this to `apps/web/lib/admin-timezone.ts` (or a shared admin utility) and importing it in both files:

   ```ts
   // In admin-timezone.ts
   export function formatDateWindow(
     startDate: string,
     endDate: string,
     formatDate: (value?: string) => string | null,
   ): string | null {
     const start = formatDate(startDate);
     const end = formatDate(endDate);
     if (start && end) return `${start} to ${end}`;
     return start || end;
   }
   ```

   This same issue is also present in `apps/web/components/admin/CourseEditor.tsx`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/app/admin/offers/page.tsx
   Line: 178-190

   Comment:
   **Duplicate `formatDateWindow` helper**

   This `formatDateWindow` function is identical to the one defined at the module level in `apps/web/components/admin/CourseEditor.tsx` (lines ~1101–1114 of the diff). Having two copies means any future change to the formatting logic must be made in two places.

   Consider extracting this to `apps/web/lib/admin-timezone.ts` (or a shared admin utility) and importing it in both files:

   ```ts
   // In admin-timezone.ts
   export function formatDateWindow(
     startDate: string,
     endDate: string,
     formatDate: (value?: string) => string | null,
   ): string | null {
     const start = formatDate(startDate);
     const end = formatDate(endDate);
     if (start && end) return `${start} to ${end}`;
     return start || end;
   }
   ```

   This same issue is also present in `apps/web/components/admin/CourseEditor.tsx`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fapp%2Fadmin%2Foffers%2Fpage.tsx%0ALine%3A%20178-190%0A%0AComment%3A%0A**Duplicate%20%60formatDateWindow%60%20helper**%0A%0AThis%20%60formatDateWindow%60%20function%20is%20identical%20to%20the%20one%20defined%20at%20the%20module%20level%20in%20%60apps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%60%20%28lines%20~1101%E2%80%931114%20of%20the%20diff%29.%20Having%20two%20copies%20means%20any%20future%20change%20to%20the%20formatting%20logic%20must%20be%20made%20in%20two%20places.%0A%0AConsider%20extracting%20this%20to%20%60apps%2Fweb%2Flib%2Fadmin-timezone.ts%60%20%28or%20a%20shared%20admin%20utility%29%20and%20importing%20it%20in%20both%20files%3A%0A%0A%60%60%60ts%0A%2F%2F%20In%20admin-timezone.ts%0Aexport%20function%20formatDateWindow%28%0A%20%20startDate%3A%20string%2C%0A%20%20endDate%3A%20string%2C%0A%20%20formatDate%3A%20%28value%3F%3A%20string%29%20%3D%3E%20string%20%7C%20null%2C%0A%29%3A%20string%20%7C%20null%20%7B%0A%20%20const%20start%20%3D%20formatDate%28startDate%29%3B%0A%20%20const%20end%20%3D%20formatDate%28endDate%29%3B%0A%20%20if%20%28start%20%26%26%20end%29%20return%20%60%24%7Bstart%7D%20to%20%24%7Bend%7D%60%3B%0A%20%20return%20start%20%7C%7C%20end%3B%0A%7D%0A%60%60%60%0A%0AThis%20same%20issue%20is%20also%20present%20in%20%60apps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fapp%2Fadmin%2Foffers%2Fpage.tsx%0ALine%3A%20178-190%0A%0AComment%3A%0A**Duplicate%20%60formatDateWindow%60%20helper**%0A%0AThis%20%60formatDateWindow%60%20function%20is%20identical%20to%20the%20one%20defined%20at%20the%20module%20level%20in%20%60apps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%60%20%28lines%20~1101%E2%80%931114%20of%20the%20diff%29.%20Having%20two%20copies%20means%20any%20future%20change%20to%20the%20formatting%20logic%20must%20be%20made%20in%20two%20places.%0A%0AConsider%20extracting%20this%20to%20%60apps%2Fweb%2Flib%2Fadmin-timezone.ts%60%20%28or%20a%20shared%20admin%20utility%29%20and%20importing%20it%20in%20both%20files%3A%0A%0A%60%60%60ts%0A%2F%2F%20In%20admin-timezone.ts%0Aexport%20function%20formatDateWindow%28%0A%20%20startDate%3A%20string%2C%0A%20%20endDate%3A%20string%2C%0A%20%20formatDate%3A%20%28value%3F%3A%20string%29%20%3D%3E%20string%20%7C%20null%2C%0A%29%3A%20string%20%7C%20null%20%7B%0A%20%20const%20start%20%3D%20formatDate%28startDate%29%3B%0A%20%20const%20end%20%3D%20formatDate%28endDate%29%3B%0A%20%20if%20%28start%20%26%26%20end%29%20return%20%60%24%7Bstart%7D%20to%20%24%7Bend%7D%60%3B%0A%20%20return%20start%20%7C%7C%20end%3B%0A%7D%0A%60%60%60%0A%0AThis%20same%20issue%20is%20also%20present%20in%20%60apps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fapp%2Fadmin%2Foffers%2Fpage.tsx%0ALine%3A%20178-190%0A%0AComment%3A%0A**Duplicate%20%60formatDateWindow%60%20helper**%0A%0AThis%20%60formatDateWindow%60%20function%20is%20identical%20to%20the%20one%20defined%20at%20the%20module%20level%20in%20%60apps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%60%20%28lines%20~1101%E2%80%931114%20of%20the%20diff%29.%20Having%20two%20copies%20means%20any%20future%20change%20to%20the%20formatting%20logic%20must%20be%20made%20in%20two%20places.%0A%0AConsider%20extracting%20this%20to%20%60apps%2Fweb%2Flib%2Fadmin-timezone.ts%60%20%28or%20a%20shared%20admin%20utility%29%20and%20importing%20it%20in%20both%20files%3A%0A%0A%60%60%60ts%0A%2F%2F%20In%20admin-timezone.ts%0Aexport%20function%20formatDateWindow%28%0A%20%20startDate%3A%20string%2C%0A%20%20endDate%3A%20string%2C%0A%20%20formatDate%3A%20%28value%3F%3A%20string%29%20%3D%3E%20string%20%7C%20null%2C%0A%29%3A%20string%20%7C%20null%20%7B%0A%20%20const%20start%20%3D%20formatDate%28startDate%29%3B%0A%20%20const%20end%20%3D%20formatDate%28endDate%29%3B%0A%20%20if%20%28start%20%26%26%20end%29%20return%20%60%24%7Bstart%7D%20to%20%24%7Bend%7D%60%3B%0A%20%20return%20start%20%7C%7C%20end%3B%0A%7D%0A%60%60%60%0A%0AThis%20same%20issue%20is%20also%20present%20in%20%60apps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix in Cursor" src="https://img.shields.io/badge/Fix_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

2. `convex/adminReviews.ts`, line 1646-1657 ([link](https://github.com/ayushj1001/mindpoint/blob/be2b05a21dce0531a3b1bc3fb4e22d2616fa339e/convex/adminReviews.ts#L1646-L1657)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`listReviews` performs N individual `ctx.db.get()` calls for course enrichment**

   After collecting reviews, the query resolves each unique `courseId` with a separate `ctx.db.get()`:

   ```ts
   const courseDocs = await Promise.all(
     courseIds.map(async (courseId) => ({
       courseId: String(courseId),
       course: await ctx.db.get(courseId),
     })),
   );
   ```

   While `Promise.all` parallelises these, for a scan of 1500–2500 rows this can become many round-trips. If the Convex guidelines for this project recommend avoiding N+1 patterns (e.g. using indexes or batch APIs), this should be revisited. If the review set is always small in practice this is acceptable, but it's worth noting at scale.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: convex/adminReviews.ts
   Line: 1646-1657

   Comment:
   **`listReviews` performs N individual `ctx.db.get()` calls for course enrichment**

   After collecting reviews, the query resolves each unique `courseId` with a separate `ctx.db.get()`:

   ```ts
   const courseDocs = await Promise.all(
     courseIds.map(async (courseId) => ({
       courseId: String(courseId),
       course: await ctx.db.get(courseId),
     })),
   );
   ```

   While `Promise.all` parallelises these, for a scan of 1500–2500 rows this can become many round-trips. If the Convex guidelines for this project recommend avoiding N+1 patterns (e.g. using indexes or batch APIs), this should be revisited. If the review set is always small in practice this is acceptable, but it's worth noting at scale.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201646-1657%0A%0AComment%3A%0A**%60listReviews%60%20performs%20N%20individual%20%60ctx.db.get%28%29%60%20calls%20for%20course%20enrichment**%0A%0AAfter%20collecting%20reviews%2C%20the%20query%20resolves%20each%20unique%20%60courseId%60%20with%20a%20separate%20%60ctx.db.get%28%29%60%3A%0A%0A%60%60%60ts%0Aconst%20courseDocs%20%3D%20await%20Promise.all%28%0A%20%20courseIds.map%28async%20%28courseId%29%20%3D%3E%20%28%7B%0A%20%20%20%20courseId%3A%20String%28courseId%29%2C%0A%20%20%20%20course%3A%20await%20ctx.db.get%28courseId%29%2C%0A%20%20%7D%29%29%2C%0A%29%3B%0A%60%60%60%0A%0AWhile%20%60Promise.all%60%20parallelises%20these%2C%20for%20a%20scan%20of%201500%E2%80%932500%20rows%20this%20can%20become%20many%20round-trips.%20If%20the%20Convex%20guidelines%20for%20this%20project%20recommend%20avoiding%20N%2B1%20patterns%20%28e.g.%20using%20indexes%20or%20batch%20APIs%29%2C%20this%20should%20be%20revisited.%20If%20the%20review%20set%20is%20always%20small%20in%20practice%20this%20is%20acceptable%2C%20but%20it's%20worth%20noting%20at%20scale.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201646-1657%0A%0AComment%3A%0A**%60listReviews%60%20performs%20N%20individual%20%60ctx.db.get%28%29%60%20calls%20for%20course%20enrichment**%0A%0AAfter%20collecting%20reviews%2C%20the%20query%20resolves%20each%20unique%20%60courseId%60%20with%20a%20separate%20%60ctx.db.get%28%29%60%3A%0A%0A%60%60%60ts%0Aconst%20courseDocs%20%3D%20await%20Promise.all%28%0A%20%20courseIds.map%28async%20%28courseId%29%20%3D%3E%20%28%7B%0A%20%20%20%20courseId%3A%20String%28courseId%29%2C%0A%20%20%20%20course%3A%20await%20ctx.db.get%28courseId%29%2C%0A%20%20%7D%29%29%2C%0A%29%3B%0A%60%60%60%0A%0AWhile%20%60Promise.all%60%20parallelises%20these%2C%20for%20a%20scan%20of%201500%E2%80%932500%20rows%20this%20can%20become%20many%20round-trips.%20If%20the%20Convex%20guidelines%20for%20this%20project%20recommend%20avoiding%20N%2B1%20patterns%20%28e.g.%20using%20indexes%20or%20batch%20APIs%29%2C%20this%20should%20be%20revisited.%20If%20the%20review%20set%20is%20always%20small%20in%20practice%20this%20is%20acceptable%2C%20but%20it's%20worth%20noting%20at%20scale.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201646-1657%0A%0AComment%3A%0A**%60listReviews%60%20performs%20N%20individual%20%60ctx.db.get%28%29%60%20calls%20for%20course%20enrichment**%0A%0AAfter%20collecting%20reviews%2C%20the%20query%20resolves%20each%20unique%20%60courseId%60%20with%20a%20separate%20%60ctx.db.get%28%29%60%3A%0A%0A%60%60%60ts%0Aconst%20courseDocs%20%3D%20await%20Promise.all%28%0A%20%20courseIds.map%28async%20%28courseId%29%20%3D%3E%20%28%7B%0A%20%20%20%20courseId%3A%20String%28courseId%29%2C%0A%20%20%20%20course%3A%20await%20ctx.db.get%28courseId%29%2C%0A%20%20%7D%29%29%2C%0A%29%3B%0A%60%60%60%0A%0AWhile%20%60Promise.all%60%20parallelises%20these%2C%20for%20a%20scan%20of%201500%E2%80%932500%20rows%20this%20can%20become%20many%20round-trips.%20If%20the%20Convex%20guidelines%20for%20this%20project%20recommend%20avoiding%20N%2B1%20patterns%20%28e.g.%20using%20indexes%20or%20batch%20APIs%29%2C%20this%20should%20be%20revisited.%20If%20the%20review%20set%20is%20always%20small%20in%20practice%20this%20is%20acceptable%2C%20but%20it's%20worth%20noting%20at%20scale.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix in Cursor" src="https://img.shields.io/badge/Fix_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

3. `convex/adminReviews.ts`, line 1591-1598 ([link](https://github.com/ayushj1001/mindpoint/blob/aa102cee95541f958a8c742b709fc487beb3f577/convex/adminReviews.ts#L1591-L1598)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`isCourseDoc` check fails for courses without a `reviews` field**

   The `"reviews" in value` guard will return `false` for any course document that doesn't yet have a `reviews` array (e.g., courses created before this PR, or courses whose `reviews` field has never been written). In Convex, optional fields are simply absent from the document if they were never set.

   This means `getCourse` will return `null` for a significant number of valid courses, and every review linked to those courses will show **"Unknown course"** in the admin review list — even though the course document exists and is queryable.

   The fix is to drop the `"reviews" in value` check, since `reviews` is declared optional in the schema:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: convex/adminReviews.ts
   Line: 1591-1598

   Comment:
   **`isCourseDoc` check fails for courses without a `reviews` field**

   The `"reviews" in value` guard will return `false` for any course document that doesn't yet have a `reviews` array (e.g., courses created before this PR, or courses whose `reviews` field has never been written). In Convex, optional fields are simply absent from the document if they were never set.

   This means `getCourse` will return `null` for a significant number of valid courses, and every review linked to those courses will show **"Unknown course"** in the admin review list — even though the course document exists and is queryable.

   The fix is to drop the `"reviews" in value` check, since `reviews` is declared optional in the schema:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201591-1598%0A%0AComment%3A%0A**%60isCourseDoc%60%20check%20fails%20for%20courses%20without%20a%20%60reviews%60%20field**%0A%0AThe%20%60%22reviews%22%20in%20value%60%20guard%20will%20return%20%60false%60%20for%20any%20course%20document%20that%20doesn't%20yet%20have%20a%20%60reviews%60%20array%20%28e.g.%2C%20courses%20created%20before%20this%20PR%2C%20or%20courses%20whose%20%60reviews%60%20field%20has%20never%20been%20written%29.%20In%20Convex%2C%20optional%20fields%20are%20simply%20absent%20from%20the%20document%20if%20they%20were%20never%20set.%0A%0AThis%20means%20%60getCourse%60%20will%20return%20%60null%60%20for%20a%20significant%20number%20of%20valid%20courses%2C%20and%20every%20review%20linked%20to%20those%20courses%20will%20show%20**%22Unknown%20course%22**%20in%20the%20admin%20review%20list%20%E2%80%94%20even%20though%20the%20course%20document%20exists%20and%20is%20queryable.%0A%0AThe%20fix%20is%20to%20drop%20the%20%60%22reviews%22%20in%20value%60%20check%2C%20since%20%60reviews%60%20is%20declared%20optional%20in%20the%20schema%3A%0A%0A%60%60%60suggestion%0Afunction%20isCourseDoc%28value%3A%20unknown%29%3A%20value%20is%20Doc%3C%22courses%22%3E%20%7B%0A%20%20return%20%28%0A%20%20%20%20!!value%20%26%26%0A%20%20%20%20typeof%20value%20%3D%3D%3D%20%22object%22%20%26%26%0A%20%20%20%20%22name%22%20in%20value%20%26%26%0A%20%20%20%20%22code%22%20in%20value%0A%20%20%29%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201591-1598%0A%0AComment%3A%0A**%60isCourseDoc%60%20check%20fails%20for%20courses%20without%20a%20%60reviews%60%20field**%0A%0AThe%20%60%22reviews%22%20in%20value%60%20guard%20will%20return%20%60false%60%20for%20any%20course%20document%20that%20doesn't%20yet%20have%20a%20%60reviews%60%20array%20%28e.g.%2C%20courses%20created%20before%20this%20PR%2C%20or%20courses%20whose%20%60reviews%60%20field%20has%20never%20been%20written%29.%20In%20Convex%2C%20optional%20fields%20are%20simply%20absent%20from%20the%20document%20if%20they%20were%20never%20set.%0A%0AThis%20means%20%60getCourse%60%20will%20return%20%60null%60%20for%20a%20significant%20number%20of%20valid%20courses%2C%20and%20every%20review%20linked%20to%20those%20courses%20will%20show%20**%22Unknown%20course%22**%20in%20the%20admin%20review%20list%20%E2%80%94%20even%20though%20the%20course%20document%20exists%20and%20is%20queryable.%0A%0AThe%20fix%20is%20to%20drop%20the%20%60%22reviews%22%20in%20value%60%20check%2C%20since%20%60reviews%60%20is%20declared%20optional%20in%20the%20schema%3A%0A%0A%60%60%60suggestion%0Afunction%20isCourseDoc%28value%3A%20unknown%29%3A%20value%20is%20Doc%3C%22courses%22%3E%20%7B%0A%20%20return%20%28%0A%20%20%20%20!!value%20%26%26%0A%20%20%20%20typeof%20value%20%3D%3D%3D%20%22object%22%20%26%26%0A%20%20%20%20%22name%22%20in%20value%20%26%26%0A%20%20%20%20%22code%22%20in%20value%0A%20%20%29%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201591-1598%0A%0AComment%3A%0A**%60isCourseDoc%60%20check%20fails%20for%20courses%20without%20a%20%60reviews%60%20field**%0A%0AThe%20%60%22reviews%22%20in%20value%60%20guard%20will%20return%20%60false%60%20for%20any%20course%20document%20that%20doesn't%20yet%20have%20a%20%60reviews%60%20array%20%28e.g.%2C%20courses%20created%20before%20this%20PR%2C%20or%20courses%20whose%20%60reviews%60%20field%20has%20never%20been%20written%29.%20In%20Convex%2C%20optional%20fields%20are%20simply%20absent%20from%20the%20document%20if%20they%20were%20never%20set.%0A%0AThis%20means%20%60getCourse%60%20will%20return%20%60null%60%20for%20a%20significant%20number%20of%20valid%20courses%2C%20and%20every%20review%20linked%20to%20those%20courses%20will%20show%20**%22Unknown%20course%22**%20in%20the%20admin%20review%20list%20%E2%80%94%20even%20though%20the%20course%20document%20exists%20and%20is%20queryable.%0A%0AThe%20fix%20is%20to%20drop%20the%20%60%22reviews%22%20in%20value%60%20check%2C%20since%20%60reviews%60%20is%20declared%20optional%20in%20the%20schema%3A%0A%0A%60%60%60suggestion%0Afunction%20isCourseDoc%28value%3A%20unknown%29%3A%20value%20is%20Doc%3C%22courses%22%3E%20%7B%0A%20%20return%20%28%0A%20%20%20%20!!value%20%26%26%0A%20%20%20%20typeof%20value%20%3D%3D%3D%20%22object%22%20%26%26%0A%20%20%20%20%22name%22%20in%20value%20%26%26%0A%20%20%20%20%22code%22%20in%20value%0A%20%20%29%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix in Cursor" src="https://img.shields.io/badge/Fix_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

4. `convex/adminReviews.ts`, line 1665 ([link](https://github.com/ayushj1001/mindpoint/blob/aa102cee95541f958a8c742b709fc487beb3f577/convex/adminReviews.ts#L1665)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`hasMore` is computed before rating/search filters are applied**

   `hitScanLimit` is set immediately after the initial database fetch — before the `args.rating` filter and the `args.search` loop reduce the result set. If the scan fills to `scanLimit` (e.g., 2500 docs) but the post-filter result is only 3 rows, `hasMore` is still `true`, and the frontend shows the "Showing the first 500 reviews" warning unnecessarily. This is misleading to admins who believe they have an incomplete view when they actually see everything.

   The flag should be computed after all filters have been applied and after the slice:

   ```ts
   // After rating and search filters, then:
   const limitedRows = rows.slice(0, limit);
   const hasMore = hitScanLimit && rows.length > limitedRows.length;
   ```

   This way `hasMore` is only true when both the scan limit was hit AND filtering produced more results than the display limit.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: convex/adminReviews.ts
   Line: 1665

   Comment:
   **`hasMore` is computed before rating/search filters are applied**

   `hitScanLimit` is set immediately after the initial database fetch — before the `args.rating` filter and the `args.search` loop reduce the result set. If the scan fills to `scanLimit` (e.g., 2500 docs) but the post-filter result is only 3 rows, `hasMore` is still `true`, and the frontend shows the "Showing the first 500 reviews" warning unnecessarily. This is misleading to admins who believe they have an incomplete view when they actually see everything.

   The flag should be computed after all filters have been applied and after the slice:

   ```ts
   // After rating and search filters, then:
   const limitedRows = rows.slice(0, limit);
   const hasMore = hitScanLimit && rows.length > limitedRows.length;
   ```

   This way `hasMore` is only true when both the scan limit was hit AND filtering produced more results than the display limit.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201665%0A%0AComment%3A%0A**%60hasMore%60%20is%20computed%20before%20rating%2Fsearch%20filters%20are%20applied**%0A%0A%60hitScanLimit%60%20is%20set%20immediately%20after%20the%20initial%20database%20fetch%20%E2%80%94%20before%20the%20%60args.rating%60%20filter%20and%20the%20%60args.search%60%20loop%20reduce%20the%20result%20set.%20If%20the%20scan%20fills%20to%20%60scanLimit%60%20%28e.g.%2C%202500%20docs%29%20but%20the%20post-filter%20result%20is%20only%203%20rows%2C%20%60hasMore%60%20is%20still%20%60true%60%2C%20and%20the%20frontend%20shows%20the%20%22Showing%20the%20first%20500%20reviews%22%20warning%20unnecessarily.%20This%20is%20misleading%20to%20admins%20who%20believe%20they%20have%20an%20incomplete%20view%20when%20they%20actually%20see%20everything.%0A%0AThe%20flag%20should%20be%20computed%20after%20all%20filters%20have%20been%20applied%20and%20after%20the%20slice%3A%0A%0A%60%60%60ts%0A%2F%2F%20After%20rating%20and%20search%20filters%2C%20then%3A%0Aconst%20limitedRows%20%3D%20rows.slice%280%2C%20limit%29%3B%0Aconst%20hasMore%20%3D%20hitScanLimit%20%26%26%20rows.length%20%3E%20limitedRows.length%3B%0A%60%60%60%0A%0AThis%20way%20%60hasMore%60%20is%20only%20true%20when%20both%20the%20scan%20limit%20was%20hit%20AND%20filtering%20produced%20more%20results%20than%20the%20display%20limit.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201665%0A%0AComment%3A%0A**%60hasMore%60%20is%20computed%20before%20rating%2Fsearch%20filters%20are%20applied**%0A%0A%60hitScanLimit%60%20is%20set%20immediately%20after%20the%20initial%20database%20fetch%20%E2%80%94%20before%20the%20%60args.rating%60%20filter%20and%20the%20%60args.search%60%20loop%20reduce%20the%20result%20set.%20If%20the%20scan%20fills%20to%20%60scanLimit%60%20%28e.g.%2C%202500%20docs%29%20but%20the%20post-filter%20result%20is%20only%203%20rows%2C%20%60hasMore%60%20is%20still%20%60true%60%2C%20and%20the%20frontend%20shows%20the%20%22Showing%20the%20first%20500%20reviews%22%20warning%20unnecessarily.%20This%20is%20misleading%20to%20admins%20who%20believe%20they%20have%20an%20incomplete%20view%20when%20they%20actually%20see%20everything.%0A%0AThe%20flag%20should%20be%20computed%20after%20all%20filters%20have%20been%20applied%20and%20after%20the%20slice%3A%0A%0A%60%60%60ts%0A%2F%2F%20After%20rating%20and%20search%20filters%2C%20then%3A%0Aconst%20limitedRows%20%3D%20rows.slice%280%2C%20limit%29%3B%0Aconst%20hasMore%20%3D%20hitScanLimit%20%26%26%20rows.length%20%3E%20limitedRows.length%3B%0A%60%60%60%0A%0AThis%20way%20%60hasMore%60%20is%20only%20true%20when%20both%20the%20scan%20limit%20was%20hit%20AND%20filtering%20produced%20more%20results%20than%20the%20display%20limit.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201665%0A%0AComment%3A%0A**%60hasMore%60%20is%20computed%20before%20rating%2Fsearch%20filters%20are%20applied**%0A%0A%60hitScanLimit%60%20is%20set%20immediately%20after%20the%20initial%20database%20fetch%20%E2%80%94%20before%20the%20%60args.rating%60%20filter%20and%20the%20%60args.search%60%20loop%20reduce%20the%20result%20set.%20If%20the%20scan%20fills%20to%20%60scanLimit%60%20%28e.g.%2C%202500%20docs%29%20but%20the%20post-filter%20result%20is%20only%203%20rows%2C%20%60hasMore%60%20is%20still%20%60true%60%2C%20and%20the%20frontend%20shows%20the%20%22Showing%20the%20first%20500%20reviews%22%20warning%20unnecessarily.%20This%20is%20misleading%20to%20admins%20who%20believe%20they%20have%20an%20incomplete%20view%20when%20they%20actually%20see%20everything.%0A%0AThe%20flag%20should%20be%20computed%20after%20all%20filters%20have%20been%20applied%20and%20after%20the%20slice%3A%0A%0A%60%60%60ts%0A%2F%2F%20After%20rating%20and%20search%20filters%2C%20then%3A%0Aconst%20limitedRows%20%3D%20rows.slice%280%2C%20limit%29%3B%0Aconst%20hasMore%20%3D%20hitScanLimit%20%26%26%20rows.length%20%3E%20limitedRows.length%3B%0A%60%60%60%0A%0AThis%20way%20%60hasMore%60%20is%20only%20true%20when%20both%20the%20scan%20limit%20was%20hit%20AND%20filtering%20produced%20more%20results%20than%20the%20display%20limit.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix in Cursor" src="https://img.shields.io/badge/Fix_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

5. `apps/web/lib/admin-timezone.ts`, line 1376-1394 ([link](https://github.com/ayushj1001/mindpoint/blob/aa102cee95541f958a8c742b709fc487beb3f577/apps/web/lib/admin-timezone.ts#L1376-L1394)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`formatPlainDateTimeForAdmin` formats in UTC but labels with the selected timezone**

   The formatter always uses `timeZone: "UTC"` when rendering the date and time parts. The `timeZone` parameter is only appended as a display label (e.g., `"• ET"`), not used for the actual conversion. This means the schedule preview in `CourseEditor` will always read the hours/minutes as UTC wall-clock values and then stamp them with "ET" or "IST", producing an output like "May 25, 2026, 3:00 PM • ET" where "3:00 PM" is actually the raw form value treated as UTC — not 3:00 PM in Eastern Time.

   The `convertPlainDateTimeBetweenTimeZones` logic correctly adjusts form values on timezone switch, so the form holds the correct wall-clock display time. However, if there's any case where the conversion hasn't run (e.g., first render with a stored value, or only `startDate` without `startTime`), the label and the rendered value will describe different instants.

   Consider using the `timeZone` parameter in the `Intl.DateTimeFormat` call to actually format the date in the correct timezone, similar to how `formatTimestampInTimeZone` works. If the intent is to display "raw form value + timezone label", that should be documented clearly with a comment to avoid future confusion.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/lib/admin-timezone.ts
   Line: 1376-1394

   Comment:
   **`formatPlainDateTimeForAdmin` formats in UTC but labels with the selected timezone**

   The formatter always uses `timeZone: "UTC"` when rendering the date and time parts. The `timeZone` parameter is only appended as a display label (e.g., `"• ET"`), not used for the actual conversion. This means the schedule preview in `CourseEditor` will always read the hours/minutes as UTC wall-clock values and then stamp them with "ET" or "IST", producing an output like "May 25, 2026, 3:00 PM • ET" where "3:00 PM" is actually the raw form value treated as UTC — not 3:00 PM in Eastern Time.

   The `convertPlainDateTimeBetweenTimeZones` logic correctly adjusts form values on timezone switch, so the form holds the correct wall-clock display time. However, if there's any case where the conversion hasn't run (e.g., first render with a stored value, or only `startDate` without `startTime`), the label and the rendered value will describe different instants.

   Consider using the `timeZone` parameter in the `Intl.DateTimeFormat` call to actually format the date in the correct timezone, similar to how `formatTimestampInTimeZone` works. If the intent is to display "raw form value + timezone label", that should be documented clearly with a comment to avoid future confusion.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Flib%2Fadmin-timezone.ts%0ALine%3A%201376-1394%0A%0AComment%3A%0A**%60formatPlainDateTimeForAdmin%60%20formats%20in%20UTC%20but%20labels%20with%20the%20selected%20timezone**%0A%0AThe%20formatter%20always%20uses%20%60timeZone%3A%20%22UTC%22%60%20when%20rendering%20the%20date%20and%20time%20parts.%20The%20%60timeZone%60%20parameter%20is%20only%20appended%20as%20a%20display%20label%20%28e.g.%2C%20%60%22%E2%80%A2%20ET%22%60%29%2C%20not%20used%20for%20the%20actual%20conversion.%20This%20means%20the%20schedule%20preview%20in%20%60CourseEditor%60%20will%20always%20read%20the%20hours%2Fminutes%20as%20UTC%20wall-clock%20values%20and%20then%20stamp%20them%20with%20%22ET%22%20or%20%22IST%22%2C%20producing%20an%20output%20like%20%22May%2025%2C%202026%2C%203%3A00%20PM%20%E2%80%A2%20ET%22%20where%20%223%3A00%20PM%22%20is%20actually%20the%20raw%20form%20value%20treated%20as%20UTC%20%E2%80%94%20not%203%3A00%20PM%20in%20Eastern%20Time.%0A%0AThe%20%60convertPlainDateTimeBetweenTimeZones%60%20logic%20correctly%20adjusts%20form%20values%20on%20timezone%20switch%2C%20so%20the%20form%20holds%20the%20correct%20wall-clock%20display%20time.%20However%2C%20if%20there's%20any%20case%20where%20the%20conversion%20hasn't%20run%20%28e.g.%2C%20first%20render%20with%20a%20stored%20value%2C%20or%20only%20%60startDate%60%20without%20%60startTime%60%29%2C%20the%20label%20and%20the%20rendered%20value%20will%20describe%20different%20instants.%0A%0AConsider%20using%20the%20%60timeZone%60%20parameter%20in%20the%20%60Intl.DateTimeFormat%60%20call%20to%20actually%20format%20the%20date%20in%20the%20correct%20timezone%2C%20similar%20to%20how%20%60formatTimestampInTimeZone%60%20works.%20If%20the%20intent%20is%20to%20display%20%22raw%20form%20value%20%2B%20timezone%20label%22%2C%20that%20should%20be%20documented%20clearly%20with%20a%20comment%20to%20avoid%20future%20confusion.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Flib%2Fadmin-timezone.ts%0ALine%3A%201376-1394%0A%0AComment%3A%0A**%60formatPlainDateTimeForAdmin%60%20formats%20in%20UTC%20but%20labels%20with%20the%20selected%20timezone**%0A%0AThe%20formatter%20always%20uses%20%60timeZone%3A%20%22UTC%22%60%20when%20rendering%20the%20date%20and%20time%20parts.%20The%20%60timeZone%60%20parameter%20is%20only%20appended%20as%20a%20display%20label%20%28e.g.%2C%20%60%22%E2%80%A2%20ET%22%60%29%2C%20not%20used%20for%20the%20actual%20conversion.%20This%20means%20the%20schedule%20preview%20in%20%60CourseEditor%60%20will%20always%20read%20the%20hours%2Fminutes%20as%20UTC%20wall-clock%20values%20and%20then%20stamp%20them%20with%20%22ET%22%20or%20%22IST%22%2C%20producing%20an%20output%20like%20%22May%2025%2C%202026%2C%203%3A00%20PM%20%E2%80%A2%20ET%22%20where%20%223%3A00%20PM%22%20is%20actually%20the%20raw%20form%20value%20treated%20as%20UTC%20%E2%80%94%20not%203%3A00%20PM%20in%20Eastern%20Time.%0A%0AThe%20%60convertPlainDateTimeBetweenTimeZones%60%20logic%20correctly%20adjusts%20form%20values%20on%20timezone%20switch%2C%20so%20the%20form%20holds%20the%20correct%20wall-clock%20display%20time.%20However%2C%20if%20there's%20any%20case%20where%20the%20conversion%20hasn't%20run%20%28e.g.%2C%20first%20render%20with%20a%20stored%20value%2C%20or%20only%20%60startDate%60%20without%20%60startTime%60%29%2C%20the%20label%20and%20the%20rendered%20value%20will%20describe%20different%20instants.%0A%0AConsider%20using%20the%20%60timeZone%60%20parameter%20in%20the%20%60Intl.DateTimeFormat%60%20call%20to%20actually%20format%20the%20date%20in%20the%20correct%20timezone%2C%20similar%20to%20how%20%60formatTimestampInTimeZone%60%20works.%20If%20the%20intent%20is%20to%20display%20%22raw%20form%20value%20%2B%20timezone%20label%22%2C%20that%20should%20be%20documented%20clearly%20with%20a%20comment%20to%20avoid%20future%20confusion.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Flib%2Fadmin-timezone.ts%0ALine%3A%201376-1394%0A%0AComment%3A%0A**%60formatPlainDateTimeForAdmin%60%20formats%20in%20UTC%20but%20labels%20with%20the%20selected%20timezone**%0A%0AThe%20formatter%20always%20uses%20%60timeZone%3A%20%22UTC%22%60%20when%20rendering%20the%20date%20and%20time%20parts.%20The%20%60timeZone%60%20parameter%20is%20only%20appended%20as%20a%20display%20label%20%28e.g.%2C%20%60%22%E2%80%A2%20ET%22%60%29%2C%20not%20used%20for%20the%20actual%20conversion.%20This%20means%20the%20schedule%20preview%20in%20%60CourseEditor%60%20will%20always%20read%20the%20hours%2Fminutes%20as%20UTC%20wall-clock%20values%20and%20then%20stamp%20them%20with%20%22ET%22%20or%20%22IST%22%2C%20producing%20an%20output%20like%20%22May%2025%2C%202026%2C%203%3A00%20PM%20%E2%80%A2%20ET%22%20where%20%223%3A00%20PM%22%20is%20actually%20the%20raw%20form%20value%20treated%20as%20UTC%20%E2%80%94%20not%203%3A00%20PM%20in%20Eastern%20Time.%0A%0AThe%20%60convertPlainDateTimeBetweenTimeZones%60%20logic%20correctly%20adjusts%20form%20values%20on%20timezone%20switch%2C%20so%20the%20form%20holds%20the%20correct%20wall-clock%20display%20time.%20However%2C%20if%20there's%20any%20case%20where%20the%20conversion%20hasn't%20run%20%28e.g.%2C%20first%20render%20with%20a%20stored%20value%2C%20or%20only%20%60startDate%60%20without%20%60startTime%60%29%2C%20the%20label%20and%20the%20rendered%20value%20will%20describe%20different%20instants.%0A%0AConsider%20using%20the%20%60timeZone%60%20parameter%20in%20the%20%60Intl.DateTimeFormat%60%20call%20to%20actually%20format%20the%20date%20in%20the%20correct%20timezone%2C%20similar%20to%20how%20%60formatTimestampInTimeZone%60%20works.%20If%20the%20intent%20is%20to%20display%20%22raw%20form%20value%20%2B%20timezone%20label%22%2C%20that%20should%20be%20documented%20clearly%20with%20a%20comment%20to%20avoid%20future%20confusion.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix in Cursor" src="https://img.shields.io/badge/Fix_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

6. `convex/adminReviews.ts`, line 1821-1832 ([link](https://github.com/ayushj1001/mindpoint/blob/aa102cee95541f958a8c742b709fc487beb3f577/convex/adminReviews.ts#L1821-L1832)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Course reference sync on `updateReview` may leave stale references if the target course doesn't exist**

   When a review's course is changed, `syncCourseReviewReference` with `action: "remove"` is called on the old course and `action: "add"` on the new one. However, `syncCourseReviewReference` silently returns early if the course document is not found (`if (!course) return;`).

   The new course is already validated to exist (lines above this block), so the `add` is safe. But if the old course was somehow deleted between the review's creation and this update, the remove silently does nothing. This is acceptable behavior, but it means the old course's `reviews` array can accumulate stale IDs that are never cleaned up. A log or audit trail here would help catch data integrity drift.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: convex/adminReviews.ts
   Line: 1821-1832

   Comment:
   **Course reference sync on `updateReview` may leave stale references if the target course doesn't exist**

   When a review's course is changed, `syncCourseReviewReference` with `action: "remove"` is called on the old course and `action: "add"` on the new one. However, `syncCourseReviewReference` silently returns early if the course document is not found (`if (!course) return;`).

   The new course is already validated to exist (lines above this block), so the `add` is safe. But if the old course was somehow deleted between the review's creation and this update, the remove silently does nothing. This is acceptable behavior, but it means the old course's `reviews` array can accumulate stale IDs that are never cleaned up. A log or audit trail here would help catch data integrity drift.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201821-1832%0A%0AComment%3A%0A**Course%20reference%20sync%20on%20%60updateReview%60%20may%20leave%20stale%20references%20if%20the%20target%20course%20doesn't%20exist**%0A%0AWhen%20a%20review's%20course%20is%20changed%2C%20%60syncCourseReviewReference%60%20with%20%60action%3A%20%22remove%22%60%20is%20called%20on%20the%20old%20course%20and%20%60action%3A%20%22add%22%60%20on%20the%20new%20one.%20However%2C%20%60syncCourseReviewReference%60%20silently%20returns%20early%20if%20the%20course%20document%20is%20not%20found%20%28%60if%20%28!course%29%20return%3B%60%29.%0A%0AThe%20new%20course%20is%20already%20validated%20to%20exist%20%28lines%20above%20this%20block%29%2C%20so%20the%20%60add%60%20is%20safe.%20But%20if%20the%20old%20course%20was%20somehow%20deleted%20between%20the%20review's%20creation%20and%20this%20update%2C%20the%20remove%20silently%20does%20nothing.%20This%20is%20acceptable%20behavior%2C%20but%20it%20means%20the%20old%20course's%20%60reviews%60%20array%20can%20accumulate%20stale%20IDs%20that%20are%20never%20cleaned%20up.%20A%20log%20or%20audit%20trail%20here%20would%20help%20catch%20data%20integrity%20drift.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201821-1832%0A%0AComment%3A%0A**Course%20reference%20sync%20on%20%60updateReview%60%20may%20leave%20stale%20references%20if%20the%20target%20course%20doesn't%20exist**%0A%0AWhen%20a%20review's%20course%20is%20changed%2C%20%60syncCourseReviewReference%60%20with%20%60action%3A%20%22remove%22%60%20is%20called%20on%20the%20old%20course%20and%20%60action%3A%20%22add%22%60%20on%20the%20new%20one.%20However%2C%20%60syncCourseReviewReference%60%20silently%20returns%20early%20if%20the%20course%20document%20is%20not%20found%20%28%60if%20%28!course%29%20return%3B%60%29.%0A%0AThe%20new%20course%20is%20already%20validated%20to%20exist%20%28lines%20above%20this%20block%29%2C%20so%20the%20%60add%60%20is%20safe.%20But%20if%20the%20old%20course%20was%20somehow%20deleted%20between%20the%20review's%20creation%20and%20this%20update%2C%20the%20remove%20silently%20does%20nothing.%20This%20is%20acceptable%20behavior%2C%20but%20it%20means%20the%20old%20course's%20%60reviews%60%20array%20can%20accumulate%20stale%20IDs%20that%20are%20never%20cleaned%20up.%20A%20log%20or%20audit%20trail%20here%20would%20help%20catch%20data%20integrity%20drift.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminReviews.ts%0ALine%3A%201821-1832%0A%0AComment%3A%0A**Course%20reference%20sync%20on%20%60updateReview%60%20may%20leave%20stale%20references%20if%20the%20target%20course%20doesn't%20exist**%0A%0AWhen%20a%20review's%20course%20is%20changed%2C%20%60syncCourseReviewReference%60%20with%20%60action%3A%20%22remove%22%60%20is%20called%20on%20the%20old%20course%20and%20%60action%3A%20%22add%22%60%20on%20the%20new%20one.%20However%2C%20%60syncCourseReviewReference%60%20silently%20returns%20early%20if%20the%20course%20document%20is%20not%20found%20%28%60if%20%28!course%29%20return%3B%60%29.%0A%0AThe%20new%20course%20is%20already%20validated%20to%20exist%20%28lines%20above%20this%20block%29%2C%20so%20the%20%60add%60%20is%20safe.%20But%20if%20the%20old%20course%20was%20somehow%20deleted%20between%20the%20review's%20creation%20and%20this%20update%2C%20the%20remove%20silently%20does%20nothing.%20This%20is%20acceptable%20behavior%2C%20but%20it%20means%20the%20old%20course's%20%60reviews%60%20array%20can%20accumulate%20stale%20IDs%20that%20are%20never%20cleaned%20up.%20A%20log%20or%20audit%20trail%20here%20would%20help%20catch%20data%20integrity%20drift.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix in Cursor" src="https://img.shields.io/badge/Fix_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

7. `convex/adminReviews.ts`, line 1716 ([link](https://github.com/ayushj1001/mindpoint/blob/c90b93c041cd97bd8fc2e91494cbfedf41e8f5c7/convex/adminReviews.ts#L1716)) 

   **`hasMore` flag gives false negatives when scan limit is hit**

   `hasMore` is computed as `hitScanLimit && rows.length > limitedRows.length`. This means `hasMore` is `false` whenever the filtered results fit within the display limit — even if the DB scan was cut short.

   Consider the scenario: scan 2,500 documents (hit `scanLimit`), search for "foo" → only 50 rows match after filtering. `rows.length = 50`, `limitedRows.length = 50`. `hasMore = true && (50 > 50) = false` — but there could be thousands of unscanned documents that contain "foo".

   The banner on the UI is only shown when `hasMore` is true, so users get no warning about a potentially incomplete result set.

   The correct condition is simply:

   This way, whenever the DB scan was cut short — regardless of whether filtered results fill the display limit — the user is warned to narrow their search.

8. `apps/web/app/admin/reviews/page.tsx`, line 338-342 ([link](https://github.com/ayushj1001/mindpoint/blob/c90b93c041cd97bd8fc2e91494cbfedf41e8f5c7/apps/web/app/admin/reviews/page.tsx#L338-L342)) 

   **Unsafe string-to-`Id<"courses">` cast for `selectedCourseId`**

   `selectedCourseId` is typed as a plain `string` (initialized from `searchParams.get("courseId") ?? "all"` or a `<select>` `value`). It is then cast to `Id<"courses">` with `selectedCourseId as Id<"courses">`. If a caller ever constructs a URL with an arbitrary `?courseId=` value, this bypass reaches the Convex query and will cause a runtime error.

   The same unsound cast exists for `formState.courseId` at the `handleSave` call site.

   A safer pattern is to validate the value before using it:

   ```ts
   // For the query arg:
   courseId:
     selectedCourseId !== "all"
       ? (selectedCourseId as Id<"courses">)  // ← unsafe
       : undefined,
   ```

   Consider storing `selectedCourseId` as `Id<"courses"> | "all"` from the start, initializing it with an explicit validation step, or at minimum guarding with a runtime check before the cast.

9. `apps/web/app/admin/reviews/page.tsx`, line 395-408 ([link](https://github.com/ayushj1001/mindpoint/blob/c90b93c041cd97bd8fc2e91494cbfedf41e8f5c7/apps/web/app/admin/reviews/page.tsx#L395-L408)) 

   **Rating bounds not validated client-side**

   `handleSave` validates that `courseId`, `userName`, and `content` are present, but doesn't check that the numeric rating is within the valid 0.5–5 range. Two problematic edge cases:

   1. The user clears the rating field → `Number("") === 0` → server silently clamps to `0.5` without a targeted error toast.
   2. The user types an out-of-range value (e.g. `6`) → same silent server clamp.

   Consider adding a guard before the `try` block:

   ```ts
   if (!Number.isFinite(numericRating) || numericRating < 0.5 || numericRating > 5) {
     toast.error("Rating must be between 0.5 and 5");
     return;
   }
   ```

10. `apps/web/components/admin/AdminTimeZoneProvider.tsx`, line 1000 ([link](https://github.com/ayushj1001/mindpoint/blob/c90b93c041cd97bd8fc2e91494cbfedf41e8f5c7/apps/web/components/admin/AdminTimeZoneProvider.tsx#L1000)) 

    **`formatDate` in context ignores the selected time zone**

    `formatDate` is exposed through `AdminTimeZoneContext` as a timezone-aware helper, but its implementation always formats dates in UTC:

    ```ts
    formatDate: (input) => formatPlainDateForAdmin(input),
    // ↑ formatPlainDateForAdmin hardcodes timeZone: "UTC"
    ```

    For plain-date fields (course start/end stored as `YYYY-MM-DD`), using UTC is intentional to avoid day-boundary shifts, but this makes `formatDate` effectively a timezone-independent function despite being in the timezone context. Consumers (e.g. `CourseEditor`, `offers/page.tsx`) pass it to `formatDateWindow` which labels the result with the current timezone label, creating a subtle inconsistency — the date was formatted in UTC, but the label suggests it was formatted in, say, IST.

    Consider either documenting that `formatDate` is always UTC, or renaming it to `formatPlainDate` to signal its timezone-agnostic behavior.

11. `apps/web/app/admin/reviews/page.tsx`, line 157 ([link](https://github.com/ayushj1001/mindpoint/blob/91277a9b66b08273b8a7630e8a26a415a2e30fc5/apps/web/app/admin/reviews/page.tsx#L157)) 

    **Potential TypeError when `userId` is `undefined` on legacy reviews**

    `review.userId.startsWith("admin-managed:")` will throw a `TypeError` if `userId` is `undefined`. The null guard in `adminReviews.ts` (line 119) — `filter((part): part is string => typeof part === "string")` applied to `[row.userName, row.userId, row.content]` — is strong evidence that `userId` can be absent in existing review documents. The local `ReviewRow` type declares `userId: string` (non-optional), but the cast `as ReviewsResponse` on line 117 silently hides any mismatch with the actual Convex schema.

    If an admin opens the edit dialog for an older review that has no `userId`, this line will crash.

12. `convex/courses.ts`, line 169-174 ([link](https://github.com/ayushj1001/mindpoint/blob/91277a9b66b08273b8a7630e8a26a415a2e30fc5/convex/courses.ts#L169-L174)) 

    **Unsafe string-to-ID round-trip type assertion**

    The code converts `Id<"reviews">` values to plain strings for `Set`-based deduplication, then maps them back with `id as Id<"reviews">`. While the values are unchanged at runtime, the `as` cast bypasses Convex's type system. Convex validates ID references against the schema, and if a string that isn't a true Convex ID slips in here (e.g., from a future code path), it will produce a hard-to-diagnose runtime error.

    A safer approach is to keep the IDs in their native type and deduplicate by converting to string only for the `Set` key:

    ```ts
    const existingIdStrings = new Set(
      (course.reviews ?? []).map((id) => String(id)),
    );
    if (!existingIdStrings.has(String(reviewId))) {
      await ctx.db.patch(args.courseId, {
        reviews: [...(course.reviews ?? []), reviewId],
      });
    }
    ```

    This avoids the round-trip and keeps the `reviews` array populated with properly-typed `Id<"reviews">` values.

13. `apps/web/app/admin/reviews/page.tsx`, line 111-117 ([link](https://github.com/ayushj1001/mindpoint/blob/91277a9b66b08273b8a7630e8a26a415a2e30fc5/apps/web/app/admin/reviews/page.tsx#L111-L117)) 

    **`as ReviewsResponse` cast hides potential type mismatch**

    The `useQuery` result is cast to `ReviewsResponse | undefined`. If the actual Convex-generated return type for `listReviews` has `userId` as optional (matching the `v.optional(v.string())` schema used for the `userId` arg in `createReview`), this cast silently suppresses the type error on line 157 where `review.userId.startsWith(...)` is called without a null check.

    Consider either:
    - Removing the cast and using the Convex-generated types directly, or
    - Updating `ReviewRow.userId` to `string | undefined` and adding defensive guards wherever `userId` is accessed as a string method receiver.

14. `convex/adminReviews.ts`, line 158 ([link](https://github.com/ayushj1001/mindpoint/blob/bf210d99dc6c7726e6faeff0778a1a42c80ac804/convex/adminReviews.ts#L158)) 

    **`hasMore` computed from pre-filter scan, producing false positives**

    `hitScanLimit` is recorded on line 108 from the raw `.take(scanLimit)` result — before the rating filter (line 111) and the search filter (lines 116–140) are applied. `hasMore` is then set directly from this pre-filter flag on line 158.

    This means the amber "Showing the first 500 reviews…" banner fires in the frontend whenever the *total* review count exceeds `scanLimit`, even when the *filtered* match set is tiny and every matching record is already visible. For example: 3 000 reviews exist, a search term matches only 2 of them → the scan hits `scanLimit = 2 500`, so `hitScanLimit = true`, so `hasMore = true` — but both matching rows are already returned.

    The fix is to compute `hasMore` after filtering, taking the limit into account:

    

    `rows.length >= limit` (checked *after* filtering) means the filtered result set is large enough that the scan truncation is actually relevant. When the filtered set is smaller than `limit`, all matching results are visible regardless of whether the raw scan was truncated.

15. `apps/web/components/admin/CourseEditor.tsx`, line 289-326 ([link](https://github.com/ayushj1001/mindpoint/blob/bf210d99dc6c7726e6faeff0778a1a42c80ac804/apps/web/components/admin/CourseEditor.tsx#L289-L326)) 

    **Timezone hydration triggers incorrect schedule-date conversion**

    `previousTimeZoneRef` is initialised with the context value at the time `CourseEditor` mounts — which is always `"America/New_York"` (the hard-coded `useState` default in `AdminTimeZoneProvider`). `AdminTimeZoneProvider`'s `useEffect` then reads from `localStorage` and updates the timezone (e.g., to `"Asia/Kolkata"`). This change propagates to `CourseEditor`'s conversion `useEffect`:

    - `previousTimeZone` = `"America/New_York"` (the transient default)
    - `timeZone` = `"Asia/Kolkata"` (the user's stored preference)

    If Convex returns cached course data instantly, the form is already initialised with the course's stored wall-clock values before this effect runs. Those values are then shifted as if they were Eastern Time, corrupting the schedule dates shown in the editor.

    The root cause is that `previousTimeZoneRef` does not reflect the timezone that was active when the stored schedule values were last edited; it only reflects the transient SSR default.

    A targeted fix is to skip the conversion on the initial provider hydration by exposing an `isHydrated` flag from the provider:

    ```ts
    // In AdminTimeZoneProvider
    const [isHydrated, setIsHydrated] = useState(false);
    useEffect(() => {
      const stored = window.localStorage.getItem(ADMIN_TIME_ZONE_STORAGE_KEY);
      setTimeZoneState(stored && isSupportedAdminTimeZone(stored) ? stored : resolveDefaultAdminTimeZone());
      setIsHydrated(true);
    }, []);
    // expose isHydrated in context value

    // In CourseEditor
    useEffect(() => {
      if (!isHydrated) return; // skip initial hydration switch
      ...
    }, [timeZone, isHydrated]);
    ```

    Alternatively, synchronously read `localStorage` into `previousTimeZoneRef` during the same `useEffect` that initialises the form state, so the two states are always in sync.

16. `convex/adminReviews.ts`, line 158 ([link](https://github.com/ayushj1001/mindpoint/blob/2d28a1380d9fe7a27cf38af1a2a5663fac712abf/convex/adminReviews.ts#L158)) 

    **`hasMore` flag can suppress the warning when it should appear**

    The condition `hitScanLimit && rows.length >= limit` means that when the database scan hits the cap (`hitScanLimit = true`) but the rating/search filters reduce the matching set below `limit`, `hasMore` becomes `false` and the amber warning banner is hidden. This falsely implies the admin is seeing a complete result set, even though there may be additional matching documents beyond the scan window that were never fetched.

    For example, with `scanLimit = 2500` and `limit = 500`:
    - Database returns 2500 rows → `hitScanLimit = true`
    - Rating filter keeps only 420 rows → `rows.length = 420`
    - `hasMore = true && (420 >= 500) = false` ← incorrect, more matches may exist past row 2500

    The warning should appear whenever the scan was truncated, regardless of how many filtered results came back:

17. `convex/adminReviews.ts`, line 8-21 ([link](https://github.com/ayushj1001/mindpoint/blob/2d28a1380d9fe7a27cf38af1a2a5663fac712abf/convex/adminReviews.ts#L8-L21)) 

    **Rating range inconsistency with public `createReview`**

    `normalizeRating` clamps to `[0.5, 5]` using half-integer steps, but the public-facing mutation in `courses.ts` enforces **integer** ratings in `[1, 5]` via `Math.max(1, Math.min(5, Math.round(args.rating)))`. This means admin-created reviews can have a `0.5` rating, which:

    1. Appears on the public course page via `courses.listReviewsForCourse` (no filter excludes admin-managed reviews).
    2. Could break any star-rating UI that assumes integer values between 1 and 5.

    The admin UI already validates `numericRating < 0.5`, which matches `normalizeRating`, so the minimum was intentionally lowered for admins. If half-integer ratings down to 0.5 are a valid product requirement, the public mutation and all display components should be updated to handle them. If the intent is to match the public schema, change the clamp minimum here:

    ```ts
    const clamped = Math.max(1, Math.min(5, rounded));
    ```

18. `convex/courses.ts`, line 156-171 ([link](https://github.com/ayushj1001/mindpoint/blob/4917ae739b0ffd0b4c34b510c5daeaaf956af145/convex/courses.ts#L156-L171)) 

    **Silent behavior change in public rating normalization**

    The old normalization in the public `createReview` and `updateReview` mutations was:
    ```ts
    const rating = Math.max(1, Math.min(5, Math.round(args.rating)));
    ```
    This produced **integer** ratings in the range **1–5**.

    The new `normalizeReviewRating` produces **0.5-step** ratings in the range **0.5–5**:
    ```ts
    const rounded = Math.round(value * 2) / 2;
    return Math.max(0.5, Math.min(5, rounded));
    ```

    There are two concrete breaking changes for callers of these public mutations:
    1. **Minimum rating changed from `1` to `0.5`** — any value below `1` that previously rounded up to `1` will now produce `0.5`.
    2. **Rounding granularity changed from integers to half-integers** — e.g., `1.7` previously became `2`, but now becomes `1.5`.

    If the user-facing review UI still only renders or submits integer star ratings, a mismatch will accumulate in the database between admin-created reviews (which intentionally use 0.5 steps) and user-created reviews (which would now sometimes also have 0.5 steps unintentionally). Consider keeping a separate normalization function for the public mutations, or explicitly documenting that the public API now also supports 0.5-step ratings.

19. `convex/adminReviews.ts`, line 2026-2037 ([link](https://github.com/ayushj1001/mindpoint/blob/4917ae739b0ffd0b4c34b510c5daeaaf956af145/convex/adminReviews.ts#L2026-L2037)) 

    **Misleading `previousCourseReferenceRemoved` in audit log when course is unchanged**

    `previousCourseReferenceRemoved` is initialized to `true` and only re-assigned when the course actually changes. When a review is updated without changing its course (the common case), the block inside `if (String(existing.course) !== String(args.courseId))` is skipped, so `previousCourseReferenceRemoved` stays as `true` and is written to the audit log — implying a removal occurred when none did.

    Consider using a more semantically accurate initial value (e.g., `null` or `"not-applicable"`) to distinguish "no removal needed" from "removal succeeded":

    ```ts
    let previousCourseReferenceRemoved: boolean | null = null;
    if (String(existing.course) !== String(args.courseId)) {
      previousCourseReferenceRemoved = await syncCourseReviewReference(ctx, {
        courseId: existing.course,
        reviewId: args.reviewId,
        action: "remove",
      });
      await syncCourseReviewReference(ctx, {
        courseId: args.courseId,
        reviewId: args.reviewId,
        action: "add",
      });
    }
    ```

20. `convex/courses.ts`, line 181-189 ([link](https://github.com/ayushj1001/mindpoint/blob/4917ae739b0ffd0b4c34b510c5daeaaf956af145/convex/courses.ts#L181-L189)) 

    **Dead code — `existingIdStrings.has(reviewId)` is always `false`**

    `course` is fetched from the database _before_ `ctx.db.insert("reviews", review)` is called, so `course.reviews` can never contain the just-inserted `reviewId`. The condition `!existingIdStrings.has(String(reviewId))` is always `true`, and the surrounding `if` guard is effectively unreachable dead code that adds noise without protection.

21. `apps/web/components/admin/CourseEditor.tsx`, line 709-713 ([link](https://github.com/ayushj1001/mindpoint/blob/3f869ed19526363abb13fa6c8092df31891ba523/apps/web/components/admin/CourseEditor.tsx#L709-L713)) 

    **Empty-content warning never fires on initial publish**

    `state.lifecycleStatus` reflects the **current** DB state at the time this block runs — before the `transition` mutation executes. When an admin publishes a *draft* for the first time, `state.lifecycleStatus` is `"draft"`, so the condition `state.lifecycleStatus === "published"` is `false` and the warning is silently skipped. The guard only activates when *re-saving* an already-published course with empty content — the exact scenario where the editor is not switching lifecycle states at all.

    To actually warn on the initial publish action, remove the lifecycle guard:

22. `apps/web/app/admin/reviews/page.tsx`, line 504-509 ([link](https://github.com/ayushj1001/mindpoint/blob/5f6dc0184b4fac4a2b0a4810d8709924850d45c0/apps/web/app/admin/reviews/page.tsx#L504-L509)) 

    **Banner text hardcoded to "500" regardless of actual displayed count**

    `hasMore` is `true` whenever the DB scan hit `scanLimit` (up to 2500 rows scanned), not when 500 results are shown. If the rating or search filter reduces the visible rows to, say, 12, the banner still reads _"Showing the first 500 reviews from the current scan"_ — which is factually wrong and confusing to the admin.

    Consider making the count dynamic:

23. `apps/web/lib/admin-timezone.ts`, line 137-161 ([link](https://github.com/ayushj1001/mindpoint/blob/5f6dc0184b4fac4a2b0a4810d8709924850d45c0/apps/web/lib/admin-timezone.ts#L137-L161)) 

    **`timeZone` parameter only appends a label — it does not affect date formatting**

    The function signature implies that `timeZone` drives the timezone used when rendering the datetime, but it is actually ignored during formatting (which always uses `"UTC"` to preserve the wall-clock value). `timeZone` only adds a short suffix like `• ET`.

    A caller that later passes a fresh timezone here expecting the displayed time to shift will get silently incorrect output. Consider renaming the parameter to `timeZoneLabel` (and accepting a pre-computed label string rather than the zone identifier) to make the one-sided contract explicit:

    ```ts
    export function formatPlainDateTimeForAdmin(
      dateValue?: string,
      timeValue?: string,
      timeZoneLabel?: string,   // rename: only used for the "• ET" suffix
    ): string | null {
    ```

    This makes it immediately obvious that the function does not convert the time — it only stamps the label that was already chosen by the caller.

24. `convex/adminReviews.ts`, line 127-130 ([link](https://github.com/ayushj1001/mindpoint/blob/2bc83e92eba3dee339d16e6005cdef1eaa4b37a7/convex/adminReviews.ts#L127-L130)) 

    **`hasMore` flag misses post-filter overflow case**

    `hitScanLimit` only tracks whether the _initial scan_ hit its cap. But if the scan returns fewer than `scanLimit` rows, yet after rating/search filtering the matching rows still exceed `limit`, those extra matches are silently dropped and `hasMore` remains `false`.

    Concrete example: `scanLimit = 1500`, 1200 rows fetched (`hitScanLimit = false`), 700 rows survive the search filter, `limit = 500` → 200 matching reviews are silently discarded with no warning shown to the admin.

25. `apps/web/app/admin/reviews/page.tsx`, line 110-125 ([link](https://github.com/ayushj1001/mindpoint/blob/2bc83e92eba3dee339d16e6005cdef1eaa4b37a7/apps/web/app/admin/reviews/page.tsx#L110-L125)) 

    **Preselected `courseId` filter silently drops to "all courses" until the course list loads**

    `selectedCourseIdValue` is gated on `knownCourseIds.has(selectedCourseId)`. On first render, `courses` is `undefined` and `knownCourseIds` is an empty `Set`, so `selectedCourseIdValue` is always `undefined` — even when `?courseId=<id>` is present in the URL. This causes the initial `listReviews` query to run without any course filter, loading the full review list, and then re-running once the courses query resolves with the correct filter applied.

    Beyond the unnecessary extra query, if an admin navigates from the course detail "Manage Reviews" link, they will briefly see all reviews before the correct course filter is applied, which is confusing.

    Consider passing the `courseId` query param directly to the query without waiting for the course list to validate it — Convex will return an empty result if the ID is invalid anyway. Alternatively, keep the current guard but show a "Loading…" state instead of firing the unfiltered query:

    ```ts
    const selectedCourseIdValue =
      courses === undefined
        ? undefined // still loading — hold the query
        : selectedCourseId !== "all" && knownCourseIds.has(selectedCourseId)
          ? (selectedCourseId as Id<"courses">)
          : undefined;

    // Pass `skip` to useQuery while courses are loading to avoid the unfiltered fetch:
    const reviewsResult = useQuery(
      api.adminReviews.listReviews,
      courses === undefined
        ? "skip"
        : { search: search || undefined, courseId: selectedCourseIdValue, ... },
    ) as ReviewsResponse | undefined;
    ```

26. `apps/web/app/admin/reviews/page.tsx`, line 346-351 ([link](https://github.com/ayushj1001/mindpoint/blob/c5c4481bd29c3189b4d0900f13860cb4fbb9eda8/apps/web/app/admin/reviews/page.tsx#L346-L351)) 

    **Unsafe `as Doc<"courses">[]` cast on `listCourses` result**

    `useQuery(api.adminCourses.listCourses, ...)` already returns a fully-typed value inferred from Convex's type generation. Adding `as Doc<"courses">[] | undefined` bypasses that inference: if the handler ever returns a shape that doesn't match `Doc<"courses">` exactly (e.g., additional computed fields, omitted optional fields), the cast silently hides the mismatch.

    Remove the assertion and let TypeScript infer the return type:

    ```ts
    const courses = useQuery(api.adminCourses.listCourses, {
      limit: 500,
      sortBy: "name",
      sortOrder: "asc",
    });
    ```

    If specific fields (`_id`, `name`, `code`) are all that's needed, narrow to a locally declared type instead of asserting the full document shape.

27. `convex/adminReviews.ts`, line 95-101 ([link](https://github.com/ayushj1001/mindpoint/blob/60ce0b021a9f745412cb93dd32ee11acc9b31869/convex/adminReviews.ts#L95-L101)) 

    **"Oldest" sort never returns truly oldest reviews on large datasets**

    The initial database query always uses `.order("desc")` regardless of `args.sortBy`. When `sortBy` is `"oldest"` on a dataset larger than `scanLimit` (max 2500), the query fetches the 2500 **most recent** documents. The in-memory `.sort()` on line 139 then re-orders those 2500 records oldest-first — but the truly oldest documents (positions 2501+) are never retrieved and can never appear in the result.

    An admin using the "Oldest first" sort would expect to see the oldest reviews in the system. Instead they see the oldest reviews within the most-recent scan window.

    To correctly serve an "oldest" sort, the initial Convex query should use `.order("asc")` when `sortBy === "oldest"`:
    ```ts
    let rows = args.courseId
      ? await ctx.db
          .query("reviews")
          .withIndex("by_course", (q) => q.eq("course", args.courseId!))
          .order(args.sortBy === "oldest" ? "asc" : "desc")
          .take(scanLimit)
      : await ctx.db
          .query("reviews")
          .order(args.sortBy === "oldest" ? "asc" : "desc")
          .take(scanLimit);
    ```

    Note that if the sort order changes, the `hitScanLimit` flag still correctly signals whether additional results may exist.

28. `apps/web/app/admin/reviews/page.tsx`, line 285-297 ([link](https://github.com/ayushj1001/mindpoint/blob/60ce0b021a9f745412cb93dd32ee11acc9b31869/apps/web/app/admin/reviews/page.tsx#L285-L297)) 

    **"Average Rating" misleads when result set is truncated without user filters**

    `hasActiveFilters` only checks for explicit user-applied filters (search text, course selection, rating filter). However, `hasMore` can be `true` due to the backend scan-limit truncation even when no user filter is active — e.g., if the database has 3000 reviews, only 500 are returned and the label still reads "Average Rating" as if it reflects the global average.

    The stat card label should also account for the truncation case:

    ```tsx
    <CardTitle className="text-sm text-slate-600">
      {hasActiveFilters || hasMore ? "Average (visible)" : "Average Rating"}
    </CardTitle>
    ```

    Without this, admins could be misled into treating a partial average as a global KPI.

29. `convex/adminReviews.ts`, line 152 ([link](https://github.com/ayushj1001/mindpoint/blob/60ce0b021a9f745412cb93dd32ee11acc9b31869/convex/adminReviews.ts#L152)) 

    **`hasMore` is inflated when rating/search filters reduce the result below the limit**

    `hitScanLimit` is captured before the rating filter and search filter are applied:
    ```ts
    const hitScanLimit = rows.length === scanLimit;  // line 102 — pre-filter
    // ... rating filter and search filter applied to rows ...
    const hasMore = hitScanLimit || rows.length > limit;  // line 152
    ```

    If 2500 documents are scanned (so `hitScanLimit = true`) but the applied filters reduce the final result set to, say, 3 reviews, `hasMore` is still `true`. The UI will show the amber warning banner telling the admin to "narrow filters for a complete result set" — even though all matching documents ARE visible.

    Consider capturing `hitScanLimit` only when the filtered result reaches the limit, or documenting this as a known conservative false-positive so future readers understand the intent:
    ```ts
    // Conservative: hitScanLimit may produce false-positive hasMore when filters
    // aggressively narrow the scanned set.
    const hasMore = hitScanLimit || rows.length > limit;
    ```

    At minimum, add a comment explaining the intentional trade-off so this isn't silently "fixed" in a way that reintroduces the silent-truncation issue.

30. `apps/web/lib/admin-timezone.ts`, line 80-90 ([link](https://github.com/ayushj1001/mindpoint/blob/60ce0b021a9f745412cb93dd32ee11acc9b31869/apps/web/lib/admin-timezone.ts#L80-L90)) 

    **`parsePlainDate` silently accepts partially invalid date strings**

    `dateValue.split("-").map(Number)` will destructure as many segments as are present. If `dateValue` is `"2024"` (year only) or `"2024-13"` (invalid month), only `year` (or `year` + `month`) will be defined; the remaining variables will be `undefined`. `Number(undefined)` is `NaN`, which passes `Number.isFinite(NaN)` as `false`, so `null` is returned — that part is correct.

    However, a value like `"2024-00-01"` (month `0`) or `"2024-01-00"` (day `0`) will pass the `isFinite` checks but produce semantically wrong dates via `Date.UTC` (month `0` = January, day `0` = previous month's last day). These are unlikely in practice since inputs come from `<input type="date">`, but if the field is ever edited programmatically or arrives from backend data, the silent wrong-date result could be confusing.

    Consider adding range checks:
    ```ts
    if (month < 1 || month > 12 || day < 1 || day > 31) {
      return null;
    }
    ```

31. `convex/courses.ts`, line 176-180 ([link](https://github.com/ayushj1001/mindpoint/blob/06fa306d0873a1597cf05bd2262108c5eb56e849/convex/courses.ts#L176-L180)) 

    **Data inconsistency for pre-existing reviews**

    `createReview` now populates `course.reviews` for new reviews, but all reviews that existed _before_ this PR were inserted when the patch call was intentionally commented out. Those older documents will never have their IDs in `course.reviews`.

    If any public-facing query (e.g., `pickPublicCourse`, a public `getCourse` endpoint) reads `course.reviews` to enumerate or display reviews, every review created before this PR becomes invisible — ratings won't count toward display stars, review text won't appear on the course page, etc. Only the new admin `deleteCourse` guard was updated to use the `by_course` index directly; other consumers may still rely on the denormalized array.

    Before merging, either:
    1. Run a one-time backfill migration to populate `course.reviews` for every existing review document using the `by_course` index, or
    2. Ensure all remaining consumers query by index (`withIndex("by_course", …)`) so `course.reviews` is only used for future writes.

32. `apps/web/app/admin/reviews/page.tsx`, line 129-141 ([link](https://github.com/ayushj1001/mindpoint/blob/06fa306d0873a1597cf05bd2262108c5eb56e849/apps/web/app/admin/reviews/page.tsx#L129-L141)) 

    **Unsafe `as` cast discards generated return type**

    The Convex `useQuery` hook already infers the return type from the generated API definition, so casting the result with `as ReviewsResponse | undefined` bypasses TypeScript's structural check. If the backend query handler ever changes its shape (e.g., renames `hasMore` → `hasNextPage`, or the `reviews` array element type changes), TypeScript won't catch the mismatch and the component will silently break at runtime.

    Prefer keeping the inferred type and deriving `ReviewRow` from it instead of maintaining a parallel hand-written type:

    ```ts
    import type { FunctionReturnType } from "convex/server";
    import type { api } from "@mindpoint/backend/api";

    type ReviewsResponse = NonNullable<
      FunctionReturnType<typeof api.adminReviews.listReviews>
    >;
    type ReviewRow = ReviewsResponse["reviews"][number];
    ```

    This ensures `ReviewRow` and `ReviewsResponse` stay in sync with the backend automatically.

33. `convex/adminReviews.ts`, line 121-135 ([link](https://github.com/ayushj1001/mindpoint/blob/06fa306d0873a1597cf05bd2262108c5eb56e849/convex/adminReviews.ts#L121-L135)) 

    **Redundant in-memory sort for "newest" and "oldest" modes**

    The initial query already uses `queryOrder` (`"asc"` for "oldest", `"desc"` for everything else), so the `rows` array coming back from `take(scanLimit)` is already in the correct order. The `switch` block then re-sorts those same rows with an identical comparator, duplicating work on up to 2 500 items for no benefit.

    The in-memory sort is only genuinely needed for the `"rating"` case (since the DB scan is by creation time, not rating). The other two branches can be removed:

    ```ts
    if (args.sortBy === "rating") {
      rows.sort(
        (a, b) => b.rating - a.rating || b._creationTime - a._creationTime,
      );
    }
    // "newest" and "oldest" are already correct from the index scan order
    ```

34. `convex/courses.ts`, line 158-164 ([link](https://github.com/ayushj1001/mindpoint/blob/06fa306d0873a1597cf05bd2262108c5eb56e849/convex/courses.ts#L158-L164)) 

    **Public `createReview` allows multiple reviews per user per course**

    The mutation now actively tracks reviews in `course.reviews`, yet there is still no guard against a single user submitting more than one review for the same course. The previous implementation had the patch commented out, so duplicate reviews were harmless (they just didn't surface anywhere). Now that `course.reviews` is maintained and presumably drives public display, two reviews from the same user on the same course will both appear.

    Add a duplicate check before inserting:

    ```ts
    const identity = await ctx.auth.getUserIdentity();
    if (identity) {
      const existing = await ctx.db
        .query("reviews")
        .withIndex("by_course", (q) => q.eq("course", args.courseId))
        .filter((q) => q.eq(q.field("userId"), identity.subject))
        .first();

      if (existing) {
        throw new Error("You have already reviewed this course");
      }
    }
    ```

    (Adjust the index/field names to match your schema if different.)

35. `apps/web/app/admin/reviews/page.tsx`, line 364-368 ([link](https://github.com/ayushj1001/mindpoint/blob/5f6dc0184b4fac4a2b0a4810d8709924850d45c0/apps/web/app/admin/reviews/page.tsx#L364-L368)) 

    **Banner text hardcodes "500" regardless of visible row count**

    `hasMore` is set to `hitScanLimit`, which is determined *before* rating/search filtering. When the scan hits the limit (e.g. 2500 rows scanned) but the active filters reduce the visible result to, say, 3 rows, the banner still reads "Showing the first **500** reviews from the current scan" — even though only 3 are displayed. This is objectively incorrect and will confuse admins.

    Replace the hardcoded `500` with the actual visible count:

36. `apps/web/app/admin/reviews/page.tsx`, line 10 ([link](https://github.com/ayushj1001/mindpoint/blob/5f6dc0184b4fac4a2b0a4810d8709924850d45c0/apps/web/app/admin/reviews/page.tsx#L10)) 

    **`useSearchParams()` used without a `<Suspense>` boundary**

    Next.js App Router requires every component that calls `useSearchParams()` to be wrapped in a `<Suspense>` boundary. Without it, the router opts the entire page out of pre-rendering (even when `force-dynamic` is set, this causes a build-time warning and can affect streaming SSR). The recommended pattern is to extract the search-param reading into a separate small component and wrap it:

    ```tsx
    // In the same file, split the component:
    import { Suspense } from "react";

    function AdminReviewsPageInner() {
      const searchParams = useSearchParams();
      // ... rest of the component
    }

    export default function AdminReviewsPage() {
      return (
        <Suspense>
          <AdminReviewsPageInner />
        </Suspense>
      );
    }
    ```

37. `apps/web/app/admin/reviews/page.tsx`, line 104-108 ([link](https://github.com/ayushj1001/mindpoint/blob/5f6dc0184b4fac4a2b0a4810d8709924850d45c0/apps/web/app/admin/reviews/page.tsx#L104-L108)) 

    **Unsafe `as Doc<"courses">[]` type cast on `useQuery` result**

    `adminCourses.listCourses` likely returns a projected/summary shape (e.g. with only `name`, `code`, `_id`), not the full `Doc<"courses">` document. Casting with `as Doc<"courses">[] | undefined` silently bypasses TypeScript's type checking — if the backend ever removes or renames a field, this cast will hide the resulting type mismatch until runtime.

    Use the inferred type from the API instead, or define a narrower local type matching the actual returned shape:

    ```ts
    const courses = useQuery(api.adminCourses.listCourses, {
      limit: 500,
      sortBy: "name",
      sortOrder: "asc",
    });
    // courses is already properly typed by Convex's generated types
    ```

    If only `_id`, `name`, and `code` are used downstream, the inferred type from Convex will be a subtype of `Doc<"courses">` and won't require an explicit cast.

38. `convex/courses.ts`, line 158-181 ([link](https://github.com/ayushj1001/mindpoint/blob/5f6dc0184b4fac4a2b0a4810d8709924850d45c0/convex/courses.ts#L158-L181)) 

    **No uniqueness guard — one user can create multiple reviews for the same course**

    `createReview` no longer has any check preventing the same `userId` from submitting multiple reviews for the same course. Every call unconditionally inserts a new document and appends its ID to `course.reviews`. A user (or a misbehaving client) can submit the same review multiple times, resulting in duplicate entries on the public course page.

    Consider adding a check before inserting:

    ```ts
    const existingReview = await ctx.db
      .query("reviews")
      .withIndex("by_course", (q) => q.eq("course", args.courseId))
      .filter((q) => q.eq(q.field("userId"), userId))
      .first();

    if (existingReview) {
      throw new Error("You have already reviewed this course");
    }
    ```

    If per-user uniqueness is intentionally not enforced for the public path (e.g. anonymous reviews), please add a comment clarifying the design intent.

39. `convex/courses.ts`, line 167-173 ([link](https://github.com/ayushj1001/mindpoint/blob/174295377819d0333296798fb6c9176c3d1edc52/convex/courses.ts#L167-L173)) 

    **Duplicate check blocks all anonymous users after the first**

    `userId` defaults to `"anonymous"` for any unauthenticated caller (`identity?.subject ?? "anonymous"`). With this new duplicate check, the very first anonymous reviewer for a course inserts a record with `userId = "anonymous"`. Every subsequent unauthenticated user on any device will then hit the `existingReview` guard and receive *"You have already reviewed this course"* — even though they are completely different people.

    The check is only meaningful for authenticated users whose `subject` is unique. For unauthenticated callers, the guard should be skipped:

    ```
    const existingReview = identity
      ? await ctx.db
          .query("reviews")
          .withIndex("by_course", (q) => q.eq("course", args.courseId))
          .filter((q) => q.eq(q.field("userId"), userId))
          .first()
      : null;
    ```

    Alternatively, consider requiring authentication before allowing a review submission so that the duplicate check always has a meaningful, user-specific `userId` to test against.

40. `convex/adminReviews.ts`, line 216-221 ([link](https://github.com/ayushj1001/mindpoint/blob/174295377819d0333296798fb6c9176c3d1edc52/convex/adminReviews.ts#L216-L221)) 

    **Admin cannot clear `userId` when editing a review**

    When an admin opens a non-admin-attributed review and clears the Reviewer ID field, `formState.userId` becomes `""`, which is passed to the mutation as `userId: undefined` (via `formState.userId || undefined`). Inside `updateReview`, `normalizeOptionalUserId(undefined)` returns `undefined`, which makes the expression fall through to `existing.userId`, silently preserving the old value instead of switching the review to `admin-managed`.

    This means an admin can never reassign a review from a real user to admin-managed — the clear action has no observable effect.

    To differentiate "field intentionally cleared" from "field not sent", consider accepting the raw (possibly empty) string and normalizing inside the mutation:

    ```ts
    // mutation arg — keep as required string, empty == "clear"
    userId: v.string(),

    // inside handler
    userId:
      normalizeOptionalUserId(args.userId) ??
      `admin-managed:${admin.userId}`,
    ```

    And update the UI to always pass `formState.userId` (not `formState.userId || undefined`).

41. `convex/adminReviews.ts`, line 83-97 ([link](https://github.com/ayushj1001/mindpoint/blob/e901fdc334cc3d4d718c9938871789790bfb0374/convex/adminReviews.ts#L83-L97)) 

    **Scan direction ignores requested sort order**

    The initial DB query always uses `.order("desc")` (newest-first) regardless of `args.sortBy`. When `sortBy = "oldest"`, the scan window fetches the newest `scanLimit` documents from the database, sorts them oldest-first in memory, and then slices to `limit`. If the database contains more reviews than `scanLimit`, the globally oldest reviews are never fetched and are permanently invisible in "oldest" sort — the UI ends up showing "oldest among the newest 2500", which is semantically wrong.

    The same problem applies to `sortBy = "rating"`: highest-rated old reviews outside the scan window are never surfaced.

    Consider making the initial fetch order match the sort:

    ```ts
    const dbOrder =
      args.sortBy === "oldest" ? "asc" : "desc";

    let rows = args.courseId
      ? await ctx.db
          .query("reviews")
          .withIndex("by_course", (q) => q.eq("course", args.courseId!))
          .order(dbOrder)
          .take(scanLimit)
      : await ctx.db.query("reviews").order(dbOrder).take(scanLimit);
    ```

    For `rating` sort there's no perfect index-based solution (Convex doesn't support ordering by arbitrary fields), but at least fixing `oldest` gives correct semantics for that case. The `hasMore` warning already encourages users to narrow filters, but the ordering is still incorrect when the flag is set.

42. `apps/web/app/admin/offers/page.tsx`, line 628-641 ([link](https://github.com/ayushj1001/mindpoint/blob/e901fdc334cc3d4d718c9938871789790bfb0374/apps/web/app/admin/offers/page.tsx#L628-L641)) 

    **Timezone label shown next to UTC-formatted plain dates**

    Both `offerWindowPreview` and `bogoWindowPreview` are produced by `formatDateWindow(..., formatDate)`, where `formatDate` always formats via `formatPlainDateForAdmin` which hard-codes `timeZone: "UTC"`. Yet the UI appends `({timeZoneLabel})` to each preview string. The displayed timezone label implies the dates reflect the selected admin timezone, but they are always rendered in UTC.

    The same pattern exists in `CourseEditor.tsx` for its offer/BOGO previews (lines ~1506 and ~1548).

    Since plain calendar dates (YYYY-MM-DD) have no time component, the day is the same in every timezone, so this is unlikely to cause confusion in practice. However, the label is misleading and should either be omitted for plain-date previews, or the documentation/tooltip should clarify that only schedule timestamps (not date-only windows) shift with the selector.

43. `convex/adminReviews.ts`, line 161-176 ([link](https://github.com/ayushj1001/mindpoint/blob/533ebb2a2284be2137ea36c1facd80ce6c9b9496/convex/adminReviews.ts#L161-L176)) 

    **Admin `createReview` bypasses per-user-per-course uniqueness**

    `courses.ts::createReview` (the public path) now queries `by_course_and_user` to prevent a user from leaving more than one review per course. The admin `createReview` path has no equivalent check. An admin can pass a real user's Clerk subject as `userId`, creating a duplicate review that sits alongside the user's own review on the public course page.

    If the admin-managed duplicate check should only apply when a non-synthetic `userId` is provided, a guard like the following would cover it:

    ```ts
    const effectiveUserId =
      normalizeOptionalUserId(args.userId) ?? `admin-managed:${admin.userId}`;

    // Only enforce uniqueness for real (non-synthetic) user IDs
    if (!effectiveUserId.startsWith("admin-managed:")) {
      const existing = await ctx.db
        .query("reviews")
        .withIndex("by_course_and_user", (q) =>
          q.eq("course", args.courseId).eq("userId", effectiveUserId),
        )
        .first();
      if (existing) {
        throw new Error(
          "A review for this user and course already exists",
        );
      }
    }
    ```

    Without this guard, admins can silently produce duplicate reviews that will both appear on the public course page.


44. `convex/adminReviews.ts`, line 85-97 ([link](https://github.com/ayushj1001/mindpoint/blob/533ebb2a2284be2137ea36c1facd80ce6c9b9496/convex/adminReviews.ts#L85-L97)) 

    **`sortBy: "rating"` scan direction biases results toward recent reviews**

    When `sortBy` is `"rating"`, `dbOrder` is `"desc"` (newest first). The query scans up to `scanLimit` documents newest-first and then sorts the in-memory window by rating. If there are more reviews than `scanLimit`, the oldest documents never enter the window, so the highest-rated reviews from earlier cohorts are permanently invisible even after the in-memory sort — and the `hasMore` banner doesn't clarify this distinction.

    Since the in-memory sort will reorder all three cases anyway, the simplest fix is to always scan in `"asc"` order (or `"desc"` for all cases consistently) so the scan window is not biased by a sort that is overridden client-side:

    ```ts
    // Always scan in insertion order; in-memory sort handles the final ordering.
    const dbOrder = "asc";
    ```

    Alternatively, only apply `dbOrder` for `"oldest"` / `"newest"` where the scan order and final sort agree:

    ```ts
    const dbOrder = args.sortBy === "rating" ? "asc" : args.sortBy === "oldest" ? "asc" : "desc";
    ```


45. `convex/courses.ts`, line 188-191 ([link](https://github.com/ayushj1001/mindpoint/blob/533ebb2a2284be2137ea36c1facd80ce6c9b9496/convex/courses.ts#L188-L191)) 

    **Two separate paths maintain `course.reviews` with different strategies**

    `courses.ts::createReview` now appends to `course.reviews` with a simple spread (`[...(course.reviews ?? []), reviewId]`), while `adminReviews.ts` uses `syncCourseReviewReference` which deduplicates with `.some()` before appending. These two code paths now co-own the same array, but behave differently:

    - The public path never deduplicates (Convex's OCC protects against concurrent writes, but it doesn't prevent an admin later calling the same course's `syncCourseReviewReference` and treating the public-inserted IDs as authoritative).
    - The admin path always deduplicates.

    Consider extracting `syncCourseReviewReference` (or an equivalent) into a shared Convex internal helper (`internalMutation` or a plain async function) and using it in both `courses.ts::createReview` and `courses.ts::deleteReview`. This ensures both paths share the same deduplication logic and makes future maintenance easier.

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aconvex%2FadminReviews.ts%3A161-176%0A**Admin%20%60createReview%60%20bypasses%20per-user-per-course%20uniqueness**%0A%0A%60courses.ts%3A%3AcreateReview%60%20%28the%20public%20path%29%20now%20queries%20%60by_course_and_user%60%20to%20prevent%20a%20user%20from%20leaving%20more%20than%20one%20review%20per%20course.%20The%20admin%20%60createReview%60%20path%20has%20no%20equivalent%20check.%20An%20admin%20can%20pass%20a%20real%20user's%20Clerk%20subject%20as%20%60userId%60%2C%20creating%20a%20duplicate%20review%20that%20sits%20alongside%20the%20user's%20own%20review%20on%20the%20public%20course%20page.%0A%0AIf%20the%20admin-managed%20duplicate%20check%20should%20only%20apply%20when%20a%20non-synthetic%20%60userId%60%20is%20provided%2C%20a%20guard%20like%20the%20following%20would%20cover%20it%3A%0A%0A%60%60%60ts%0Aconst%20effectiveUserId%20%3D%0A%20%20normalizeOptionalUserId%28args.userId%29%20%3F%3F%20%60admin-managed%3A%24%7Badmin.userId%7D%60%3B%0A%0A%2F%2F%20Only%20enforce%20uniqueness%20for%20real%20%28non-synthetic%29%20user%20IDs%0Aif%20%28!effectiveUserId.startsWith%28%22admin-managed%3A%22%29%29%20%7B%0A%20%20const%20existing%20%3D%20await%20ctx.db%0A%20%20%20%20.query%28%22reviews%22%29%0A%20%20%20%20.withIndex%28%22by_course_and_user%22%2C%20%28q%29%20%3D%3E%0A%20%20%20%20%20%20q.eq%28%22course%22%2C%20args.courseId%29.eq%28%22userId%22%2C%20effectiveUserId%29%2C%0A%20%20%20%20%29%0A%20%20%20%20.first%28%29%3B%0A%20%20if%20%28existing%29%20%7B%0A%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20%22A%20review%20for%20this%20user%20and%20course%20already%20exists%22%2C%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0AWithout%20this%20guard%2C%20admins%20can%20silently%20produce%20duplicate%20reviews%20that%20will%20both%20appear%20on%20the%20public%20course%20page.%0A%0A%23%23%23%20Issue%202%20of%203%0Aconvex%2FadminReviews.ts%3A85-97%0A**%60sortBy%3A%20%22rating%22%60%20scan%20direction%20biases%20results%20toward%20recent%20reviews**%0A%0AWhen%20%60sortBy%60%20is%20%60%22rating%22%60%2C%20%60dbOrder%60%20is%20%60%22desc%22%60%20%28newest%20first%29.%20The%20query%20scans%20up%20to%20%60scanLimit%60%20documents%20newest-first%20and%20then%20sorts%20the%20in-memory%20window%20by%20rating.%20If%20there%20are%20more%20reviews%20than%20%60scanLimit%60%2C%20the%20oldest%20documents%20never%20enter%20the%20window%2C%20so%20the%20highest-rated%20reviews%20from%20earlier%20cohorts%20are%20permanently%20invisible%20even%20after%20the%20in-memory%20sort%20%E2%80%94%20and%20the%20%60hasMore%60%20banner%20doesn't%20clarify%20this%20distinction.%0A%0ASince%20the%20in-memory%20sort%20will%20reorder%20all%20three%20cases%20anyway%2C%20the%20simplest%20fix%20is%20to%20always%20scan%20in%20%60%22asc%22%60%20order%20%28or%20%60%22desc%22%60%20for%20all%20cases%20consistently%29%20so%20the%20scan%20window%20is%20not%20biased%20by%20a%20sort%20that%20is%20overridden%20client-side%3A%0A%0A%60%60%60ts%0A%2F%2F%20Always%20scan%20in%20insertion%20order%3B%20in-memory%20sort%20handles%20the%20final%20ordering.%0Aconst%20dbOrder%20%3D%20%22asc%22%3B%0A%60%60%60%0A%0AAlternatively%2C%20only%20apply%20%60dbOrder%60%20for%20%60%22oldest%22%60%20%2F%20%60%22newest%22%60%20where%20the%20scan%20order%20and%20final%20sort%20agree%3A%0A%0A%60%60%60ts%0Aconst%20dbOrder%20%3D%20args.sortBy%20%3D%3D%3D%20%22rating%22%20%3F%20%22asc%22%20%3A%20args.sortBy%20%3D%3D%3D%20%22oldest%22%20%3F%20%22asc%22%20%3A%20%22desc%22%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aconvex%2Fcourses.ts%3A188-191%0A**Two%20separate%20paths%20maintain%20%60course.reviews%60%20with%20different%20strategies**%0A%0A%60courses.ts%3A%3AcreateReview%60%20now%20appends%20to%20%60course.reviews%60%20with%20a%20simple%20spread%20%28%60%5B...%28course.reviews%20%3F%3F%20%5B%5D%29%2C%20reviewId%5D%60%29%2C%20while%20%60adminReviews.ts%60%20uses%20%60syncCourseReviewReference%60%20which%20deduplicates%20with%20%60.some%28%29%60%20before%20appending.%20These%20two%20code%20paths%20now%20co-own%20the%20same%20array%2C%20but%20behave%20differently%3A%0A%0A-%20The%20public%20path%20never%20deduplicates%20%28Convex's%20OCC%20protects%20against%20concurrent%20writes%2C%20but%20it%20doesn't%20prevent%20an%20admin%20later%20calling%20the%20same%20course's%20%60syncCourseReviewReference%60%20and%20treating%20the%20public-inserted%20IDs%20as%20authoritative%29.%0A-%20The%20admin%20path%20always%20deduplicates.%0A%0AConsider%20extracting%20%60syncCourseReviewReference%60%20%28or%20an%20equivalent%29%20into%20a%20shared%20Convex%20internal%20helper%20%28%60internalMutation%60%20or%20a%20plain%20async%20function%29%20and%20using%20it%20in%20both%20%60courses.ts%3A%3AcreateReview%60%20and%20%60courses.ts%3A%3AdeleteReview%60.%20This%20ensures%20both%20paths%20share%20the%20same%20deduplication%20logic%20and%20makes%20future%20maintenance%20easier.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aconvex%2FadminReviews.ts%3A161-176%0A**Admin%20%60createReview%60%20bypasses%20per-user-per-course%20uniqueness**%0A%0A%60courses.ts%3A%3AcreateReview%60%20%28the%20public%20path%29%20now%20queries%20%60by_course_and_user%60%20to%20prevent%20a%20user%20from%20leaving%20more%20than%20one%20review%20per%20course.%20The%20admin%20%60createReview%60%20path%20has%20no%20equivalent%20check.%20An%20admin%20can%20pass%20a%20real%20user's%20Clerk%20subject%20as%20%60userId%60%2C%20creating%20a%20duplicate%20review%20that%20sits%20alongside%20the%20user's%20own%20review%20on%20the%20public%20course%20page.%0A%0AIf%20the%20admin-managed%20duplicate%20check%20should%20only%20apply%20when%20a%20non-synthetic%20%60userId%60%20is%20provided%2C%20a%20guard%20like%20the%20following%20would%20cover%20it%3A%0A%0A%60%60%60ts%0Aconst%20effectiveUserId%20%3D%0A%20%20normalizeOptionalUserId%28args.userId%29%20%3F%3F%20%60admin-managed%3A%24%7Badmin.userId%7D%60%3B%0A%0A%2F%2F%20Only%20enforce%20uniqueness%20for%20real%20%28non-synthetic%29%20user%20IDs%0Aif%20%28!effectiveUserId.startsWith%28%22admin-managed%3A%22%29%29%20%7B%0A%20%20const%20existing%20%3D%20await%20ctx.db%0A%20%20%20%20.query%28%22reviews%22%29%0A%20%20%20%20.withIndex%28%22by_course_and_user%22%2C%20%28q%29%20%3D%3E%0A%20%20%20%20%20%20q.eq%28%22course%22%2C%20args.courseId%29.eq%28%22userId%22%2C%20effectiveUserId%29%2C%0A%20%20%20%20%29%0A%20%20%20%20.first%28%29%3B%0A%20%20if%20%28existing%29%20%7B%0A%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20%22A%20review%20for%20this%20user%20and%20course%20already%20exists%22%2C%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0AWithout%20this%20guard%2C%20admins%20can%20silently%20produce%20duplicate%20reviews%20that%20will%20both%20appear%20on%20the%20public%20course%20page.%0A%0A%23%23%23%20Issue%202%20of%203%0Aconvex%2FadminReviews.ts%3A85-97%0A**%60sortBy%3A%20%22rating%22%60%20scan%20direction%20biases%20results%20toward%20recent%20reviews**%0A%0AWhen%20%60sortBy%60%20is%20%60%22rating%22%60%2C%20%60dbOrder%60%20is%20%60%22desc%22%60%20%28newest%20first%29.%20The%20query%20scans%20up%20to%20%60scanLimit%60%20documents%20newest-first%20and%20then%20sorts%20the%20in-memory%20window%20by%20rating.%20If%20there%20are%20more%20reviews%20than%20%60scanLimit%60%2C%20the%20oldest%20documents%20never%20enter%20the%20window%2C%20so%20the%20highest-rated%20reviews%20from%20earlier%20cohorts%20are%20permanently%20invisible%20even%20after%20the%20in-memory%20sort%20%E2%80%94%20and%20the%20%60hasMore%60%20banner%20doesn't%20clarify%20this%20distinction.%0A%0ASince%20the%20in-memory%20sort%20will%20reorder%20all%20three%20cases%20anyway%2C%20the%20simplest%20fix%20is%20to%20always%20scan%20in%20%60%22asc%22%60%20order%20%28or%20%60%22desc%22%60%20for%20all%20cases%20consistently%29%20so%20the%20scan%20window%20is%20not%20biased%20by%20a%20sort%20that%20is%20overridden%20client-side%3A%0A%0A%60%60%60ts%0A%2F%2F%20Always%20scan%20in%20insertion%20order%3B%20in-memory%20sort%20handles%20the%20final%20ordering.%0Aconst%20dbOrder%20%3D%20%22asc%22%3B%0A%60%60%60%0A%0AAlternatively%2C%20only%20apply%20%60dbOrder%60%20for%20%60%22oldest%22%60%20%2F%20%60%22newest%22%60%20where%20the%20scan%20order%20and%20final%20sort%20agree%3A%0A%0A%60%60%60ts%0Aconst%20dbOrder%20%3D%20args.sortBy%20%3D%3D%3D%20%22rating%22%20%3F%20%22asc%22%20%3A%20args.sortBy%20%3D%3D%3D%20%22oldest%22%20%3F%20%22asc%22%20%3A%20%22desc%22%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aconvex%2Fcourses.ts%3A188-191%0A**Two%20separate%20paths%20maintain%20%60course.reviews%60%20with%20different%20strategies**%0A%0A%60courses.ts%3A%3AcreateReview%60%20now%20appends%20to%20%60course.reviews%60%20with%20a%20simple%20spread%20%28%60%5B...%28course.reviews%20%3F%3F%20%5B%5D%29%2C%20reviewId%5D%60%29%2C%20while%20%60adminReviews.ts%60%20uses%20%60syncCourseReviewReference%60%20which%20deduplicates%20with%20%60.some%28%29%60%20before%20appending.%20These%20two%20code%20paths%20now%20co-own%20the%20same%20array%2C%20but%20behave%20differently%3A%0A%0A-%20The%20public%20path%20never%20deduplicates%20%28Convex's%20OCC%20protects%20against%20concurrent%20writes%2C%20but%20it%20doesn't%20prevent%20an%20admin%20later%20calling%20the%20same%20course's%20%60syncCourseReviewReference%60%20and%20treating%20the%20public-inserted%20IDs%20as%20authoritative%29.%0A-%20The%20admin%20path%20always%20deduplicates.%0A%0AConsider%20extracting%20%60syncCourseReviewReference%60%20%28or%20an%20equivalent%29%20into%20a%20shared%20Convex%20internal%20helper%20%28%60internalMutation%60%20or%20a%20plain%20async%20function%29%20and%20using%20it%20in%20both%20%60courses.ts%3A%3AcreateReview%60%20and%20%60courses.ts%3A%3AdeleteReview%60.%20This%20ensures%20both%20paths%20share%20the%20same%20deduplication%20logic%20and%20makes%20future%20maintenance%20easier.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aconvex%2FadminReviews.ts%3A161-176%0A**Admin%20%60createReview%60%20bypasses%20per-user-per-course%20uniqueness**%0A%0A%60courses.ts%3A%3AcreateReview%60%20%28the%20public%20path%29%20now%20queries%20%60by_course_and_user%60%20to%20prevent%20a%20user%20from%20leaving%20more%20than%20one%20review%20per%20course.%20The%20admin%20%60createReview%60%20path%20has%20no%20equivalent%20check.%20An%20admin%20can%20pass%20a%20real%20user's%20Clerk%20subject%20as%20%60userId%60%2C%20creating%20a%20duplicate%20review%20that%20sits%20alongside%20the%20user's%20own%20review%20on%20the%20public%20course%20page.%0A%0AIf%20the%20admin-managed%20duplicate%20check%20should%20only%20apply%20when%20a%20non-synthetic%20%60userId%60%20is%20provided%2C%20a%20guard%20like%20the%20following%20would%20cover%20it%3A%0A%0A%60%60%60ts%0Aconst%20effectiveUserId%20%3D%0A%20%20normalizeOptionalUserId%28args.userId%29%20%3F%3F%20%60admin-managed%3A%24%7Badmin.userId%7D%60%3B%0A%0A%2F%2F%20Only%20enforce%20uniqueness%20for%20real%20%28non-synthetic%29%20user%20IDs%0Aif%20%28!effectiveUserId.startsWith%28%22admin-managed%3A%22%29%29%20%7B%0A%20%20const%20existing%20%3D%20await%20ctx.db%0A%20%20%20%20.query%28%22reviews%22%29%0A%20%20%20%20.withIndex%28%22by_course_and_user%22%2C%20%28q%29%20%3D%3E%0A%20%20%20%20%20%20q.eq%28%22course%22%2C%20args.courseId%29.eq%28%22userId%22%2C%20effectiveUserId%29%2C%0A%20%20%20%20%29%0A%20%20%20%20.first%28%29%3B%0A%20%20if%20%28existing%29%20%7B%0A%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20%22A%20review%20for%20this%20user%20and%20course%20already%20exists%22%2C%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0AWithout%20this%20guard%2C%20admins%20can%20silently%20produce%20duplicate%20reviews%20that%20will%20both%20appear%20on%20the%20public%20course%20page.%0A%0A%23%23%23%20Issue%202%20of%203%0Aconvex%2FadminReviews.ts%3A85-97%0A**%60sortBy%3A%20%22rating%22%60%20scan%20direction%20biases%20results%20toward%20recent%20reviews**%0A%0AWhen%20%60sortBy%60%20is%20%60%22rating%22%60%2C%20%60dbOrder%60%20is%20%60%22desc%22%60%20%28newest%20first%29.%20The%20query%20scans%20up%20to%20%60scanLimit%60%20documents%20newest-first%20and%20then%20sorts%20the%20in-memory%20window%20by%20rating.%20If%20there%20are%20more%20reviews%20than%20%60scanLimit%60%2C%20the%20oldest%20documents%20never%20enter%20the%20window%2C%20so%20the%20highest-rated%20reviews%20from%20earlier%20cohorts%20are%20permanently%20invisible%20even%20after%20the%20in-memory%20sort%20%E2%80%94%20and%20the%20%60hasMore%60%20banner%20doesn't%20clarify%20this%20distinction.%0A%0ASince%20the%20in-memory%20sort%20will%20reorder%20all%20three%20cases%20anyway%2C%20the%20simplest%20fix%20is%20to%20always%20scan%20in%20%60%22asc%22%60%20order%20%28or%20%60%22desc%22%60%20for%20all%20cases%20consistently%29%20so%20the%20scan%20window%20is%20not%20biased%20by%20a%20sort%20that%20is%20overridden%20client-side%3A%0A%0A%60%60%60ts%0A%2F%2F%20Always%20scan%20in%20insertion%20order%3B%20in-memory%20sort%20handles%20the%20final%20ordering.%0Aconst%20dbOrder%20%3D%20%22asc%22%3B%0A%60%60%60%0A%0AAlternatively%2C%20only%20apply%20%60dbOrder%60%20for%20%60%22oldest%22%60%20%2F%20%60%22newest%22%60%20where%20the%20scan%20order%20and%20final%20sort%20agree%3A%0A%0A%60%60%60ts%0Aconst%20dbOrder%20%3D%20args.sortBy%20%3D%3D%3D%20%22rating%22%20%3F%20%22asc%22%20%3A%20args.sortBy%20%3D%3D%3D%20%22oldest%22%20%3F%20%22asc%22%20%3A%20%22desc%22%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aconvex%2Fcourses.ts%3A188-191%0A**Two%20separate%20paths%20maintain%20%60course.reviews%60%20with%20different%20strategies**%0A%0A%60courses.ts%3A%3AcreateReview%60%20now%20appends%20to%20%60course.reviews%60%20with%20a%20simple%20spread%20%28%60%5B...%28course.reviews%20%3F%3F%20%5B%5D%29%2C%20reviewId%5D%60%29%2C%20while%20%60adminReviews.ts%60%20uses%20%60syncCourseReviewReference%60%20which%20deduplicates%20with%20%60.some%28%29%60%20before%20appending.%20These%20two%20code%20paths%20now%20co-own%20the%20same%20array%2C%20but%20behave%20differently%3A%0A%0A-%20The%20public%20path%20never%20deduplicates%20%28Convex's%20OCC%20protects%20against%20concurrent%20writes%2C%20but%20it%20doesn't%20prevent%20an%20admin%20later%20calling%20the%20same%20course's%20%60syncCourseReviewReference%60%20and%20treating%20the%20public-inserted%20IDs%20as%20authoritative%29.%0A-%20The%20admin%20path%20always%20deduplicates.%0A%0AConsider%20extracting%20%60syncCourseReviewReference%60%20%28or%20an%20equivalent%29%20into%20a%20shared%20Convex%20internal%20helper%20%28%60internalMutation%60%20or%20a%20plain%20async%20function%29%20and%20using%20it%20in%20both%20%60courses.ts%3A%3AcreateReview%60%20and%20%60courses.ts%3A%3AdeleteReview%60.%20This%20ensures%20both%20paths%20share%20the%20same%20deduplication%20logic%20and%20makes%20future%20maintenance%20easier.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix All in Cursor" src="https://img.shields.io/badge/Fix_All_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: convex/adminReviews.ts
Line: 161-176

Comment:
**Admin `createReview` bypasses per-user-per-course uniqueness**

`courses.ts::createReview` (the public path) now queries `by_course_and_user` to prevent a user from leaving more than one review per course. The admin `createReview` path has no equivalent check. An admin can pass a real user's Clerk subject as `userId`, creating a duplicate review that sits alongside the user's own review on the public course page.

If the admin-managed duplicate check should only apply when a non-synthetic `userId` is provided, a guard like the following would cover it:

```ts
const effectiveUserId =
  normalizeOptionalUserId(args.userId) ?? `admin-managed:${admin.userId}`;

// Only enforce uniqueness for real (non-synthetic) user IDs
if (!effectiveUserId.startsWith("admin-managed:")) {
  const existing = await ctx.db
    .query("reviews")
    .withIndex("by_course_and_user", (q) =>
      q.eq("course", args.courseId).eq("userId", effectiveUserId),
    )
    .first();
  if (existing) {
    throw new Error(
      "A review for this user and course already exists",
    );
  }
}
```

Without this guard, admins can silently produce duplicate reviews that will both appear on the public course page.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: convex/adminReviews.ts
Line: 85-97

Comment:
**`sortBy: "rating"` scan direction biases results toward recent reviews**

When `sortBy` is `"rating"`, `dbOrder` is `"desc"` (newest first). The query scans up to `scanLimit` documents newest-first and then sorts the in-memory window by rating. If there are more reviews than `scanLimit`, the oldest documents never enter the window, so the highest-rated reviews from earlier cohorts are permanently invisible even after the in-memory sort — and the `hasMore` banner doesn't clarify this distinction.

Since the in-memory sort will reorder all three cases anyway, the simplest fix is to always scan in `"asc"` order (or `"desc"` for all cases consistently) so the scan window is not biased by a sort that is overridden client-side:

```ts
// Always scan in insertion order; in-memory sort handles the final ordering.
const dbOrder = "asc";
```

Alternatively, only apply `dbOrder` for `"oldest"` / `"newest"` where the scan order and final sort agree:

```ts
const dbOrder = args.sortBy === "rating" ? "asc" : args.sortBy === "oldest" ? "asc" : "desc";
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: convex/courses.ts
Line: 188-191

Comment:
**Two separate paths maintain `course.reviews` with different strategies**

`courses.ts::createReview` now appends to `course.reviews` with a simple spread (`[...(course.reviews ?? []), reviewId]`), while `adminReviews.ts` uses `syncCourseReviewReference` which deduplicates with `.some()` before appending. These two code paths now co-own the same array, but behave differently:

- The public path never deduplicates (Convex's OCC protects against concurrent writes, but it doesn't prevent an admin later calling the same course's `syncCourseReviewReference` and treating the public-inserted IDs as authoritative).
- The admin path always deduplicates.

Consider extracting `syncCourseReviewReference` (or an equivalent) into a shared Convex internal helper (`internalMutation` or a plain async function) and using it in both `courses.ts::createReview` and `courses.ts::deleteReview`. This ensures both paths share the same deduplication logic and makes future maintenance easier.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["Fix admin review sor..."](https://github.com/ayushj1001/mindpoint/commit/533ebb2a2284be2137ea36c1facd80ce6c9b9496)</sub>

<!-- /greptile_comment -->