### PR TITLE
Trim empty coupon fields from mobile checkout payload

### DIFF
--- a/apps/mobile/app/(tabs)/cart.tsx
+++ b/apps/mobile/app/(tabs)/cart.tsx
@@ -159,13 +159,10 @@ export default function CartScreen() {
       const checkoutPrice = Math.round(item.price ?? 0);
       return {
         courseId: item.id,
-        courseType: item.courseType as string | undefined,
         listedPrice,
         checkoutPrice,
         amountPaid: checkoutPrice,
         redemptionDiscountAmount: 0,
-        couponCode: undefined as string | undefined,
-        mindPointsRedeemed: undefined as number | undefined,
       };
     });
 
@@ -185,7 +182,7 @@ export default function CartScreen() {
       let bestPrice = -1;
       baseItems.forEach((item, index) => {
         if (
-          item.courseType === appliedCoupon.courseType &&
+          items[index]?.courseType === appliedCoupon.courseType &&
           item.checkoutPrice > 0 &&
           item.checkoutPrice > bestPrice
         ) {
@@ -217,9 +214,12 @@ export default function CartScreen() {
         ...item,
         amountPaid,
         redemptionDiscountAmount: discountAmount,
-        couponCode: appliedCoupon.code,
-        mindPointsRedeemed:
-          discountAmount > 0 ? appliedCoupon.pointsCost : undefined,
+        ...(discountAmount > 0
+          ? {
+              couponCode: appliedCoupon.code,
+              mindPointsRedeemed: appliedCoupon.pointsCost,
+            }
+          : {}),
       };
     });
 

--- a/apps/mobile/app/checkout.tsx
+++ b/apps/mobile/app/checkout.tsx
@@ -107,8 +107,6 @@ export default function CheckoutScreen() {
         checkoutPrice,
         amountPaid: checkoutPrice,
         redemptionDiscountAmount: 0,
-        couponCode: undefined as string | undefined,
-        mindPointsRedeemed: undefined as number | undefined,
       };
     });
 


### PR DESCRIPTION
## Summary
- Removed unused `couponCode` and `mindPointsRedeemed` fields from mobile cart and checkout item payloads when no discount is applied.
- Kept coupon metadata only when a discount is actually being redeemed.
- Adjusted the mobile cart coupon matching logic to read course type from the original cart items.

## Testing
- Not run (not requested).
- Verified the diff only touches mobile cart and checkout payload construction.
- Confirmed empty coupon fields are no longer emitted for non-discounted checkout items.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR trims empty coupon-related fields (`couponCode`, `mindPointsRedeemed`) from the mobile cart and checkout item payloads when no discount is being applied, and fixes the coupon eligibility matching logic to read `courseType` from the original cart items instead of the intermediate `baseItems` (which no longer carry that field).

**Key changes:**
- `courseType`, `couponCode: undefined`, and `mindPointsRedeemed: undefined` removed from `baseItems` in `cart.tsx` — none of these were part of the `CheckoutPricingItem` type, so the trimming is type-safe and avoids sending spurious fields to the Convex mutation validator.
- The coupon eligibility check in `baseItems.forEach` is updated from `item.courseType` to `items[index]?.courseType`, correctly sourcing the course type from the original cart items now that `baseItems` no longer carries the field. Since `baseItems` is built as a direct `items.map`, the indices align exactly so the logic is equivalent.
- Coupon metadata (`couponCode`, `mindPointsRedeemed`) is now spread conditionally with `...(discountAmount > 0 ? {...} : {})`, ensuring `markCouponUsed` is only triggered when an actual discount was applied. This is strictly better than the previous behavior where `couponCode` was always emitted even when `discountAmount === 0`.
- Identical cleanup of explicit `undefined` fields in `checkout.tsx`'s fallback pricing builder.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are correct, type-safe, and strictly improve the payload hygiene and coupon marking logic.

Both changed files are self-contained payload builders. The courseType removal is consistent with the CheckoutPricingItem type (which never included it), the index-based courseType lookup is equivalent to the previous in-object lookup, and the discountAmount > 0 guard prevents spurious markCouponUsed calls. No P0 or P1 issues were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/mobile/app/(tabs)/cart.tsx | Removes courseType, couponCode, and mindPointsRedeemed from baseItems; fixes coupon matching to read courseType from the original cart items array; conditionally spreads coupon metadata only when discountAmount > 0 |
| apps/mobile/app/checkout.tsx | Removes explicit undefined couponCode and mindPointsRedeemed fields from the fallback checkout pricing — both were already optional in CheckoutPricingItem, so the removal is type-safe and clean |

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove empty coupon fields from mobile c..."](https://github.com/ayushj1001/mindpoint/commit/01d3c199159f207b90a2f48ac27a399ad6e2934b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26658800)</sub>

<!-- /greptile_comment -->