### PR TITLE
Add iOS photo library permission strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /apps/web/.next/
 /out/
 /apps/web/out/
+/apps/mobile/build/
 
 # production
 /build

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -33,6 +33,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       infoPlist: {
         ...config.ios?.infoPlist,
         CFBundleDisplayName: "The Mind Point",
+        NSPhotoLibraryUsageDescription:
+          "The Mind Point needs photo library access so you can attach and upload images from your library.",
+        NSPhotoLibraryAddUsageDescription:
+          "The Mind Point needs permission to save images to your photo library when you choose to export or download them.",
       },
     },
     extra: {

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -30,6 +30,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     scheme: "mindpoint",
     ios: {
       ...config.ios,
+      bundleIdentifier: "com.anonymous.mindpoint-mobile",
       infoPlist: {
         ...config.ios?.infoPlist,
         CFBundleDisplayName: "The Mind Point",

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -34,6 +34,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       infoPlist: {
         ...config.ios?.infoPlist,
         CFBundleDisplayName: "The Mind Point",
+        // Apple validation requires these because a linked dependency references
+        // photo-library APIs, even though the current app flow does not present
+        // an image picker directly.
         NSPhotoLibraryUsageDescription:
           "The Mind Point needs photo library access so you can attach and upload images from your library.",
         NSPhotoLibraryAddUsageDescription:

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -15,8 +15,11 @@
     "ios": {
       "supportsTablet": true,
       "infoPlist": {
-        "CFBundleDisplayName": "The Mind Point"
-      }
+        "CFBundleDisplayName": "The Mind Point",
+        "NSPhotoLibraryUsageDescription": "The Mind Point needs photo library access so you can attach and upload images from your library.",
+        "NSPhotoLibraryAddUsageDescription": "The Mind Point needs permission to save images to your photo library when you choose to export or download them."
+      },
+      "bundleIdentifier": "com.anonymous.mindpoint-mobile"
     },
     "android": {
       "adaptiveIcon": {

--- a/apps/mobile/nativewind-env.d.ts
+++ b/apps/mobile/nativewind-env.d.ts
@@ -1,15 +1,31 @@
-/// <reference types="nativewind/types" />
-
-// Augment ScrollView / FlatList to accept contentContainerClassName
-// NativeWind v5 supports this at runtime but the type declarations
-// haven't shipped yet in the preview packages.
 import "react-native";
 
 declare module "react-native" {
+  interface ViewProps {
+    className?: string;
+  }
+  interface TextProps {
+    className?: string;
+  }
+  interface PressableProps {
+    className?: string;
+  }
+  interface TextInputProps {
+    className?: string;
+  }
+  interface ImageProps {
+    className?: string;
+  }
   interface ScrollViewProps {
+    className?: string;
     contentContainerClassName?: string;
   }
   interface FlatListProps<ItemT> {
+    className?: string;
+    contentContainerClassName?: string;
+  }
+  interface SectionListProps<ItemT, SectionT = DefaultSectionT> {
+    className?: string;
     contentContainerClassName?: string;
   }
 }

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "strict": true,
     "jsx": "react-jsx",
-    "jsxImportSource": "nativewind",
     "paths": {
       "@/*": ["./*"]
     }

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "strict": true,
     "jsx": "react-jsx",
+    "types": ["nativewind/types", "react", "react-native"],
     "paths": {
       "@/*": ["./*"]
     }


### PR DESCRIPTION
## Summary
- Added `NSPhotoLibraryUsageDescription` so iOS can prompt for access when users attach or upload images from the library.
- Added `NSPhotoLibraryAddUsageDescription` so iOS can prompt when the app saves exported or downloaded images.
- Kept the Expo app config and static app manifest aligned for iOS permission metadata.

## Testing
- Not run (configuration-only change).
- Verified the new permission strings are present in both `apps/mobile/app.config.ts` and `apps/mobile/app.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added user-facing iOS photo library permission prompts for access and adding photos.
  * Set the iOS app bundle identifier for proper distribution.
  * Ensured the iOS app display name is explicitly configured as "The Mind Point".
  * Updated repository ignore rules to exclude mobile build output directories.
  * Adjusted TypeScript type resolution for the mobile app build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the two iOS photo-library permission strings (`NSPhotoLibraryUsageDescription` and `NSPhotoLibraryAddUsageDescription`) required to pass Apple's ITMS-90683 validation, which is triggered by a linked dependency that references photo-library APIs even though the app does not expose an image-picker UI directly. Both `app.config.ts` (dynamic Expo config) and `app.json` (static manifest) are kept in sync. The PR also refactors the NativeWind TypeScript setup and adds the mobile `build/` directory to `.gitignore`.

**Key changes:**
- `app.config.ts` / `app.json`: permission strings added to `infoPlist`; both files now carry a `bundleIdentifier` field.
- `nativewind-env.d.ts`: migrated from a `/// <reference types=\"nativewind/types\" />` triple-slash directive to an explicit ES-module augmentation that extends `className` on `View`, `Text`, `Pressable`, `TextInput`, `Image`, `ScrollView`, `FlatList`, and `SectionList`. Any custom or third-party components that also accept `className` are not covered by the manual augmentation; their type safety relies on `nativewind/types` being in the `types` array of `tsconfig.json`.
- `tsconfig.json`: `jsxImportSource: \"nativewind\"` replaced with `\"types\": [\"nativewind/types\", \"react\", \"react-native\"]`. This is safe — the only `@types/*` package in `devDependencies` is `@types/react`, which is covered by `\"react\"` in the array; `react-native` ships its own bundled types and is unaffected by the restriction.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — all changes are configuration-only and the previously raised concerns have been addressed in prior review threads.

No P0 or P1 issues found. The permission strings are correctly justified by the ITMS-90683 requirement discussed in prior threads. The NativeWind type setup refactor is valid for the project's devDependency footprint. All remaining observations are P2 style/coverage notes that do not block merge.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/mobile/app.config.ts | Adds NSPhotoLibraryUsageDescription and NSPhotoLibraryAddUsageDescription to infoPlist, and sets bundleIdentifier; includes an inline comment explaining that a linked dependency triggers the Apple ITMS-90683 requirement |
| apps/mobile/app.json | Mirrors the permission strings and bundleIdentifier from app.config.ts in the static manifest to keep both sources aligned |
| apps/mobile/nativewind-env.d.ts | Replaces the NativeWind triple-slash reference with a module-augmentation approach, manually extending className on View, Text, Pressable, TextInput, Image, ScrollView, FlatList, and SectionList; coverage for non-listed custom components depends on nativewind/types in tsconfig |
| apps/mobile/tsconfig.json | Switches from jsxImportSource:"nativewind" to an explicit types array; safe given only @types/react is in devDependencies, and react-native ships its own bundled types |
| .gitignore | Adds /apps/mobile/build/ to prevent native build artifacts from being committed |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as The Mind Point App
    participant iOS as iOS Permission System
    participant Library as Photo Library

    App->>iOS: Launch / trigger linked dependency API
    iOS-->>App: Checks Info.plist for NSPhotoLibraryUsageDescription
    iOS->>User: "The Mind Point needs photo library access..."
    User-->>iOS: Allow / Don't Allow
    iOS-->>App: PHAuthorizationStatus granted/denied

    App->>iOS: Save image to library
    iOS-->>App: Checks Info.plist for NSPhotoLibraryAddUsageDescription
    iOS->>User: "The Mind Point needs permission to save images..."
    User-->>iOS: Allow / Don't Allow
    iOS-->>Library: Write image (if granted)
    Library-->>App: Success / Error
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/mobile/app.config.ts`, line 31-40 ([link](https://github.com/ayushj1001/mindpoint/blob/231478d495c8f91c2f9e7927be482819e2bd91af/apps/mobile/app.config.ts#L31-L40)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`bundleIdentifier` implicit in `app.config.ts` but explicit in `app.json`**

   `app.json` now declares `bundleIdentifier` inside `ios`, but `app.config.ts` relies on the `...config.ios` spread to pick it up implicitly. Since `app.config.ts` is the authoritative runtime config (it overrides `app.json`), it's easy to accidentally drop or shadow the identifier in future edits. Consider declaring it explicitly here to keep both files obviously in sync:

   ```ts
         ios: {
           ...config.ios,
           bundleIdentifier: "com.yourcompany.mindpoint",
           infoPlist: {
             ...config.ios?.infoPlist,
             CFBundleDisplayName: "The Mind Point",
             NSPhotoLibraryUsageDescription:
               "The Mind Point needs photo library access so you can attach and upload images from your library.",
             NSPhotoLibraryAddUsageDescription:
               "The Mind Point needs permission to save images to your photo library when you choose to export or download them.",
           },
         },
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/mobile/app.config.ts
   Line: 31-40

   Comment:
   **`bundleIdentifier` implicit in `app.config.ts` but explicit in `app.json`**

   `app.json` now declares `bundleIdentifier` inside `ios`, but `app.config.ts` relies on the `...config.ios` spread to pick it up implicitly. Since `app.config.ts` is the authoritative runtime config (it overrides `app.json`), it's easy to accidentally drop or shadow the identifier in future edits. Consider declaring it explicitly here to keep both files obviously in sync:

   ```ts
         ios: {
           ...config.ios,
           bundleIdentifier: "com.yourcompany.mindpoint",
           infoPlist: {
             ...config.ios?.infoPlist,
             CFBundleDisplayName: "The Mind Point",
             NSPhotoLibraryUsageDescription:
               "The Mind Point needs photo library access so you can attach and upload images from your library.",
             NSPhotoLibraryAddUsageDescription:
               "The Mind Point needs permission to save images to your photo library when you choose to export or download them.",
           },
         },
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fapp.config.ts%0ALine%3A%2031-40%0A%0AComment%3A%0A**%60bundleIdentifier%60%20implicit%20in%20%60app.config.ts%60%20but%20explicit%20in%20%60app.json%60**%0A%0A%60app.json%60%20now%20declares%20%60bundleIdentifier%60%20inside%20%60ios%60%2C%20but%20%60app.config.ts%60%20relies%20on%20the%20%60...config.ios%60%20spread%20to%20pick%20it%20up%20implicitly.%20Since%20%60app.config.ts%60%20is%20the%20authoritative%20runtime%20config%20%28it%20overrides%20%60app.json%60%29%2C%20it's%20easy%20to%20accidentally%20drop%20or%20shadow%20the%20identifier%20in%20future%20edits.%20Consider%20declaring%20it%20explicitly%20here%20to%20keep%20both%20files%20obviously%20in%20sync%3A%0A%0A%60%60%60ts%0A%20%20%20%20%20%20ios%3A%20%7B%0A%20%20%20%20%20%20%20%20...config.ios%2C%0A%20%20%20%20%20%20%20%20bundleIdentifier%3A%20%22com.yourcompany.mindpoint%22%2C%0A%20%20%20%20%20%20%20%20infoPlist%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20...config.ios%3F.infoPlist%2C%0A%20%20%20%20%20%20%20%20%20%20CFBundleDisplayName%3A%20%22The%20Mind%20Point%22%2C%0A%20%20%20%20%20%20%20%20%20%20NSPhotoLibraryUsageDescription%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%22The%20Mind%20Point%20needs%20photo%20library%20access%20so%20you%20can%20attach%20and%20upload%20images%20from%20your%20library.%22%2C%0A%20%20%20%20%20%20%20%20%20%20NSPhotoLibraryAddUsageDescription%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%22The%20Mind%20Point%20needs%20permission%20to%20save%20images%20to%20your%20photo%20library%20when%20you%20choose%20to%20export%20or%20download%20them.%22%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fapp.config.ts%0ALine%3A%2031-40%0A%0AComment%3A%0A**%60bundleIdentifier%60%20implicit%20in%20%60app.config.ts%60%20but%20explicit%20in%20%60app.json%60**%0A%0A%60app.json%60%20now%20declares%20%60bundleIdentifier%60%20inside%20%60ios%60%2C%20but%20%60app.config.ts%60%20relies%20on%20the%20%60...config.ios%60%20spread%20to%20pick%20it%20up%20implicitly.%20Since%20%60app.config.ts%60%20is%20the%20authoritative%20runtime%20config%20%28it%20overrides%20%60app.json%60%29%2C%20it's%20easy%20to%20accidentally%20drop%20or%20shadow%20the%20identifier%20in%20future%20edits.%20Consider%20declaring%20it%20explicitly%20here%20to%20keep%20both%20files%20obviously%20in%20sync%3A%0A%0A%60%60%60ts%0A%20%20%20%20%20%20ios%3A%20%7B%0A%20%20%20%20%20%20%20%20...config.ios%2C%0A%20%20%20%20%20%20%20%20bundleIdentifier%3A%20%22com.yourcompany.mindpoint%22%2C%0A%20%20%20%20%20%20%20%20infoPlist%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20...config.ios%3F.infoPlist%2C%0A%20%20%20%20%20%20%20%20%20%20CFBundleDisplayName%3A%20%22The%20Mind%20Point%22%2C%0A%20%20%20%20%20%20%20%20%20%20NSPhotoLibraryUsageDescription%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%22The%20Mind%20Point%20needs%20photo%20library%20access%20so%20you%20can%20attach%20and%20upload%20images%20from%20your%20library.%22%2C%0A%20%20%20%20%20%20%20%20%20%20NSPhotoLibraryAddUsageDescription%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%22The%20Mind%20Point%20needs%20permission%20to%20save%20images%20to%20your%20photo%20library%20when%20you%20choose%20to%20export%20or%20download%20them.%22%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fmobile%2Fapp.config.ts%0ALine%3A%2031-40%0A%0AComment%3A%0A**%60bundleIdentifier%60%20implicit%20in%20%60app.config.ts%60%20but%20explicit%20in%20%60app.json%60**%0A%0A%60app.json%60%20now%20declares%20%60bundleIdentifier%60%20inside%20%60ios%60%2C%20but%20%60app.config.ts%60%20relies%20on%20the%20%60...config.ios%60%20spread%20to%20pick%20it%20up%20implicitly.%20Since%20%60app.config.ts%60%20is%20the%20authoritative%20runtime%20config%20%28it%20overrides%20%60app.json%60%29%2C%20it's%20easy%20to%20accidentally%20drop%20or%20shadow%20the%20identifier%20in%20future%20edits.%20Consider%20declaring%20it%20explicitly%20here%20to%20keep%20both%20files%20obviously%20in%20sync%3A%0A%0A%60%60%60ts%0A%20%20%20%20%20%20ios%3A%20%7B%0A%20%20%20%20%20%20%20%20...config.ios%2C%0A%20%20%20%20%20%20%20%20bundleIdentifier%3A%20%22com.yourcompany.mindpoint%22%2C%0A%20%20%20%20%20%20%20%20infoPlist%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20...config.ios%3F.infoPlist%2C%0A%20%20%20%20%20%20%20%20%20%20CFBundleDisplayName%3A%20%22The%20Mind%20Point%22%2C%0A%20%20%20%20%20%20%20%20%20%20NSPhotoLibraryUsageDescription%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%22The%20Mind%20Point%20needs%20photo%20library%20access%20so%20you%20can%20attach%20and%20upload%20images%20from%20your%20library.%22%2C%0A%20%20%20%20%20%20%20%20%20%20NSPhotoLibraryAddUsageDescription%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%22The%20Mind%20Point%20needs%20permission%20to%20save%20images%20to%20your%20photo%20library%20when%20you%20choose%20to%20export%20or%20download%20them.%22%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix in Cursor" src="https://img.shields.io/badge/Fix_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["Add NativeWind className typings for mob..."](https://github.com/ayushj1001/mindpoint/commit/4429b8096bfafbf8e194e7924e85adce7d5e4017) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26641341)</sub>

<!-- /greptile_comment -->