### PR TITLE
Add Clerk load timeout guidance to mobile account screen

### DIFF
--- a/apps/mobile/app/(tabs)/account.tsx
+++ b/apps/mobile/app/(tabs)/account.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import type { ReactNode } from "react";
 import {
   Alert,
@@ -56,11 +56,25 @@ function ConnectedAccountScreen() {
   const { isLoading } = useConvexAuth();
   const [activeTab, setActiveTab] = useState<TabName>("Enrollments");
   const [refreshing, setRefreshing] = useState(false);
+  const [clerkLoadTimedOut, setClerkLoadTimedOut] = useState(false);
 
   const onRefresh = useCallback(() => {
     setRefreshing(true);
     setTimeout(() => setRefreshing(false), 1000);
   }, []);
+
+  useEffect(() => {
+    if (isLoaded) {
+      setClerkLoadTimedOut(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setClerkLoadTimedOut(true);
+    }, 8000);
+
+    return () => clearTimeout(timer);
+  }, [isLoaded]);
 
   if (!isLoaded) {
     return (
@@ -77,6 +91,14 @@ function ConnectedAccountScreen() {
             <Text className="text-xl font-bold text-[#1a1f2e]">
               Loading account...
             </Text>
+            {clerkLoadTimedOut ? (
+              <Text className="text-sm leading-5 text-[#64748b]">
+                Account sign-in is taking longer than expected. For TestFlight
+                and App Store builds, make sure the live Clerk instance has
+                Native API enabled and that this iOS app's bundle ID is added on
+                the Native applications page.
+              </Text>
+            ) : null}
           </View>
         </ScrollView>
       </View>


### PR DESCRIPTION
## Summary
- Adds an 8-second timeout on the mobile account loading state.
- Shows a Clerk-specific guidance message when sign-in takes longer than expected.
- Resets the timeout state as soon as Clerk finishes loading.

## Testing
- Not run
- Verified the UI path now conditionally renders the timeout guidance after the delay.
- Verified the timeout is cleared when `isLoaded` becomes `true`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a graceful timeout UX to the mobile account loading screen: after 8 seconds without Clerk finishing its initialization, a guidance message is shown explaining how to fix common TestFlight / App Store Clerk configuration problems.

**Key changes:**
- Introduces a `clerkLoadTimedOut` boolean state (default `false`) in `ConnectedAccountScreen`.
- A `useEffect` dependent on `isLoaded` sets an 8-second `setTimeout`; the cleanup correctly cancels the timer if `isLoaded` flips to `true` before it fires, preventing both memory leaks and stale `setState` calls on unmounted components.
- Resets `clerkLoadTimedOut` to `false` immediately when `isLoaded` becomes `true`, so a subsequent fast load cycle won't show stale guidance.
- Renders the guidance `<Text>` block conditionally inside the existing `!isLoaded` branch.

The implementation is clean and correct. The only minor point is that the timeout message is worded for iOS (references TestFlight and iOS bundle IDs) with no `Platform.OS` guard, which could be confusing on Android builds if they exist.

<h3>Confidence Score: 5/5</h3>

Safe to merge — logic, cleanup, and state transitions are all correct; the sole finding is a minor P2 platform-copy suggestion.

All findings are P2 or lower. The useEffect implementation is correct: the dependency array is right, the cleanup prevents memory leaks, and the state reset on isLoaded=true is handled properly. No functional regressions introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/mobile/app/(tabs)/account.tsx | Adds an 8-second timeout via `useEffect` that shows iOS-specific Clerk configuration guidance; logic and cleanup are correct, minor note that the guidance copy is iOS-only with no platform guard. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as AccountScreen
    participant Clerk as Clerk (isLoaded)
    participant UI as UI

    App->>Clerk: mount — isLoaded = false
    App->>App: start 8s timer
    UI->>UI: render "Loading account..."

    alt Clerk loads within 8s
        Clerk-->>App: isLoaded = true
        App->>App: clearTimeout (cleanup)
        App->>App: setClerkLoadTimedOut(false)
        UI->>UI: render signed-in or sign-in form
    else Clerk takes > 8s
        App->>App: timer fires → setClerkLoadTimedOut(true)
        UI->>UI: render "Loading account..." + guidance text
        Clerk-->>App: isLoaded = true (eventually)
        App->>App: setClerkLoadTimedOut(false)
        UI->>UI: render signed-in or sign-in form
    end
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fmobile%2Fapp%2F%28tabs%29%2Faccount.tsx%3A95-100%0A**iOS-only%20guidance%20shown%20on%20all%20platforms**%0A%0AThe%20timeout%20message%20references%20%22TestFlight%20and%20App%20Store%20builds%22%20and%20%22iOS%20app's%20bundle%20ID%22%2C%20but%20there's%20no%20%60Platform.OS%60%20check.%20If%20this%20app%20targets%20Android%20as%20well%2C%20Android%20users%20will%20see%20confusing%20iOS-specific%20instructions.%0A%0AConsider%20guarding%20the%20message%20%28or%20tailoring%20the%20copy%29%20based%20on%20platform%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%7BclerkLoadTimedOut%20%3F%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CText%20className%3D%22text-sm%20leading-5%20text-%5B%2364748b%5D%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Account%20sign-in%20is%20taking%20longer%20than%20expected.%7B%22%20%22%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7BPlatform.OS%20%3D%3D%3D%20%22ios%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20%22For%20TestFlight%20and%20App%20Store%20builds%2C%20make%20sure%20the%20live%20Clerk%20instance%20has%20Native%20API%20enabled%20and%20that%20this%20iOS%20app's%20bundle%20ID%20is%20added%20on%20the%20Native%20applications%20page.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3A%20%22Make%20sure%20the%20live%20Clerk%20instance%20has%20Native%20API%20enabled%20and%20that%20this%20app%20is%20registered%20on%20the%20Native%20applications%20page.%22%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2FText%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%20%3A%20null%7D%0A%60%60%60%0A%0A%28Also%20requires%20importing%20%60Platform%60%20from%20%60react-native%60.%29%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fmobile%2Fapp%2F%28tabs%29%2Faccount.tsx%3A95-100%0A**iOS-only%20guidance%20shown%20on%20all%20platforms**%0A%0AThe%20timeout%20message%20references%20%22TestFlight%20and%20App%20Store%20builds%22%20and%20%22iOS%20app's%20bundle%20ID%22%2C%20but%20there's%20no%20%60Platform.OS%60%20check.%20If%20this%20app%20targets%20Android%20as%20well%2C%20Android%20users%20will%20see%20confusing%20iOS-specific%20instructions.%0A%0AConsider%20guarding%20the%20message%20%28or%20tailoring%20the%20copy%29%20based%20on%20platform%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%7BclerkLoadTimedOut%20%3F%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CText%20className%3D%22text-sm%20leading-5%20text-%5B%2364748b%5D%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Account%20sign-in%20is%20taking%20longer%20than%20expected.%7B%22%20%22%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7BPlatform.OS%20%3D%3D%3D%20%22ios%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20%22For%20TestFlight%20and%20App%20Store%20builds%2C%20make%20sure%20the%20live%20Clerk%20instance%20has%20Native%20API%20enabled%20and%20that%20this%20iOS%20app's%20bundle%20ID%20is%20added%20on%20the%20Native%20applications%20page.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3A%20%22Make%20sure%20the%20live%20Clerk%20instance%20has%20Native%20API%20enabled%20and%20that%20this%20app%20is%20registered%20on%20the%20Native%20applications%20page.%22%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2FText%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%20%3A%20null%7D%0A%60%60%60%0A%0A%28Also%20requires%20importing%20%60Platform%60%20from%20%60react-native%60.%29%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fmobile%2Fapp%2F%28tabs%29%2Faccount.tsx%3A95-100%0A**iOS-only%20guidance%20shown%20on%20all%20platforms**%0A%0AThe%20timeout%20message%20references%20%22TestFlight%20and%20App%20Store%20builds%22%20and%20%22iOS%20app's%20bundle%20ID%22%2C%20but%20there's%20no%20%60Platform.OS%60%20check.%20If%20this%20app%20targets%20Android%20as%20well%2C%20Android%20users%20will%20see%20confusing%20iOS-specific%20instructions.%0A%0AConsider%20guarding%20the%20message%20%28or%20tailoring%20the%20copy%29%20based%20on%20platform%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%7BclerkLoadTimedOut%20%3F%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CText%20className%3D%22text-sm%20leading-5%20text-%5B%2364748b%5D%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Account%20sign-in%20is%20taking%20longer%20than%20expected.%7B%22%20%22%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7BPlatform.OS%20%3D%3D%3D%20%22ios%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20%22For%20TestFlight%20and%20App%20Store%20builds%2C%20make%20sure%20the%20live%20Clerk%20instance%20has%20Native%20API%20enabled%20and%20that%20this%20iOS%20app's%20bundle%20ID%20is%20added%20on%20the%20Native%20applications%20page.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3A%20%22Make%20sure%20the%20live%20Clerk%20instance%20has%20Native%20API%20enabled%20and%20that%20this%20app%20is%20registered%20on%20the%20Native%20applications%20page.%22%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2FText%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%20%3A%20null%7D%0A%60%60%60%0A%0A%28Also%20requires%20importing%20%60Platform%60%20from%20%60react-native%60.%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix All in Cursor" src="https://img.shields.io/badge/Fix_All_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/mobile/app/(tabs)/account.tsx
Line: 95-100

Comment:
**iOS-only guidance shown on all platforms**

The timeout message references "TestFlight and App Store builds" and "iOS app's bundle ID", but there's no `Platform.OS` check. If this app targets Android as well, Android users will see confusing iOS-specific instructions.

Consider guarding the message (or tailoring the copy) based on platform:

```suggestion
            {clerkLoadTimedOut ? (
              <Text className="text-sm leading-5 text-[#64748b]">
                Account sign-in is taking longer than expected.{" "}
                {Platform.OS === "ios"
                  ? "For TestFlight and App Store builds, make sure the live Clerk instance has Native API enabled and that this iOS app's bundle ID is added on the Native applications page."
                  : "Make sure the live Clerk instance has Native API enabled and that this app is registered on the Native applications page."}
              </Text>
            ) : null}
```

(Also requires importing `Platform` from `react-native`.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Clerk load timeout guidance in mobil..."](https://github.com/ayushj1001/mindpoint/commit/7b8a17a59d2b09c7cc01fe2880808dad8b24e6e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26656645)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account loading reliability with timeout detection. When account loading takes longer than expected, users now receive helpful guidance for troubleshooting iOS build configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->