### PR TITLE
Fix mobile video playback and NativeWind resolution

### DIFF
--- a/apps/mobile/components/VideoTestimonialsSection.tsx
+++ b/apps/mobile/components/VideoTestimonialsSection.tsx
@@ -1,22 +1,22 @@
-import { useState, useRef } from "react";
+import { useState, useCallback } from "react";
 import {
   View,
   Text,
-  Pressable,
+  TouchableOpacity,
   ScrollView,
   Modal,
   Dimensions,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
-import { Video, ResizeMode } from "expo-av";
+import { useVideoPlayer, VideoView } from "expo-video";
 import { Play, X } from "lucide-react-native";
 import {
   VIDEO_TESTIMONIALS,
   type VideoTestimonial,
 } from "@/lib/videoTestimonials";
 
-const CARD_WIDTH = 150;
-const CARD_ASPECT = 4 / 5;
+const CARD_WIDTH = 140;
+const CARD_HEIGHT = 175;
 
 function VideoCard({
   testimonial,
@@ -26,72 +26,95 @@ function VideoCard({
   onPress: () => void;
 }) {
   return (
-    <Pressable
+    <TouchableOpacity
       onPress={onPress}
-      style={({ pressed }) => ({
-        opacity: pressed ? 0.9 : 1,
-        width: CARD_WIDTH,
-        aspectRatio: CARD_ASPECT,
-      })}
-      className="overflow-hidden rounded-xl"
+      activeOpacity={0.85}
     >
-      {/* Background gradient (poster fallback) */}
-      <LinearGradient
-        colors={["#dbeafe", "#e0e7ff"]}
-        style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
-      />
-
-      {/* Dark overlay for contrast */}
       <View
-        className="absolute inset-0 bg-black/20"
-        style={{ zIndex: 1 }}
-      />
-
-      {/* Play button */}
-      <View
-        className="absolute inset-0 items-center justify-center"
-        style={{ zIndex: 2 }}
-      >
-        <View className="h-12 w-12 items-center justify-center rounded-full bg-white/90"
-          style={{
-            shadowColor: "#000",
-            shadowOffset: { width: 0, height: 2 },
-            shadowOpacity: 0.2,
-            shadowRadius: 4,
-            elevation: 4,
-          }}
-        >
-          <Play
-            size={20}
-            color="#2563eb"
-            fill="#2563eb"
-            style={{ marginLeft: 2 }}
-          />
-        </View>
-      </View>
-
-      {/* Label overlay at bottom */}
-      <LinearGradient
-        colors={["transparent", "rgba(0,0,0,0.6)"]}
         style={{
-          position: "absolute",
-          bottom: 0,
-          left: 0,
-          right: 0,
-          zIndex: 2,
-          paddingTop: 32,
-          paddingBottom: 12,
-          paddingHorizontal: 12,
+          width: CARD_WIDTH,
+          height: CARD_HEIGHT,
+          borderRadius: 12,
+          overflow: "hidden",
+          backgroundColor: "#dbeafe",
         }}
       >
-        <Text className="text-xs font-medium text-white">
-          {testimonial.name || "Student Testimonial"}
-        </Text>
-        {testimonial.role && (
-          <Text className="text-[10px] text-white/80">{testimonial.role}</Text>
-        )}
-      </LinearGradient>
-    </Pressable>
+        {/* Background gradient */}
+        <LinearGradient
+          colors={["#dbeafe", "#c7d2fe", "#e0e7ff"]}
+          style={{
+            width: CARD_WIDTH,
+            height: CARD_HEIGHT,
+          }}
+        />
+
+        {/* Dark overlay */}
+        <View
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: CARD_WIDTH,
+            height: CARD_HEIGHT,
+            backgroundColor: "rgba(0,0,0,0.1)",
+          }}
+        />
+
+        {/* Play button centered */}
+        <View
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: CARD_WIDTH,
+            height: CARD_HEIGHT,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <View
+            style={{
+              height: 40,
+              width: 40,
+              alignItems: "center",
+              justifyContent: "center",
+              borderRadius: 20,
+              backgroundColor: "rgba(255,255,255,0.9)",
+              shadowColor: "#000",
+              shadowOffset: { width: 0, height: 2 },
+              shadowOpacity: 0.2,
+              shadowRadius: 4,
+              elevation: 4,
+            }}
+          >
+            <Play
+              size={16}
+              color="#2563eb"
+              fill="#2563eb"
+              style={{ marginLeft: 2 }}
+            />
+          </View>
+        </View>
+
+        {/* Label at bottom */}
+        <LinearGradient
+          colors={["transparent", "rgba(0,0,0,0.55)"]}
+          style={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            paddingTop: 28,
+            paddingBottom: 8,
+            paddingHorizontal: 10,
+          }}
+        >
+          <Text style={{ fontSize: 11, fontWeight: "500", color: "white" }}>
+            {testimonial.name || "Student Testimonial"}
+          </Text>
+        </LinearGradient>
+      </View>
+    </TouchableOpacity>
   );
 }
 
