### PR TITLE
Bump mobile app version to 1.0.1

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "The Mind Point",
     "slug": "mindpoint-mobile",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "mindpoint",


### PR DESCRIPTION
## Summary
- Bump the Expo mobile app version from `1.0.0` to `1.0.1`.
- Keeps the mobile package metadata aligned with the latest release version.

## Testing
- Not run (version-only change).
- Verified the diff updates `apps/mobile/app.json` as expected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a single-line change to bump the Expo mobile app's user-facing version string from `1.0.0` to `1.0.1` in `apps/mobile/app.json`. The change is minimal and low-risk.

- **Version bump**: `apps/mobile/app.json` `version` updated from `1.0.0` → `1.0.1`.
- **`package.json` not updated**: `apps/mobile/package.json` still declares `\"version\": \"1.0.0\"`, creating a minor inconsistency between the two metadata files.
- **No native build identifiers bumped**: Neither `ios.buildNumber` nor `android.versionCode` are present in `app.json`; if app store submissions are done manually, these fields will need to be added/incremented. If EAS `autoIncrement` handles this, it can be safely ignored.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single version-string update with no functional code changes.

All findings are P2 style/best-practice suggestions (package.json sync and native build identifier fields). There are no logic errors, security issues, or runtime defects introduced.

No files require special attention beyond the minor housekeeping notes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/mobile/app.json | Version bumped from 1.0.0 to 1.0.1; no `ios.buildNumber` or `android.versionCode` present, which may be needed for app store submissions if not managed by EAS. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[app.json version 1.0.0] -->|PR #33| B[app.json version 1.0.1]
    B --> C{Build method?}
    C -->|EAS autoIncrement| D[buildNumber & versionCode auto-managed ✅]
    C -->|Manual submission| E[Need to bump ios.buildNumber & android.versionCode ⚠️]
    B -.->|Not updated| F[package.json still at 1.0.0 ⚠️]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fmobile%2Fapp.json%3A5%0A**Missing%20%60ios.buildNumber%60%20and%20%60android.versionCode%60**%0A%0ABumping%20the%20user-facing%20%60version%60%20string%20alone%20is%20typically%20not%20enough%20for%20app%20store%20submissions.%20The%20Apple%20App%20Store%20requires%20a%20unique%20%60ios.buildNumber%60%20and%20the%20Google%20Play%20Store%20requires%20an%20incremented%20%60android.versionCode%60%20to%20accept%20a%20new%20build.%20Without%20these%2C%20a%20submission%20attempt%20may%20be%20rejected.%0A%0AIf%20these%20are%20managed%20automatically%20by%20EAS%20Build%20or%20a%20CI%20pipeline%20%28e.g.%20via%20%60eas.json%60%20%60autoIncrement%60%20settings%29%2C%20this%20is%20fine%20to%20ignore.%20But%20if%20builds%20are%20submitted%20manually%2C%20consider%20adding%2Fbumping%20both%3A%0A%0A%60%60%60json%0A%22ios%22%3A%20%7B%0A%20%20%22buildNumber%22%3A%20%222%22%2C%0A%20%20...%0A%7D%2C%0A%22android%22%3A%20%7B%0A%20%20%22versionCode%22%3A%202%2C%0A%20%20...%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fmobile%2Fapp.json%3A5%0A**%60package.json%60%20version%20out%20of%20sync**%0A%0A%60apps%2Fmobile%2Fpackage.json%60%20still%20declares%20%60%22version%22%3A%20%221.0.0%22%60%20while%20%60app.json%60%20is%20now%20at%20%601.0.1%60.%20For%20a%20monorepo%2C%20keeping%20both%20in%20sync%20avoids%20confusion%2C%20even%20though%20Expo%20reads%20the%20app-store%20version%20from%20%60app.json%60%20rather%20than%20%60package.json%60.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fmobile%2Fapp.json%3A5%0A**Missing%20%60ios.buildNumber%60%20and%20%60android.versionCode%60**%0A%0ABumping%20the%20user-facing%20%60version%60%20string%20alone%20is%20typically%20not%20enough%20for%20app%20store%20submissions.%20The%20Apple%20App%20Store%20requires%20a%20unique%20%60ios.buildNumber%60%20and%20the%20Google%20Play%20Store%20requires%20an%20incremented%20%60android.versionCode%60%20to%20accept%20a%20new%20build.%20Without%20these%2C%20a%20submission%20attempt%20may%20be%20rejected.%0A%0AIf%20these%20are%20managed%20automatically%20by%20EAS%20Build%20or%20a%20CI%20pipeline%20%28e.g.%20via%20%60eas.json%60%20%60autoIncrement%60%20settings%29%2C%20this%20is%20fine%20to%20ignore.%20But%20if%20builds%20are%20submitted%20manually%2C%20consider%20adding%2Fbumping%20both%3A%0A%0A%60%60%60json%0A%22ios%22%3A%20%7B%0A%20%20%22buildNumber%22%3A%20%222%22%2C%0A%20%20...%0A%7D%2C%0A%22android%22%3A%20%7B%0A%20%20%22versionCode%22%3A%202%2C%0A%20%20...%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fmobile%2Fapp.json%3A5%0A**%60package.json%60%20version%20out%20of%20sync**%0A%0A%60apps%2Fmobile%2Fpackage.json%60%20still%20declares%20%60%22version%22%3A%20%221.0.0%22%60%20while%20%60app.json%60%20is%20now%20at%20%601.0.1%60.%20For%20a%20monorepo%2C%20keeping%20both%20in%20sync%20avoids%20confusion%2C%20even%20though%20Expo%20reads%20the%20app-store%20version%20from%20%60app.json%60%20rather%20than%20%60package.json%60.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fmobile%2Fapp.json%3A5%0A**Missing%20%60ios.buildNumber%60%20and%20%60android.versionCode%60**%0A%0ABumping%20the%20user-facing%20%60version%60%20string%20alone%20is%20typically%20not%20enough%20for%20app%20store%20submissions.%20The%20Apple%20App%20Store%20requires%20a%20unique%20%60ios.buildNumber%60%20and%20the%20Google%20Play%20Store%20requires%20an%20incremented%20%60android.versionCode%60%20to%20accept%20a%20new%20build.%20Without%20these%2C%20a%20submission%20attempt%20may%20be%20rejected.%0A%0AIf%20these%20are%20managed%20automatically%20by%20EAS%20Build%20or%20a%20CI%20pipeline%20%28e.g.%20via%20%60eas.json%60%20%60autoIncrement%60%20settings%29%2C%20this%20is%20fine%20to%20ignore.%20But%20if%20builds%20are%20submitted%20manually%2C%20consider%20adding%2Fbumping%20both%3A%0A%0A%60%60%60json%0A%22ios%22%3A%20%7B%0A%20%20%22buildNumber%22%3A%20%222%22%2C%0A%20%20...%0A%7D%2C%0A%22android%22%3A%20%7B%0A%20%20%22versionCode%22%3A%202%2C%0A%20%20...%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fmobile%2Fapp.json%3A5%0A**%60package.json%60%20version%20out%20of%20sync**%0A%0A%60apps%2Fmobile%2Fpackage.json%60%20still%20declares%20%60%22version%22%3A%20%221.0.0%22%60%20while%20%60app.json%60%20is%20now%20at%20%601.0.1%60.%20For%20a%20monorepo%2C%20keeping%20both%20in%20sync%20avoids%20confusion%2C%20even%20though%20Expo%20reads%20the%20app-store%20version%20from%20%60app.json%60%20rather%20than%20%60package.json%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix All in Cursor" src="https://img.shields.io/badge/Fix_All_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/mobile/app.json
Line: 5

Comment:
**Missing `ios.buildNumber` and `android.versionCode`**

Bumping the user-facing `version` string alone is typically not enough for app store submissions. The Apple App Store requires a unique `ios.buildNumber` and the Google Play Store requires an incremented `android.versionCode` to accept a new build. Without these, a submission attempt may be rejected.

If these are managed automatically by EAS Build or a CI pipeline (e.g. via `eas.json` `autoIncrement` settings), this is fine to ignore. But if builds are submitted manually, consider adding/bumping both:

```json
"ios": {
  "buildNumber": "2",
  ...
},
"android": {
  "versionCode": 2,
  ...
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/mobile/app.json
Line: 5

Comment:
**`package.json` version out of sync**

`apps/mobile/package.json` still declares `"version": "1.0.0"` while `app.json` is now at `1.0.1`. For a monorepo, keeping both in sync avoids confusion, even though Expo reads the app-store version from `app.json` rather than `package.json`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Bump mobile app version to 1.0.1"](https://github.com/ayushj1001/mindpoint/commit/d2d38dbb69f2e40abf7012f355dcca17933d0913) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26655739)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped mobile app version to 1.0.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->