@@ -104,16 +127,18 @@ function VideoModal({
   visible: boolean;
   onClose: () => void;
 }) {
-  const videoRef = useRef<Video>(null);
   const { width, height } = Dimensions.get("window");
 
-  const handleClose = async () => {
-    if (videoRef.current) {
-      await videoRef.current.stopAsync();
-      await videoRef.current.unloadAsync();
+  const player = useVideoPlayer(testimonial?.videoUrl ?? null, (p) => {
+    if (testimonial) {
+      p.play();
     }
+  });
+
+  const handleClose = useCallback(() => {
+    player.pause();
     onClose();
-  };
+  }, [player, onClose]);
 
   return (
     <Modal
@@ -122,23 +147,39 @@ function VideoModal({
       presentationStyle="fullScreen"
       onRequestClose={handleClose}
     >
-      <View className="flex-1 bg-black items-center justify-center">
-        {/* Close button */}
-        <Pressable
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: "black",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <TouchableOpacity
           onPress={handleClose}
-          className="absolute top-14 right-5 z-10 h-10 w-10 items-center justify-center rounded-full bg-white/20"
+          activeOpacity={0.7}
+          style={{
+            position: "absolute",
+            top: 56,
+            right: 20,
+            zIndex: 10,
+            height: 40,
+            width: 40,
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: 20,
+            backgroundColor: "rgba(255,255,255,0.2)",
+          }}
         >
           <X size={20} color="#ffffff" />
-        </Pressable>
+        </TouchableOpacity>
 
         {testimonial && (
-          <Video
-            ref={videoRef}
-            source={{ uri: testimonial.videoUrl }}
-            useNativeControls
-            resizeMode={ResizeMode.CONTAIN}
-            shouldPlay
+          <VideoView
+            player={player}
             style={{ width, height: height * 0.85 }}
+            contentFit="contain"
+            nativeControls
           />
         )}
       </View>
@@ -165,11 +206,27 @@ export default function VideoTestimonialsSection() {
   if (VIDEO_TESTIMONIALS.length === 0) return null;
 
   return (
-    <View className="mt-8">
-      <Text className="mb-2 text-center text-2xl font-bold text-foreground">
+    <View style={{ marginTop: 32 }}>
+      <Text
+        style={{
+          marginBottom: 8,
+          textAlign: "center",
+          fontSize: 20,
+          fontWeight: "700",
+          color: "#303853",
+        }}
+      >
         Hear From Our Students
       </Text>
-      <Text className="mb-5 text-center text-sm text-muted-foreground">
+      <Text
+        style={{
+          marginBottom: 20,
+          textAlign: "center",
+          fontSize: 13,
+          color: "#717a93",
+          paddingHorizontal: 16,
+        }}
+      >
         Real stories from students who transformed their understanding of mental
         health with The Mind Point
       </Text>
@@ -178,6 +235,7 @@ export default function VideoTestimonialsSection() {
         horizontal
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={{ gap: 12, paddingHorizontal: 4 }}
+        style={{ minHeight: CARD_HEIGHT + 8 }}
       >
         {VIDEO_TESTIMONIALS.map((testimonial) => (
           <VideoCard

--- a/apps/mobile/components/course/MasterclassCourse.tsx
+++ b/apps/mobile/components/course/MasterclassCourse.tsx
@@ -70,7 +70,7 @@ export default function MasterclassCourse({ course }: MasterclassCourseProps) {
                 <View className="flex-row items-start gap-3 p-4">
                   <LinearGradient
                     colors={["#4338ca", "#7c3aed"]}
-                    className="h-11 w-11 items-center justify-center rounded-xl"
+                    style={{ height: 44, width: 44, alignItems: "center", justifyContent: "center", borderRadius: 12 }}
                   >
                     <Icon size={20} color="#ffffff" />
                   </LinearGradient>

--- a/apps/mobile/components/course/SupervisedCourse.tsx
+++ b/apps/mobile/components/course/SupervisedCourse.tsx
@@ -280,7 +280,7 @@ export default function SupervisedCourse({
                 colors={plan.gradientColors}
                 start={{ x: 0, y: 0 }}
                 end={{ x: 1, y: 0 }}
-                className="px-4 py-4"
+                style={{ paddingHorizontal: 16, paddingVertical: 16 }}
               >
                 <View className="flex-row items-center gap-3">
                   <View className="h-10 w-10 items-center justify-center rounded-xl bg-white/20">
@@ -344,7 +344,7 @@ export default function SupervisedCourse({
                       colors={plan.gradientColors}
                       start={{ x: 0, y: 0 }}
                       end={{ x: 1, y: 0 }}
-                      className="flex-row items-center rounded-xl px-4 py-2.5"
+                      style={{ flexDirection: "row", alignItems: "center", borderRadius: 12, paddingHorizontal: 16, paddingVertical: 10 }}
                     >
                       <Text className="text-sm font-semibold text-white">
                         Start Session

--- a/apps/mobile/components/course/TherapyCourse.tsx
+++ b/apps/mobile/components/course/TherapyCourse.tsx
@@ -287,7 +287,7 @@ export default function TherapyCourse({
                 colors={plan.gradientColors}
                 start={{ x: 0, y: 0 }}
                 end={{ x: 1, y: 0 }}
-                className="px-4 py-4"
+                style={{ paddingHorizontal: 16, paddingVertical: 16 }}
               >
                 <View className="flex-row items-center gap-3">
                   <View className="h-10 w-10 items-center justify-center rounded-xl bg-white/20">
@@ -354,7 +354,7 @@ export default function TherapyCourse({
                       colors={plan.gradientColors}
                       start={{ x: 0, y: 0 }}
                       end={{ x: 1, y: 0 }}
-                      className="flex-row items-center rounded-xl px-4 py-2.5"
+                      style={{ flexDirection: "row", alignItems: "center", borderRadius: 12, paddingHorizontal: 16, paddingVertical: 10 }}
                     >
                       <Text className="text-sm font-semibold text-white">
                         Start Session
@@ -409,7 +409,7 @@ export default function TherapyCourse({
                 <View className="flex-row items-start gap-3 p-4">
                   <LinearGradient
                     colors={["#4338ca", "#7c3aed"]}
-                    className="h-11 w-11 items-center justify-center rounded-xl"
+                    style={{ height: 44, width: 44, alignItems: "center", justifyContent: "center", borderRadius: 12 }}
                   >
                     <Icon size={20} color="#ffffff" />
                   </LinearGradient>
@@ -430,7 +430,7 @@ export default function TherapyCourse({
         {/* Trust Indicators */}
         <LinearGradient
           colors={["#4338ca10", "#7c3aed10"]}
-          className="mt-6 flex-row items-center justify-around rounded-2xl p-5"
+          style={{ marginTop: 24, flexDirection: "row", alignItems: "center", justifyContent: "space-around", borderRadius: 16, padding: 20 }}
         >
           <View className="items-center">
             <Text className="text-2xl font-bold text-primary">1000+</Text>

--- a/apps/mobile/components/course/communities-section.tsx
+++ b/apps/mobile/components/course/communities-section.tsx
@@ -25,40 +25,57 @@ function InstagramIcon() {
 
 export function CommunitiesSection() {
   return (
-    <View className="mt-8 overflow-hidden rounded-2xl">
+    <View style={{ marginTop: 32, borderRadius: 16, overflow: "hidden" }}>
       <LinearGradient
         colors={["#2563eb", "#9333ea"]}
         start={{ x: 0, y: 0 }}
         end={{ x: 1, y: 0 }}
-        className="items-center px-5 py-8"
+        style={{ alignItems: "center", paddingHorizontal: 20, paddingVertical: 28 }}
       >
-        <Text className="mb-2 text-center text-2xl font-bold text-white">
+        <Text
+          style={{
+            marginBottom: 6,
+            textAlign: "center",
+            fontSize: 18,
+            fontWeight: "700",
+            color: "white",
+          }}
+        >
           Join Our Learning Community!
         </Text>
-        <Text className="mb-6 text-center text-sm text-white/90">
+        <Text
+          style={{
+            marginBottom: 20,
+            textAlign: "center",
+            fontSize: 12,
+            lineHeight: 18,
+            color: "rgba(255,255,255,0.9)",
+            paddingHorizontal: 8,
+          }}
+        >
           Connect with fellow learners, share insights, and continue your
           journey together
         </Text>
 
-        <View className="w-full gap-3">
+        <View style={{ width: "100%", gap: 10 }}>
           <Pressable
             onPress={() => Linking.openURL(WHATSAPP_LINK)}
-            className="flex-row items-center justify-center gap-3 rounded-xl bg-white px-6 py-3.5"
+            className="flex-row items-center justify-center gap-3 rounded-xl bg-white px-5 py-3"
             style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
           >
             <WhatsAppIcon />
-            <Text className="text-sm font-semibold text-blue-600">
+            <Text style={{ fontSize: 13, fontWeight: "600", color: "#2563eb" }}>
               Join WhatsApp Community
             </Text>
           </Pressable>
 
           <Pressable
             onPress={() => Linking.openURL(INSTAGRAM_LINK)}
-            className="flex-row items-center justify-center gap-3 rounded-xl bg-white px-6 py-3.5"
+            className="flex-row items-center justify-center gap-3 rounded-xl bg-white px-5 py-3"
             style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
           >
             <InstagramIcon />
-            <Text className="text-sm font-semibold text-purple-600">
+            <Text style={{ fontSize: 13, fontWeight: "600", color: "#9333ea" }}>
               Join Instagram Community
             </Text>
           </Pressable>

--- a/apps/mobile/components/course/educators.tsx
+++ b/apps/mobile/components/course/educators.tsx
@@ -50,7 +50,7 @@ export function Educators() {
           >
             <LinearGradient
               colors={["#4338ca", "#7c3aed"]}
-              className="h-12 w-12 items-center justify-center rounded-full"
+              style={{ height: 48, width: 48, alignItems: "center", justifyContent: "center", borderRadius: 24 }}
             >
               <User size={24} color="#ffffff" />
             </LinearGradient>

--- a/apps/mobile/components/course/who-should-do.tsx
+++ b/apps/mobile/components/course/who-should-do.tsx
@@ -1,6 +1,5 @@
 import { View, Text } from "react-native";
 import { Target } from "lucide-react-native";
-import { LinearGradient } from "expo-linear-gradient";
 import { Card } from "@/components/ui/card";
 
 const TARGET_AUDIENCE = [

--- a/apps/mobile/components/course/why-choose.tsx
+++ b/apps/mobile/components/course/why-choose.tsx
@@ -58,7 +58,7 @@ export function WhyChoose() {
           >
             <LinearGradient
               colors={["#4338ca", "#7c3aed"]}
-              className="mb-2 h-10 w-10 items-center justify-center rounded-full"
+              style={{ marginBottom: 8, height: 40, width: 40, alignItems: "center", justifyContent: "center", borderRadius: 20 }}
             >
               <reason.icon size={18} color="#ffffff" />
             </LinearGradient>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -3,6 +3,7 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
+    "postinstall": "node scripts/fix-nativewind.js",
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
@@ -20,7 +21,6 @@
     "convex": "^1.23.0",
     "expo": "~55.0.6",
     "expo-auth-session": "~55.0.9",
-    "expo-av": "^16.0.8",
     "expo-clipboard": "^55.0.9",
     "expo-constants": "~55.0.7",
     "expo-dev-client": "^55.0.18",
@@ -34,6 +34,7 @@
     "expo-splash-screen": "~55.0.10",
     "expo-status-bar": "~55.0.4",
     "expo-symbols": "~55.0.5",
+    "expo-video": "~55.0.11",
     "expo-web-browser": "~55.0.9",
     "lucide-react-native": "^0.577.0",
     "nativewind": "^4.2.3",

--- a/apps/mobile/scripts/fix-nativewind.js
+++ b/apps/mobile/scripts/fix-nativewind.js
@@ -1,0 +1,30 @@
+/**
+ * Fix NativeWind + TailwindCSS resolution in the monorepo.
+ *
+ * Problem: The web app uses tailwindcss v4 (hoisted to root node_modules).
+ *          NativeWind requires tailwindcss v3 and is also hoisted to root,
+ *          so it resolves tailwindcss v4 and crashes.
+ *
+ * Solution: Copy nativewind (and its peer react-native-css-interop) into
+ *           mobile's local node_modules so it resolves tailwindcss v3
+ *           (which is installed locally here).
+ */
+const fs = require("fs");
+const path = require("path");
+
+const mobileNodeModules = path.resolve(__dirname, "..", "node_modules");
+const rootNodeModules = path.resolve(__dirname, "..", "..", "..", "node_modules");
+
+const packages = ["nativewind", "react-native-css-interop"];
+
+for (const pkg of packages) {
+  const localPath = path.join(mobileNodeModules, pkg);
+  const rootPath = path.join(rootNodeModules, pkg);
+
+  // Skip if already exists locally or doesn't exist at root
+  if (fs.existsSync(path.join(localPath, "package.json"))) continue;
+  if (!fs.existsSync(path.join(rootPath, "package.json"))) continue;
+
+  fs.cpSync(rootPath, localPath, { recursive: true });
+  console.log(`[fix-nativewind] Copied ${pkg} to mobile node_modules`);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
     "apps/mobile": {
       "name": "@mindpoint/mobile",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@clerk/clerk-expo": "^2.19.31",
         "@mindpoint/backend": "*",
@@ -95,7 +96,6 @@
         "convex": "^1.23.0",
         "expo": "~55.0.6",
         "expo-auth-session": "~55.0.9",
-        "expo-av": "^16.0.8",
         "expo-clipboard": "^55.0.9",
         "expo-constants": "~55.0.7",
         "expo-dev-client": "^55.0.18",
@@ -109,6 +109,7 @@
         "expo-splash-screen": "~55.0.10",
         "expo-status-bar": "~55.0.4",
         "expo-symbols": "~55.0.5",
+        "expo-video": "~55.0.11",
         "expo-web-browser": "~55.0.9",
         "lucide-react-native": "^0.577.0",
         "nativewind": "^4.2.3",
@@ -11236,23 +11237,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-av": {
-      "version": "16.0.8",
-      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-16.0.8.tgz",
-      "integrity": "sha512-cmVPftGR/ca7XBgs7R6ky36lF3OC0/MM/lpgX/yXqfv0jASTsh7AYX9JxHCwFmF+Z6JEB1vne9FDx4GiLcGreQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*",
-        "react-native-web": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-web": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/expo-clipboard": {
       "version": "55.0.9",
       "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-55.0.9.tgz",
@@ -11651,6 +11635,17 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-video": {
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/expo-video/-/expo-video-55.0.11.tgz",
+      "integrity": "sha512-XCXcPfzVYx6CgXlbRPH2sgacsNT82T6+euyyFlZsG+iuF5tUOWnMgToTuCmktAkwKDe70pNonoQI9HtZjSfNXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-web-browser": {


### PR DESCRIPTION
## Summary
- Swapped the mobile video testimonial modal from `expo-av` to `expo-video` to restore playback on mobile.
- Simplified the video testimonial card layout and tightened sizing/spacing for smaller screens.
- Standardized several course/community UI wrappers to use explicit React Native styles where NativeWind classes were causing layout issues.
- Added a `postinstall` script to copy `nativewind` and `react-native-css-interop` into the app-local `node_modules` so NativeWind resolves the correct Tailwind version in the monorepo.
- Removed the unused `expo-av` dependency and added `expo-video`.

## Testing
- Not run
- Verified the affected mobile components compile by inspection after replacing `expo-av` usage with `expo-video` APIs.
- Verified the new `postinstall` script targets the mobile app's local dependency resolution path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced video playback in the testimonials section with improved performance and reliability
  * Refined component styling and layouts throughout the mobile app for better visual consistency
  * Updated spacing, sizing, and border styling across course pages for a more polished appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces `expo-av` with `expo-video` for mobile video testimonial playback, standardises several course/community UI components from NativeWind `className` to explicit React Native inline styles (fixing layout breakage caused by NativeWind resolving tailwindcss v4 instead of v3), and introduces a `postinstall` script to patch the monorepo's NativeWind resolution.

**Key changes:**
- `VideoTestimonialsSection.tsx` — swapped `<Video>` (`expo-av`) for `<VideoView>` + `useVideoPlayer` (`expo-video`); UI layout migrated to inline styles.
- `scripts/fix-nativewind.js` — new postinstall helper that copies `nativewind` and `react-native-css-interop` from root `node_modules` into the mobile app's local `node_modules` so they resolve tailwindcss v3 rather than the web app's v4.
- `MasterclassCourse`, `SupervisedCourse`, `TherapyCourse`, `CommunitiesSection`, `Educators`, `WhyChoose` — `className` props on `LinearGradient` and other wrappers replaced with inline style objects.
- `package.json` / `package-lock.json` — `expo-av` removed, `expo-video` added.

**Issues found:**
- **P1 — Video does not auto-play on open.** `useVideoPlayer`'s setup callback runs once when `VideoModal` mounts (when `testimonial` is `null`), so `p.play()` is never called. When a card is tapped, the source is updated on the existing player but setup does not re-run, leaving the video paused — a regression from `shouldPlay`.
- **P2 — Player resources not released on close.** Only `player.pause()` is called; `player.release()` is never invoked, holding native resources for the app's entire lifetime.
- **P2 — Hardcoded three-level path in `fix-nativewind.js`.** A silent failure mode exists if the script ever runs from a different directory depth.
- **P2 — Incomplete NativeWind migration in `CommunitiesSection`.** Two `Pressable` buttons still use NativeWind `className` for layout.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge, but the video auto-play regression (P1) should be fixed before shipping.

The dependency swap and inline-style migrations are correct and low-risk. However, the core video feature — auto-play on open — is broken due to how useVideoPlayer's setup callback is scoped, which is a direct behavioural regression from the expo-av implementation. All other findings are P2.

apps/mobile/components/VideoTestimonialsSection.tsx — VideoModal needs a fix so the video actually plays when the modal opens.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/mobile/components/VideoTestimonialsSection.tsx | Migrated from expo-av to expo-video; video will not auto-play on open due to setup callback running only once at mount when testimonial is null, and player resources are not released on close. |
| apps/mobile/scripts/fix-nativewind.js | New postinstall script copying nativewind/react-native-css-interop from root to local node_modules to fix tailwindcss v3/v4 resolution; works but silently no-ops on path miscalculation. |
| apps/mobile/package.json | Swaps expo-av for expo-video, adds postinstall hook — dependency changes are correct and consistent with package-lock. |
| apps/mobile/components/course/communities-section.tsx | Most styles migrated to inline RN styles, but two Pressable buttons still rely on NativeWind className for layout, inconsistent with the rest of the migration. |
| apps/mobile/components/course/MasterclassCourse.tsx | Single LinearGradient className replaced with explicit inline style — clean, safe change. |
| apps/mobile/components/course/SupervisedCourse.tsx | Two LinearGradient className attributes converted to inline styles — mechanical, correct conversion. |
| apps/mobile/components/course/TherapyCourse.tsx | Four className attributes on LinearGradient replaced with inline styles — consistent with other course component changes. |
| apps/mobile/components/course/educators.tsx | Single LinearGradient className converted to inline style — straightforward, safe change. |
| apps/mobile/components/course/who-should-do.tsx | Removed unused LinearGradient import — clean-up only. |
| apps/mobile/components/course/why-choose.tsx | Single LinearGradient className converted to inline style — safe, correct conversion. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant VTS as VideoTestimonialsSection
    participant VM as VideoModal (always mounted)
    participant P as VideoPlayer

    Note over VM,P: On mount - testimonial is null
    VM->>P: useVideoPlayer(null, setup)
    P-->>VM: player created, setup runs with null - play() NOT called

    U->>VTS: Taps VideoCard
    VTS->>VTS: setSelectedVideo(testimonial), setModalVisible(true)
    VTS->>VM: re-render with real testimonial URL, visible=true
    VM->>P: useVideoPlayer(url) - source updated on existing player
    Note over P: setup does NOT re-run - video loads but stays paused

    U->>VM: Taps close button
    VM->>P: player.pause()
    VM->>VTS: onClose()
    VTS->>VTS: setModalVisible(false)
    VTS->>VTS: setTimeout 200ms then setSelectedVideo(null)
    VTS->>VM: re-render with testimonial=null, visible=false
    VM->>P: source cleared - player idle but never released
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fmobile%2Fcomponents%2FVideoTestimonialsSection.tsx%3A132-136%0A**Video%20will%20not%20auto-play%20when%20modal%20opens**%0A%0A%60useVideoPlayer%60's%20setup%20callback%20runs%20**once%20on%20mount**%20%E2%80%94%20when%20%60VideoModal%60%20is%20first%20rendered%20with%20%60testimonial%3D%7Bnull%7D%60%20%28before%20any%20card%20is%20tapped%29.%20At%20that%20point%2C%20%60if%20%28testimonial%29%60%20is%20%60false%60%2C%20so%20%60p.play%28%29%60%20is%20never%20called.%20Later%2C%20when%20a%20card%20is%20selected%20and%20%60testimonial%60%20changes%20to%20a%20real%20value%2C%20the%20source%20is%20updated%20on%20the%20existing%20player%2C%20but%20the%20setup%20function%20does%20**not**%20re-run.%20The%20video%20will%20load%20and%20appear%2C%20but%20remain%20paused.%0A%0AThis%20is%20a%20regression%20from%20the%20original%20%60shouldPlay%60%20behaviour%20on%20%60expo-av%60's%20%60%3CVideo%3E%60.%0A%0AThe%20most%20reliable%20fix%20is%20to%20move%20%60VideoModal%60%20inside%20a%20conditional%20so%20it%20re-mounts%20each%20time%20a%20video%20is%20selected%20%28new%20mount%20%E2%86%92%20fresh%20setup%20%E2%86%92%20%60play%28%29%60%20called%29%2C%20or%20add%20a%20%60useEffect%60%20to%20imperatively%20play%20on%20open%3A%0A%0A%60%60%60tsx%0A%2F%2F%20Option%20A%20%E2%80%93%20re-mount%20on%20each%20open%20%28simplest%29%0A%7BmodalVisible%20%26%26%20selectedVideo%20%26%26%20%28%0A%20%20%3CVideoModal%0A%20%20%20%20testimonial%3D%7BselectedVideo%7D%0A%20%20%20%20visible%3D%7BmodalVisible%7D%0A%20%20%20%20onClose%3D%7BhandleClose%7D%0A%20%20%2F%3E%0A%29%7D%0A%0A%2F%2F%20Option%20B%20%E2%80%93%20useEffect%20inside%20VideoModal%0AuseEffect%28%28%29%20%3D%3E%20%7B%0A%20%20if%20%28visible%20%26%26%20testimonial%29%20%7B%0A%20%20%20%20player.play%28%29%3B%0A%20%20%7D%0A%7D%2C%20%5Bvisible%2C%20testimonial%5D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Aapps%2Fmobile%2Fcomponents%2FVideoTestimonialsSection.tsx%3A138-141%0A**Consider%20releasing%20the%20player%20on%20close**%0A%0A%60handleClose%60%20only%20calls%20%60player.pause%28%29%60%2C%20but%20the%20%60VideoPlayer%60%20instance%20holds%20native%20audio%2Fvideo%20resources%20%28decoder%2C%20network%20connection%20for%20streaming%29%20for%20the%20lifetime%20of%20%60VideoModal%60.%20Because%20%60VideoModal%60%20is%20always%20rendered%20and%20never%20unmounts%2C%20%60useVideoPlayer%60's%20internal%20cleanup%20never%20fires.%0A%0ACalling%20%60player.release%28%29%60%20when%20the%20modal%20closes%20would%20free%20those%20resources%20promptly%2C%20especially%20relevant%20on%20low-memory%20devices%3A%0A%0A%60%60%60tsx%0Aconst%20handleClose%20%3D%20useCallback%28%28%29%20%3D%3E%20%7B%0A%20%20player.pause%28%29%3B%0A%20%20player.release%28%29%3B%20%2F%2F%20free%20native%20resources%0A%20%20onClose%28%29%3B%0A%7D%2C%20%5Bplayer%2C%20onClose%5D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Aapps%2Fmobile%2Fscripts%2Ffix-nativewind.js%3A16%0A**Hardcoded%20depth%20assumption%20for%20root%20%60node_modules%60**%0A%0AThe%20path%20resolves%20three%20directories%20up%20from%20%60scripts%2F%60%20to%20reach%20the%20monorepo%20root%3A%0A%0A%60%60%60js%0Aconst%20rootNodeModules%20%3D%20path.resolve%28__dirname%2C%20%22..%22%2C%20%22..%22%2C%20%22..%22%2C%20%22node_modules%22%29%3B%0A%60%60%60%0A%0AThis%20assumes%20the%20directory%20layout%20is%20exactly%20%60%3Croot%3E%2Fapps%2Fmobile%2Fscripts%2F%60.%20If%20the%20script%20is%20ever%20moved%20or%20the%20repo%20is%20nested%20differently%2C%20%60rootNodeModules%60%20will%20silently%20point%20to%20the%20wrong%20place.%20Because%20the%20%60if%20%28!fs.existsSync%28...%29%29%20continue%60%20guard%20swallows%20missing-package%20failures%20without%20any%20log%20output%2C%20the%20workaround%20would%20simply%20do%20nothing%20and%20the%20build%20would%20fail%20later%20with%20a%20cryptic%20NativeWind%20error.%0A%0AConsider%20adding%20an%20existence%20check%20with%20an%20explicit%20error%20message%3A%0A%0A%60%60%60js%0Aif%20%28!fs.existsSync%28rootNodeModules%29%29%20%7B%0A%20%20console.error%28%0A%20%20%20%20%60%5Bfix-nativewind%5D%20Root%20node_modules%20not%20found%20at%20%24%7BrootNodeModules%7D.%20Skipping.%60%0A%20%20%29%3B%0A%20%20process.exit%280%29%3B%20%2F%2F%20or%20process.exit%281%29%20to%20surface%20the%20problem%20in%20CI%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fmobile%2Fcomponents%2Fcourse%2Fcommunities-section.tsx%3A61-70%0A**Mixed%20NativeWind%2Finline-style%20approach%20on%20%60Pressable%60%20buttons**%0A%0AThe%20two%20%60Pressable%60%20community%20buttons%20still%20use%20%60className%60%20for%20layout%20%28%60flex-row%20items-center%20justify-center%20gap-3%20rounded-xl%20bg-white%20px-5%20py-3%60%29%2C%20while%20the%20surrounding%20components%20have%20been%20migrated%20to%20explicit%20%60style%60%20props.%20If%20NativeWind%20resolution%20is%20the%20root%20issue%20being%20fixed%20here%2C%20leaving%20these%20%60className%60%20attributes%20means%20the%20buttons%20could%20still%20render%20incorrectly%20when%20the%20NativeWind%20fix%20script%20hasn't%20run.%0A%0AFor%20consistency%20and%20reliability%2C%20consider%20converting%20these%20to%20inline%20styles%20as%20well%20%E2%80%94%20the%20same%20applies%20to%20the%20Instagram%20%60Pressable%60%20below%20it.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fmobile%2Fcomponents%2FVideoTestimonialsSection.tsx%3A132-136%0A**Video%20will%20not%20auto-play%20when%20modal%20opens**%0A%0A%60useVideoPlayer%60's%20setup%20callback%20runs%20**once%20on%20mount**%20%E2%80%94%20when%20%60VideoModal%60%20is%20first%20rendered%20with%20%60testimonial%3D%7Bnull%7D%60%20%28before%20any%20card%20is%20tapped%29.%20At%20that%20point%2C%20%60if%20%28testimonial%29%60%20is%20%60false%60%2C%20so%20%60p.play%28%29%60%20is%20never%20called.%20Later%2C%20when%20a%20card%20is%20selected%20and%20%60testimonial%60%20changes%20to%20a%20real%20value%2C%20the%20source%20is%20updated%20on%20the%20existing%20player%2C%20but%20the%20setup%20function%20does%20**not**%20re-run.%20The%20video%20will%20load%20and%20appear%2C%20but%20remain%20paused.%0A%0AThis%20is%20a%20regression%20from%20the%20original%20%60shouldPlay%60%20behaviour%20on%20%60expo-av%60's%20%60%3CVideo%3E%60.%0A%0AThe%20most%20reliable%20fix%20is%20to%20move%20%60VideoModal%60%20inside%20a%20conditional%20so%20it%20re-mounts%20each%20time%20a%20video%20is%20selected%20%28new%20mount%20%E2%86%92%20fresh%20setup%20%E2%86%92%20%60play%28%29%60%20called%29%2C%20or%20add%20a%20%60useEffect%60%20to%20imperatively%20play%20on%20open%3A%0A%0A%60%60%60tsx%0A%2F%2F%20Option%20A%20%E2%80%93%20re-mount%20on%20each%20open%20%28simplest%29%0A%7BmodalVisible%20%26%26%20selectedVideo%20%26%26%20%28%0A%20%20%3CVideoModal%0A%20%20%20%20testimonial%3D%7BselectedVideo%7D%0A%20%20%20%20visible%3D%7BmodalVisible%7D%0A%20%20%20%20onClose%3D%7BhandleClose%7D%0A%20%20%2F%3E%0A%29%7D%0A%0A%2F%2F%20Option%20B%20%E2%80%93%20useEffect%20inside%20VideoModal%0AuseEffect%28%28%29%20%3D%3E%20%7B%0A%20%20if%20%28visible%20%26%26%20testimonial%29%20%7B%0A%20%20%20%20player.play%28%29%3B%0A%20%20%7D%0A%7D%2C%20%5Bvisible%2C%20testimonial%5D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Aapps%2Fmobile%2Fcomponents%2FVideoTestimonialsSection.tsx%3A138-141%0A**Consider%20releasing%20the%20player%20on%20close**%0A%0A%60handleClose%60%20only%20calls%20%60player.pause%28%29%60%2C%20but%20the%20%60VideoPlayer%60%20instance%20holds%20native%20audio%2Fvideo%20resources%20%28decoder%2C%20network%20connection%20for%20streaming%29%20for%20the%20lifetime%20of%20%60VideoModal%60.%20Because%20%60VideoModal%60%20is%20always%20rendered%20and%20never%20unmounts%2C%20%60useVideoPlayer%60's%20internal%20cleanup%20never%20fires.%0A%0ACalling%20%60player.release%28%29%60%20when%20the%20modal%20closes%20would%20free%20those%20resources%20promptly%2C%20especially%20relevant%20on%20low-memory%20devices%3A%0A%0A%60%60%60tsx%0Aconst%20handleClose%20%3D%20useCallback%28%28%29%20%3D%3E%20%7B%0A%20%20player.pause%28%29%3B%0A%20%20player.release%28%29%3B%20%2F%2F%20free%20native%20resources%0A%20%20onClose%28%29%3B%0A%7D%2C%20%5Bplayer%2C%20onClose%5D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Aapps%2Fmobile%2Fscripts%2Ffix-nativewind.js%3A16%0A**Hardcoded%20depth%20assumption%20for%20root%20%60node_modules%60**%0A%0AThe%20path%20resolves%20three%20directories%20up%20from%20%60scripts%2F%60%20to%20reach%20the%20monorepo%20root%3A%0A%0A%60%60%60js%0Aconst%20rootNodeModules%20%3D%20path.resolve%28__dirname%2C%20%22..%22%2C%20%22..%22%2C%20%22..%22%2C%20%22node_modules%22%29%3B%0A%60%60%60%0A%0AThis%20assumes%20the%20directory%20layout%20is%20exactly%20%60%3Croot%3E%2Fapps%2Fmobile%2Fscripts%2F%60.%20If%20the%20script%20is%20ever%20moved%20or%20the%20repo%20is%20nested%20differently%2C%20%60rootNodeModules%60%20will%20silently%20point%20to%20the%20wrong%20place.%20Because%20the%20%60if%20%28!fs.existsSync%28...%29%29%20continue%60%20guard%20swallows%20missing-package%20failures%20without%20any%20log%20output%2C%20the%20workaround%20would%20simply%20do%20nothing%20and%20the%20build%20would%20fail%20later%20with%20a%20cryptic%20NativeWind%20error.%0A%0AConsider%20adding%20an%20existence%20check%20with%20an%20explicit%20error%20message%3A%0A%0A%60%60%60js%0Aif%20%28!fs.existsSync%28rootNodeModules%29%29%20%7B%0A%20%20console.error%28%0A%20%20%20%20%60%5Bfix-nativewind%5D%20Root%20node_modules%20not%20found%20at%20%24%7BrootNodeModules%7D.%20Skipping.%60%0A%20%20%29%3B%0A%20%20process.exit%280%29%3B%20%2F%2F%20or%20process.exit%281%29%20to%20surface%20the%20problem%20in%20CI%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fmobile%2Fcomponents%2Fcourse%2Fcommunities-section.tsx%3A61-70%0A**Mixed%20NativeWind%2Finline-style%20approach%20on%20%60Pressable%60%20buttons**%0A%0AThe%20two%20%60Pressable%60%20community%20buttons%20still%20use%20%60className%60%20for%20layout%20%28%60flex-row%20items-center%20justify-center%20gap-3%20rounded-xl%20bg-white%20px-5%20py-3%60%29%2C%20while%20the%20surrounding%20components%20have%20been%20migrated%20to%20explicit%20%60style%60%20props.%20If%20NativeWind%20resolution%20is%20the%20root%20issue%20being%20fixed%20here%2C%20leaving%20these%20%60className%60%20attributes%20means%20the%20buttons%20could%20still%20render%20incorrectly%20when%20the%20NativeWind%20fix%20script%20hasn't%20run.%0A%0AFor%20consistency%20and%20reliability%2C%20consider%20converting%20these%20to%20inline%20styles%20as%20well%20%E2%80%94%20the%20same%20applies%20to%20the%20Instagram%20%60Pressable%60%20below%20it.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fmobile%2Fcomponents%2FVideoTestimonialsSection.tsx%3A132-136%0A**Video%20will%20not%20auto-play%20when%20modal%20opens**%0A%0A%60useVideoPlayer%60's%20setup%20callback%20runs%20**once%20on%20mount**%20%E2%80%94%20when%20%60VideoModal%60%20is%20first%20rendered%20with%20%60testimonial%3D%7Bnull%7D%60%20%28before%20any%20card%20is%20tapped%29.%20At%20that%20point%2C%20%60if%20%28testimonial%29%60%20is%20%60false%60%2C%20so%20%60p.play%28%29%60%20is%20never%20called.%20Later%2C%20when%20a%20card%20is%20selected%20and%20%60testimonial%60%20changes%20to%20a%20real%20value%2C%20the%20source%20is%20updated%20on%20the%20existing%20player%2C%20but%20the%20setup%20function%20does%20**not**%20re-run.%20The%20video%20will%20load%20and%20appear%2C%20but%20remain%20paused.%0A%0AThis%20is%20a%20regression%20from%20the%20original%20%60shouldPlay%60%20behaviour%20on%20%60expo-av%60's%20%60%3CVideo%3E%60.%0A%0AThe%20most%20reliable%20fix%20is%20to%20move%20%60VideoModal%60%20inside%20a%20conditional%20so%20it%20re-mounts%20each%20time%20a%20video%20is%20selected%20%28new%20mount%20%E2%86%92%20fresh%20setup%20%E2%86%92%20%60play%28%29%60%20called%29%2C%20or%20add%20a%20%60useEffect%60%20to%20imperatively%20play%20on%20open%3A%0A%0A%60%60%60tsx%0A%2F%2F%20Option%20A%20%E2%80%93%20re-mount%20on%20each%20open%20%28simplest%29%0A%7BmodalVisible%20%26%26%20selectedVideo%20%26%26%20%28%0A%20%20%3CVideoModal%0A%20%20%20%20testimonial%3D%7BselectedVideo%7D%0A%20%20%20%20visible%3D%7BmodalVisible%7D%0A%20%20%20%20onClose%3D%7BhandleClose%7D%0A%20%20%2F%3E%0A%29%7D%0A%0A%2F%2F%20Option%20B%20%E2%80%93%20useEffect%20inside%20VideoModal%0AuseEffect%28%28%29%20%3D%3E%20%7B%0A%20%20if%20%28visible%20%26%26%20testimonial%29%20%7B%0A%20%20%20%20player.play%28%29%3B%0A%20%20%7D%0A%7D%2C%20%5Bvisible%2C%20testimonial%5D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Aapps%2Fmobile%2Fcomponents%2FVideoTestimonialsSection.tsx%3A138-141%0A**Consider%20releasing%20the%20player%20on%20close**%0A%0A%60handleClose%60%20only%20calls%20%60player.pause%28%29%60%2C%20but%20the%20%60VideoPlayer%60%20instance%20holds%20native%20audio%2Fvideo%20resources%20%28decoder%2C%20network%20connection%20for%20streaming%29%20for%20the%20lifetime%20of%20%60VideoModal%60.%20Because%20%60VideoModal%60%20is%20always%20rendered%20and%20never%20unmounts%2C%20%60useVideoPlayer%60's%20internal%20cleanup%20never%20fires.%0A%0ACalling%20%60player.release%28%29%60%20when%20the%20modal%20closes%20would%20free%20those%20resources%20promptly%2C%20especially%20relevant%20on%20low-memory%20devices%3A%0A%0A%60%60%60tsx%0Aconst%20handleClose%20%3D%20useCallback%28%28%29%20%3D%3E%20%7B%0A%20%20player.pause%28%29%3B%0A%20%20player.release%28%29%3B%20%2F%2F%20free%20native%20resources%0A%20%20onClose%28%29%3B%0A%7D%2C%20%5Bplayer%2C%20onClose%5D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Aapps%2Fmobile%2Fscripts%2Ffix-nativewind.js%3A16%0A**Hardcoded%20depth%20assumption%20for%20root%20%60node_modules%60**%0A%0AThe%20path%20resolves%20three%20directories%20up%20from%20%60scripts%2F%60%20to%20reach%20the%20monorepo%20root%3A%0A%0A%60%60%60js%0Aconst%20rootNodeModules%20%3D%20path.resolve%28__dirname%2C%20%22..%22%2C%20%22..%22%2C%20%22..%22%2C%20%22node_modules%22%29%3B%0A%60%60%60%0A%0AThis%20assumes%20the%20directory%20layout%20is%20exactly%20%60%3Croot%3E%2Fapps%2Fmobile%2Fscripts%2F%60.%20If%20the%20script%20is%20ever%20moved%20or%20the%20repo%20is%20nested%20differently%2C%20%60rootNodeModules%60%20will%20silently%20point%20to%20the%20wrong%20place.%20Because%20the%20%60if%20%28!fs.existsSync%28...%29%29%20continue%60%20guard%20swallows%20missing-package%20failures%20without%20any%20log%20output%2C%20the%20workaround%20would%20simply%20do%20nothing%20and%20the%20build%20would%20fail%20later%20with%20a%20cryptic%20NativeWind%20error.%0A%0AConsider%20adding%20an%20existence%20check%20with%20an%20explicit%20error%20message%3A%0A%0A%60%60%60js%0Aif%20%28!fs.existsSync%28rootNodeModules%29%29%20%7B%0A%20%20console.error%28%0A%20%20%20%20%60%5Bfix-nativewind%5D%20Root%20node_modules%20not%20found%20at%20%24%7BrootNodeModules%7D.%20Skipping.%60%0A%20%20%29%3B%0A%20%20process.exit%280%29%3B%20%2F%2F%20or%20process.exit%281%29%20to%20surface%20the%20problem%20in%20CI%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fmobile%2Fcomponents%2Fcourse%2Fcommunities-section.tsx%3A61-70%0A**Mixed%20NativeWind%2Finline-style%20approach%20on%20%60Pressable%60%20buttons**%0A%0AThe%20two%20%60Pressable%60%20community%20buttons%20still%20use%20%60className%60%20for%20layout%20%28%60flex-row%20items-center%20justify-center%20gap-3%20rounded-xl%20bg-white%20px-5%20py-3%60%29%2C%20while%20the%20surrounding%20components%20have%20been%20migrated%20to%20explicit%20%60style%60%20props.%20If%20NativeWind%20resolution%20is%20the%20root%20issue%20being%20fixed%20here%2C%20leaving%20these%20%60className%60%20attributes%20means%20the%20buttons%20could%20still%20render%20incorrectly%20when%20the%20NativeWind%20fix%20script%20hasn't%20run.%0A%0AFor%20consistency%20and%20reliability%2C%20consider%20converting%20these%20to%20inline%20styles%20as%20well%20%E2%80%94%20the%20same%20applies%20to%20the%20Instagram%20%60Pressable%60%20below%20it.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix All in Cursor" src="https://img.shields.io/badge/Fix_All_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/mobile/components/VideoTestimonialsSection.tsx
Line: 132-136

Comment:
**Video will not auto-play when modal opens**

`useVideoPlayer`'s setup callback runs **once on mount** — when `VideoModal` is first rendered with `testimonial={null}` (before any card is tapped). At that point, `if (testimonial)` is `false`, so `p.play()` is never called. Later, when a card is selected and `testimonial` changes to a real value, the source is updated on the existing player, but the setup function does **not** re-run. The video will load and appear, but remain paused.

This is a regression from the original `shouldPlay` behaviour on `expo-av`'s `<Video>`.

The most reliable fix is to move `VideoModal` inside a conditional so it re-mounts each time a video is selected (new mount → fresh setup → `play()` called), or add a `useEffect` to imperatively play on open:

```tsx
// Option A – re-mount on each open (simplest)
{modalVisible && selectedVideo && (
  <VideoModal
    testimonial={selectedVideo}
    visible={modalVisible}
    onClose={handleClose}
  />
)}

// Option B – useEffect inside VideoModal
useEffect(() => {
  if (visible && testimonial) {
    player.play();
  }
}, [visible, testimonial]);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/mobile/components/VideoTestimonialsSection.tsx
Line: 138-141

Comment:
**Consider releasing the player on close**

`handleClose` only calls `player.pause()`, but the `VideoPlayer` instance holds native audio/video resources (decoder, network connection for streaming) for the lifetime of `VideoModal`. Because `VideoModal` is always rendered and never unmounts, `useVideoPlayer`'s internal cleanup never fires.

Calling `player.release()` when the modal closes would free those resources promptly, especially relevant on low-memory devices:

```tsx
const handleClose = useCallback(() => {
  player.pause();
  player.release(); // free native resources
  onClose();
}, [player, onClose]);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/mobile/scripts/fix-nativewind.js
Line: 16

Comment:
**Hardcoded depth assumption for root `node_modules`**

The path resolves three directories up from `scripts/` to reach the monorepo root:

```js
const rootNodeModules = path.resolve(__dirname, "..", "..", "..", "node_modules");
```

This assumes the directory layout is exactly `<root>/apps/mobile/scripts/`. If the script is ever moved or the repo is nested differently, `rootNodeModules` will silently point to the wrong place. Because the `if (!fs.existsSync(...)) continue` guard swallows missing-package failures without any log output, the workaround would simply do nothing and the build would fail later with a cryptic NativeWind error.

Consider adding an existence check with an explicit error message:

```js
if (!fs.existsSync(rootNodeModules)) {
  console.error(
    `[fix-nativewind] Root node_modules not found at ${rootNodeModules}. Skipping.`
  );
  process.exit(0); // or process.exit(1) to surface the problem in CI
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/mobile/components/course/communities-section.tsx
Line: 61-70

Comment:
**Mixed NativeWind/inline-style approach on `Pressable` buttons**

The two `Pressable` community buttons still use `className` for layout (`flex-row items-center justify-center gap-3 rounded-xl bg-white px-5 py-3`), while the surrounding components have been migrated to explicit `style` props. If NativeWind resolution is the root issue being fixed here, leaving these `className` attributes means the buttons could still render incorrectly when the NativeWind fix script hasn't run.

For consistency and reliability, consider converting these to inline styles as well — the same applies to the Instagram `Pressable` below it.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["update lock file"](https://github.com/ayushj1001/mindpoint/commit/6ef1920a4708c7d3dc60bc5bd9dcc9b0e4605078) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26675806)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->