### PR TITLE
Add course schedule display and admin course fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# snapshots / archives
+*.zip
+
 # dependencies
 /node_modules
 **/node_modules/

--- a/apps/web/app/admin/courses/[courseId]/page.tsx
+++ b/apps/web/app/admin/courses/[courseId]/page.tsx
@@ -78,6 +78,11 @@ export default function AdminEditCoursePage() {
         description="Update metadata, offers, BOGO, lifecycle, and assets."
         actions={
           <>
+            <Button variant="outline" asChild>
+              <Link href={`/courses/${courseId}`} target="_blank">
+                Open Course Page
+              </Link>
+            </Button>
             <Button
               variant="outline"
               onClick={() => void runTransition("draft")}

--- a/apps/web/app/admin/courses/page.tsx
+++ b/apps/web/app/admin/courses/page.tsx
@@ -37,6 +37,16 @@ type CourseTypeFilter =
 
 type OfferFilter = "all" | "discount" | "bogo" | "both" | "none";
 
+type CourseTypeIssue = {
+  courseId: Id<"courses">;
+  name: string;
+  code: string | null;
+  lifecycleStatus: "draft" | "published" | "archived" | null;
+  currentType: Exclude<CourseTypeFilter, "all"> | null;
+  suggestedType: Exclude<CourseTypeFilter, "all">;
+  reason: string;
+};
+
 const courseTypeOptions: CourseTypeFilter[] = [
   "all",
   "certificate",
@@ -65,6 +75,9 @@ export default function AdminCoursesPage() {
     nextStatus: "draft" | "published" | "archived";
   } | null>(null);
   const [isTransitioning, setIsTransitioning] = useState(false);
+  const [fixingCourseId, setFixingCourseId] = useState<Id<"courses"> | null>(
+    null,
+  );
 
   const courses = useQuery(api.adminCourses.listCourses, {
     search: search || undefined,
@@ -72,9 +85,13 @@ export default function AdminCoursesPage() {
     type: courseType === "all" ? undefined : courseType,
     limit: 500,
   });
+  const courseTypeIssues = useQuery(api.adminCourses.listCourseTypeIssues, {
+    limit: 50,
+  }) as CourseTypeIssue[] | undefined;
   const transitionCourse = useMutation(
     api.adminCourses.transitionCourseLifecycle,
   );
+  const correctCourseType = useMutation(api.adminCourses.correctCourseType);
 
   const rows = useMemo(() => courses ?? [], [courses]);
 
@@ -139,6 +156,26 @@ export default function AdminCoursesPage() {
     }
   };
 
+  const applySuggestedTypeFix = async (issue: CourseTypeIssue) => {
+    try {
+      setFixingCourseId(issue.courseId);
+      await correctCourseType({
+        courseId: issue.courseId,
+        type: issue.suggestedType,
+        reason: issue.reason,
+      });
+      toast.success(
+        `"${issue.name}" updated from ${issue.currentType || "missing"} to ${issue.suggestedType}`,
+      );
+    } catch (error) {
+      toast.error(
+        getUserFacingErrorMessage(error, "Failed to update course type"),
+      );
+    } finally {
+      setFixingCourseId(null);
+    }
+  };
+
   return (
     <div>
       <AdminPageHeader
@@ -177,7 +214,78 @@ export default function AdminCoursesPage() {
         >
           Offers
         </Button>
+        {courseTypeIssues && courseTypeIssues.length > 0 ? (
+          <Badge variant="outline" className="self-center">
+            {courseTypeIssues.length} type issue
+            {courseTypeIssues.length === 1 ? "" : "s"}
+          </Badge>
+        ) : null}
       </div>
+
+      {view === "catalog" &&
+      courseTypeIssues &&
+      courseTypeIssues.length > 0 ? (
+        <div className="mb-4 overflow-hidden rounded-lg border border-amber-200 bg-white">
+          <div className="border-b border-amber-200 bg-amber-50 px-4 py-3">
+            <h2 className="text-sm font-semibold text-amber-950">
+              Course Type Integrity
+            </h2>
+            <p className="mt-0.5 text-xs text-amber-800">
+              Records whose stored type looks inconsistent with their code
+              prefix. Fixes patch the DB record directly.
+            </p>
+          </div>
+          <table className="w-full text-left text-sm">
+            <thead className="bg-slate-50 text-xs tracking-wide text-slate-600 uppercase">
+              <tr>
+                <th className="px-3 py-2">Course</th>
+                <th className="px-3 py-2">Current</th>
+                <th className="px-3 py-2">Suggested</th>
+                <th className="px-3 py-2">Reason</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {courseTypeIssues.map((issue) => (
+                <tr key={issue.courseId} className="border-t">
+                  <td className="px-3 py-2">
+                    <p className="font-medium text-slate-900">{issue.name}</p>
+                    <p className="text-xs text-slate-600">
+                      {issue.code || "No code"} •{" "}
+                      {issue.lifecycleStatus || "published"}
+                    </p>
+                  </td>
+                  <td className="px-3 py-2">{issue.currentType || "-"}</td>
+                  <td className="px-3 py-2 font-medium text-amber-950">
+                    {issue.suggestedType}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-slate-700">
+                    {issue.reason}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button variant="outline" size="sm" asChild>
+                        <Link href={`/admin/courses/${issue.courseId}`}>
+                          Open
+                        </Link>
+                      </Button>
+                      <Button
+                        size="sm"
+                        disabled={fixingCourseId === issue.courseId}
+                        onClick={() => void applySuggestedTypeFix(issue)}
+                      >
+                        {fixingCourseId === issue.courseId
+                          ? "Applying..."
+                          : "Apply Fix"}
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
 
       <div className="mb-4 grid gap-3 md:grid-cols-4">
         <Input
@@ -289,6 +397,11 @@ export default function AdminCoursesPage() {
                         <Button variant="outline" size="sm" asChild>
                           <Link href={`/admin/courses/${course._id}`}>
                             Open
+                          </Link>
+                        </Button>
+                        <Button variant="outline" size="sm" asChild>
+                          <Link href={`/courses/${course._id}`} target="_blank">
+                            View Page
                           </Link>
                         </Button>
                         {(["draft", "published", "archived"] as const).map(
@@ -413,11 +526,18 @@ export default function AdminCoursesPage() {
                         </div>
                       </td>
                       <td className="px-3 py-2">
-                        <Button variant="outline" size="sm" asChild>
-                          <Link href={`/admin/courses/${course._id}`}>
-                            Edit offer
-                          </Link>
-                        </Button>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Button variant="outline" size="sm" asChild>
+                            <Link href={`/admin/courses/${course._id}`}>
+                              Edit offer
+                            </Link>
+                          </Button>
+                          <Button variant="outline" size="sm" asChild>
+                            <Link href={`/courses/${course._id}`} target="_blank">
+                              View Page
+                            </Link>
+                          </Button>
+                        </div>
                       </td>
                     </tr>
                   );

--- a/apps/web/app/admin/enrollments/[enrollmentId]/page.tsx
+++ b/apps/web/app/admin/enrollments/[enrollmentId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useParams } from "next/navigation";
+import Link from "next/link";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@mindpoint/backend/api";
 import type { Id } from "@mindpoint/backend/data-model";
@@ -101,6 +102,18 @@ export default function AdminEnrollmentDetailPage() {
       <AdminPageHeader
         title={`Enrollment ${detail.enrollmentNumber}`}
         description="View complete timeline and execute transfer/cancel operations."
+        actions={
+          <>
+            <Button variant="outline" asChild>
+              <Link href={`/admin/courses/${detail.courseId}`}>Admin Course</Link>
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href={`/courses/${detail.courseId}`} target="_blank">
+                Live Course Page
+              </Link>
+            </Button>
+          </>
+        }
       />
 
       <Card>
@@ -160,6 +173,12 @@ export default function AdminEnrollmentDetailPage() {
           <p>
             <strong>Registration Source:</strong>{" "}
             {detail.registrationSource || "checkout"}
+          </p>
+          <p>
+            <strong>Last Confirmation Email:</strong>{" "}
+            {detail.lastConfirmationSentAt
+              ? formatTimestamp(detail.lastConfirmationSentAt)
+              : "Not resent yet"}
           </p>
         </CardContent>
       </Card>

--- a/apps/web/app/admin/enrollments/page.tsx
+++ b/apps/web/app/admin/enrollments/page.tsx
@@ -23,6 +23,7 @@ import { showRupees } from "@/lib/utils";
 
 export default function AdminEnrollmentsPage() {
   const [search, setSearch] = useState("");
+  const [courseId, setCourseId] = useState("all");
   const [status, setStatus] = useState<
     "all" | "active" | "cancelled" | "transferred"
   >("all");
@@ -49,6 +50,7 @@ export default function AdminEnrollmentsPage() {
   const enrollments = useQuery(api.adminEnrollments.listEnrollments, {
     search: search || undefined,
     status: status === "all" ? undefined : status,
+    courseId: courseId === "all" ? undefined : (courseId as Id<"courses">),
     limit: 500,
   });
 
@@ -76,13 +78,23 @@ export default function AdminEnrollmentsPage() {
         userId: row.userId,
         userName: row.userName,
         userEmail: row.userEmail,
+        userPhone: row.userPhone ?? "",
         courseName: row.courseName,
+        courseType: row.courseType,
         enrollmentNumber: row.enrollmentNumber,
         status: row.status,
+        registrationSource: row.registrationSource ?? "checkout",
         amountPaid: row.amountPaid ?? row.checkoutPrice ?? 0,
+        checkoutPrice: row.checkoutPrice ?? 0,
+        listedPrice: row.listedPrice ?? 0,
         mindPointsRedeemed: row.mindPointsRedeemed ?? 0,
         couponCode: row.couponCode ?? "",
         registeredAt: new Date(row._creationTime).toISOString(),
+        lastConfirmationSentAt: row.lastConfirmationSentAt
+          ? new Date(row.lastConfirmationSentAt).toISOString()
+          : "",
+        adminCourseUrl: `/admin/courses/${row.courseId}`,
+        publicCourseUrl: `/courses/${row.courseId}`,
       })),
     [rows],
   );
@@ -182,7 +194,7 @@ export default function AdminEnrollmentsPage() {
     <div>
       <AdminPageHeader
         title="Enrollments"
-        description="Run manual enrollments, cancellations, and monitor transfer/cancel status."
+        description="Single registration hub for website checkout, admin/manual adds, email resend history, and CSV export for Excel."
         actions={
           <Button
             variant="outline"
@@ -299,6 +311,18 @@ export default function AdminEnrollmentsPage() {
         />
         <select
           className="h-10 rounded-md border bg-white px-3 text-sm"
+          value={courseId}
+          onChange={(e) => setCourseId(e.target.value)}
+        >
+          <option value="all">All courses</option>
+          {(courses || []).map((course) => (
+            <option key={course._id} value={course._id}>
+              {course.name}
+            </option>
+          ))}
+        </select>
+        <select
+          className="h-10 rounded-md border bg-white px-3 text-sm"
           value={status}
           onChange={(e) =>
             setStatus(
@@ -319,24 +343,23 @@ export default function AdminEnrollmentsPage() {
             <tr>
               <th className="px-3 py-2">User</th>
               <th className="px-3 py-2">Course</th>
-              <th className="px-3 py-2">Enrollment #</th>
               <th className="px-3 py-2">Status</th>
               <th className="px-3 py-2">Paid</th>
               <th className="px-3 py-2">Mind Points</th>
-              <th className="px-3 py-2">Registered</th>
+              <th className="px-3 py-2">Registered / Email</th>
               <th className="px-3 py-2">Actions</th>
             </tr>
           </thead>
           <tbody>
             {!enrollments ? (
               <tr>
-                <td className="px-3 py-4 text-slate-600" colSpan={8}>
+                <td className="px-3 py-4 text-slate-600" colSpan={7}>
                   Loading enrollments...
                 </td>
               </tr>
             ) : rows.length === 0 ? (
               <tr>
-                <td className="px-3 py-4 text-slate-600" colSpan={8}>
+                <td className="px-3 py-4 text-slate-600" colSpan={7}>
                   No enrollments found.
                 </td>
               </tr>
@@ -349,12 +372,23 @@ export default function AdminEnrollmentsPage() {
                     </p>
                     <p className="text-xs text-slate-600">
                       {row.userEmail || row.userId}
+                      {row.userPhone ? ` • ${row.userPhone}` : ""}
                     </p>
                   </td>
-                  <td className="px-3 py-2">{row.courseName || "-"}</td>
-                  <td className="px-3 py-2">{row.enrollmentNumber}</td>
+                  <td className="px-3 py-2">
+                    <p className="font-medium text-slate-900">
+                      {row.courseName || "-"}
+                    </p>
+                    <p className="text-xs text-slate-600">
+                      {row.courseType || "course"} • {row.enrollmentNumber}
+                    </p>
+                  </td>
                   <td className="px-3 py-2">
                     <Badge variant="outline">{row.status}</Badge>
+                    <p className="mt-1 text-xs text-slate-500">
+                      {row.registrationSource || "checkout"}
+                      {row.isGuestUser ? " (guest)" : ""}
+                    </p>
                   </td>
                   <td className="px-3 py-2 text-xs text-slate-700">
                     <p>
@@ -385,7 +419,13 @@ export default function AdminEnrollmentsPage() {
                     )}
                   </td>
                   <td className="px-3 py-2 text-xs text-slate-600">
-                    {formatTimestamp(row._creationTime)}
+                    <p>{formatTimestamp(row._creationTime)}</p>
+                    <p className="text-slate-500">
+                      Last resent:{" "}
+                      {row.lastConfirmationSentAt
+                        ? formatTimestamp(row.lastConfirmationSentAt)
+                        : "—"}
+                    </p>
                   </td>
                   <td className="px-3 py-2">
                     <div className="flex gap-2">

--- a/apps/web/components/CourseTypePage.tsx
+++ b/apps/web/components/CourseTypePage.tsx
@@ -19,8 +19,12 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "../components/ui/carousel";
-import { Plus, BookOpen } from "lucide-react";
+import { Plus, BookOpen, Calendar, Clock } from "lucide-react";
 import { showRupees, getOfferDetails, getCoursePrice } from "@/lib/utils";
+import {
+  getCourseScheduleLines,
+  shouldShowCourseTiming,
+} from "@/lib/course-schedule";
 import type {
   CourseLike,
   PublicCourse,
@@ -290,6 +294,7 @@ const CourseGroupCard = ({
   };
 
   const displayPrice = getCoursePrice(selectedCourse);
+  const scheduleLines = getCourseScheduleLines(selectedCourse);
 
   return (
     <Card
@@ -441,6 +446,21 @@ const CourseGroupCard = ({
             </Select>
           )}
         </div>
+
+        {shouldShowCourseTiming(selectedCourse) && scheduleLines.length > 0 ? (
+          <div className="mb-2 space-y-1 text-xs text-slate-600">
+            {scheduleLines.map((line, index) => (
+              <div key={line} className="flex items-center gap-1.5">
+                {index === 0 ? (
+                  <Calendar className="h-3.5 w-3.5 shrink-0" />
+                ) : (
+                  <Clock className="h-3.5 w-3.5 shrink-0" />
+                )}
+                <span className="line-clamp-1">{line}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
 
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0 space-y-1">
@@ -655,6 +675,7 @@ const CourseCard = ({
   };
 
   const displayPrice = getCoursePrice(course);
+  const scheduleLines = getCourseScheduleLines(course);
 
   return (
     <Card
@@ -712,6 +733,20 @@ const CourseCard = ({
         </div>
       </CardHeader>
       <CardContent className="pt-0 pb-6">
+        {shouldShowCourseTiming(course) && scheduleLines.length > 0 ? (
+          <div className="mb-2 space-y-1 text-xs text-slate-600">
+            {scheduleLines.map((line, index) => (
+              <div key={line} className="flex items-center gap-1.5">
+                {index === 0 ? (
+                  <Calendar className="h-3.5 w-3.5 shrink-0" />
+                ) : (
+                  <Clock className="h-3.5 w-3.5 shrink-0" />
+                )}
+                <span className="line-clamp-1">{line}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <Badge
             variant="secondary"

--- a/apps/web/components/admin/CourseEditor.tsx
+++ b/apps/web/components/admin/CourseEditor.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ChangeEvent,
+  type FormEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@mindpoint/backend/api";
 import type { Doc, Id } from "@mindpoint/backend/data-model";
@@ -13,6 +20,12 @@ import { toast } from "sonner";
 import { UploadDropzone } from "@/lib/uploadthing";
 import { getUserFacingErrorMessage } from "@/lib/convex-error";
 import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
+import {
+  defaultEmotionalHooks,
+  defaultOutcomes,
+  defaultPainPoints,
+  defaultWhyDifferent,
+} from "@/lib/course-content-data";
 import {
   convertPlainDateTimeBetweenTimeZones,
   formatDateWindow,
@@ -185,8 +198,26 @@ function hasText(value: string | undefined | null): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function getDefaultMarketingState(type: CourseType) {
+  return {
+    emotionalHook: defaultEmotionalHooks[type] || "",
+    painPoints: [...(defaultPainPoints[type] || [])],
+    outcomes: [...(defaultOutcomes[type] || [])],
+    whyDifferent: [...(defaultWhyDifferent[type] || [])],
+  };
+}
+
+function matchesStringArray(value: string[], other: string[]): boolean {
+  if (value.length !== other.length) {
+    return false;
+  }
+
+  return value.every((item, index) => item === other[index]);
+}
+
 function toInitialState(course?: Doc<"courses">): CourseFormState {
   const type = (course?.type as CourseType) || "certificate";
+  const defaultMarketing = getDefaultMarketingState(type);
   const defaultVariants =
     sessionTypes.has(type) && !course
       ? defaultSessionVariants()
@@ -234,10 +265,19 @@ function toInitialState(course?: Doc<"courses">): CourseFormState {
     fileUrl: course?.fileUrl || "",
     worksheetDescription: course?.worksheetDescription || "",
     targetAudience: (course?.targetAudience || []).join(", "),
-    emotionalHook: course?.emotionalHook || "",
-    painPoints: course?.painPoints || [],
-    outcomes: course?.outcomes || [],
-    whyDifferent: course?.whyDifferent || [],
+    emotionalHook: course?.emotionalHook || defaultMarketing.emotionalHook,
+    painPoints:
+      course?.painPoints && course.painPoints.length > 0
+        ? course.painPoints
+        : defaultMarketing.painPoints,
+    outcomes:
+      course?.outcomes && course.outcomes.length > 0
+        ? course.outcomes
+        : defaultMarketing.outcomes,
+    whyDifferent:
+      course?.whyDifferent && course.whyDifferent.length > 0
+        ? course.whyDifferent
+        : defaultMarketing.whyDifferent,
     lifecycleStatus:
       (course?.lifecycleStatus as CourseLifecycleStatus | undefined) || "draft",
     offerName: course?.offer?.name || "",
@@ -272,6 +312,8 @@ export function CourseEditor({
   const [isSaving, setIsSaving] = useState(false);
   const [emotionalContentOpen, setEmotionalContentOpen] = useState(false);
   const [selectedCampaignId, setSelectedCampaignId] = useState("");
+  const [usesPlainTextScheduleInputs, setUsesPlainTextScheduleInputs] =
+    useState(false);
   const courseVersion = course
     ? `${course._id}:${course.updatedAt ?? course._creationTime}`
     : "new";
@@ -279,6 +321,7 @@ export function CourseEditor({
     useAdminTimeZone();
   const previousTimeZoneRef = useRef(timeZone);
   const hasHydratedTimeZoneRef = useRef(false);
+  const previousCourseTypeRef = useRef(state.type);
 
   const campaigns = useQuery(api.adminOffers.listCampaigns, {
     includeArchived: false,
@@ -295,6 +338,18 @@ export function CourseEditor({
     setInitialSnapshot(JSON.stringify(nextInitialState));
     setSelectedCampaignId("");
   }, [course, courseVersion]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const userAgent = window.navigator.userAgent;
+    const isSafari =
+      /Safari/i.test(userAgent) &&
+      !/Chrome|Chromium|CriOS|EdgiOS|FxiOS|Firefox|Android/i.test(userAgent);
+    setUsesPlainTextScheduleInputs(isSafari);
+  }, []);
 
   useEffect(() => {
     if (!isHydrated) {
@@ -342,6 +397,42 @@ export function CourseEditor({
       return nextState;
     });
   }, [isHydrated, timeZone]);
+
+  useEffect(() => {
+    const previousType = previousCourseTypeRef.current;
+    if (previousType === state.type) {
+      return;
+    }
+
+    previousCourseTypeRef.current = state.type;
+
+    const previousDefaults = getDefaultMarketingState(previousType);
+    const nextDefaults = getDefaultMarketingState(state.type);
+
+    setState((current) => ({
+      ...current,
+      emotionalHook:
+        !hasText(current.emotionalHook) ||
+        current.emotionalHook === previousDefaults.emotionalHook
+          ? nextDefaults.emotionalHook
+          : current.emotionalHook,
+      painPoints:
+        current.painPoints.length === 0 ||
+        matchesStringArray(current.painPoints, previousDefaults.painPoints)
+          ? nextDefaults.painPoints
+          : current.painPoints,
+      outcomes:
+        current.outcomes.length === 0 ||
+        matchesStringArray(current.outcomes, previousDefaults.outcomes)
+          ? nextDefaults.outcomes
+          : current.outcomes,
+      whyDifferent:
+        current.whyDifferent.length === 0 ||
+        matchesStringArray(current.whyDifferent, previousDefaults.whyDifferent)
+          ? nextDefaults.whyDifferent
+          : current.whyDifferent,
+    }));
+  }, [state.type]);
 
   const isWorksheet = state.type === "worksheet";
   const isInternship = state.type === "internship";
@@ -837,6 +928,19 @@ export function CourseEditor({
     }
   };
 
+  const buildScheduleInputProps = (
+    key: "startDate" | "endDate" | "startTime" | "endTime",
+  ) => ({
+    value: state[key],
+    onChange: (e: ChangeEvent<HTMLInputElement>) =>
+      setState((prev) => ({ ...prev, [key]: e.target.value })),
+    onInput: (e: FormEvent<HTMLInputElement>) =>
+      setState((prev) => ({
+        ...prev,
+        [key]: e.currentTarget.value,
+      })),
+  });
+
   return (
     <div className="space-y-6">
       <div className="sticky top-4 z-20 rounded-lg border border-slate-200 bg-white/95 p-4 shadow-sm backdrop-blur">
@@ -1009,47 +1113,78 @@ export function CourseEditor({
             <div className="space-y-2">
               <Label>Start Date</Label>
               <Input
-                type="date"
-                value={state.startDate}
-                onChange={(e) =>
-                  setState((prev) => ({ ...prev, startDate: e.target.value }))
+                type={usesPlainTextScheduleInputs ? "text" : "date"}
+                inputMode={usesPlainTextScheduleInputs ? "numeric" : undefined}
+                placeholder={
+                  usesPlainTextScheduleInputs ? "YYYY-MM-DD" : undefined
                 }
+                pattern={
+                  usesPlainTextScheduleInputs
+                    ? "\\d{4}-\\d{2}-\\d{2}"
+                    : undefined
+                }
+                lang="en-CA"
+                autoComplete="off"
+                {...buildScheduleInputProps("startDate")}
               />
             </div>
 
             <div className="space-y-2">
               <Label>End Date</Label>
               <Input
-                type="date"
-                value={state.endDate}
-                onChange={(e) =>
-                  setState((prev) => ({ ...prev, endDate: e.target.value }))
+                type={usesPlainTextScheduleInputs ? "text" : "date"}
+                inputMode={usesPlainTextScheduleInputs ? "numeric" : undefined}
+                placeholder={
+                  usesPlainTextScheduleInputs ? "YYYY-MM-DD" : undefined
                 }
+                pattern={
+                  usesPlainTextScheduleInputs
+                    ? "\\d{4}-\\d{2}-\\d{2}"
+                    : undefined
+                }
+                lang="en-CA"
+                autoComplete="off"
+                {...buildScheduleInputProps("endDate")}
               />
             </div>
 
             <div className="space-y-2">
               <Label>Start Time</Label>
               <Input
-                type="time"
-                value={state.startTime}
-                onChange={(e) =>
-                  setState((prev) => ({ ...prev, startTime: e.target.value }))
+                type={usesPlainTextScheduleInputs ? "text" : "time"}
+                inputMode={usesPlainTextScheduleInputs ? "numeric" : undefined}
+                placeholder={usesPlainTextScheduleInputs ? "HH:MM" : undefined}
+                pattern={
+                  usesPlainTextScheduleInputs ? "\\d{2}:\\d{2}" : undefined
                 }
+                step="60"
+                autoComplete="off"
+                {...buildScheduleInputProps("startTime")}
               />
             </div>
 
             <div className="space-y-2">
               <Label>End Time</Label>
               <Input
-                type="time"
-                value={state.endTime}
-                onChange={(e) =>
-                  setState((prev) => ({ ...prev, endTime: e.target.value }))
+                type={usesPlainTextScheduleInputs ? "text" : "time"}
+                inputMode={usesPlainTextScheduleInputs ? "numeric" : undefined}
+                placeholder={usesPlainTextScheduleInputs ? "HH:MM" : undefined}
+                pattern={
+                  usesPlainTextScheduleInputs ? "\\d{2}:\\d{2}" : undefined
                 }
+                step="60"
+                autoComplete="off"
+                {...buildScheduleInputProps("endTime")}
               />
             </div>
           </div>
+
+          {usesPlainTextScheduleInputs ? (
+            <p className="text-xs text-slate-500">
+              Safari fallback is active. Enter dates as `YYYY-MM-DD` and times
+              as `HH:MM`.
+            </p>
+          ) : null}
 
           {scheduleStartPreview || scheduleEndPreview ? (
             <div className="rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-900">

--- a/apps/web/components/course-card.tsx
+++ b/apps/web/components/course-card.tsx
@@ -7,6 +7,10 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CourseImageCarousel } from "@/components/CourseTypePage";
+import {
+  getCourseScheduleLines,
+  shouldShowCourseTiming,
+} from "@/lib/course-schedule";
 import { showRupees, getOfferDetails, getCoursePrice } from "@/lib/utils";
 import type { CourseLike } from "@mindpoint/backend";
 import { useEffect, useState } from "react";
@@ -174,6 +178,7 @@ export function CourseCard({
   };
 
   const displayPrice = getCoursePrice(course);
+  const scheduleLines = getCourseScheduleLines(course);
 
   return (
     <Card
@@ -229,6 +234,20 @@ export function CourseCard({
       </CardHeader>
       <CardContent className="flex flex-col gap-3 pt-0 pb-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 flex-1 space-y-1">
+          {shouldShowCourseTiming(course) && scheduleLines.length > 0 ? (
+            <div className="mb-2 space-y-1 text-xs text-slate-600">
+              {scheduleLines.map((line, index) => (
+                <div key={line} className="flex items-center gap-1.5">
+                  {index === 0 ? (
+                    <Calendar className="h-3.5 w-3.5 shrink-0" />
+                  ) : (
+                    <Clock className="h-3.5 w-3.5 shrink-0" />
+                  )}
+                  <span className="line-clamp-1">{line}</span>
+                </div>
+              ))}
+            </div>
+          ) : null}
           <Badge
             variant="secondary"
             className="px-3 py-1 text-sm font-semibold"
@@ -438,6 +457,7 @@ export function UpcomingCourseCard({
   const timeUntilStart = getTimeUntilStart(course.startDate || "");
   const formattedDate = formatDate(course.startDate || "");
   const displayPrice = getCoursePrice(course);
+  const scheduleLines = getCourseScheduleLines(course);
 
   return (
     <Card
@@ -507,6 +527,17 @@ export function UpcomingCourseCard({
             <Calendar className="mr-2 h-4 w-4" />
             <span className="font-medium">{formattedDate}</span>
           </div>
+          {shouldShowCourseTiming(course)
+            ? scheduleLines.slice(1).map((line) => (
+                <div
+                  key={line}
+                  className="text-muted-foreground flex items-center text-xs"
+                >
+                  <Clock className="mr-2 h-3.5 w-3.5" />
+                  <span>{line}</span>
+                </div>
+              ))
+            : null}
           <div className="text-xs font-medium text-orange-600 dark:text-orange-400">
             {timeUntilStart}
           </div>

--- a/apps/web/components/course/course-hero.tsx
+++ b/apps/web/components/course/course-hero.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollReveal } from "@/components/ScrollReveal";
 import { defaultEmotionalHooks } from "@/lib/course-content-data";
+import { formatCourseTimeRange } from "@/lib/course-schedule";
 import type { PublicCourse } from "@mindpoint/backend";
 
 // Keep utility functions for use by other components
@@ -77,6 +78,22 @@ export default function CourseHero({ course }: CourseHeroProps) {
     badges.push({
       icon: Calendar,
       label: `Starts ${formatDateCommon(course.startDate)}`,
+    });
+  }
+
+  const daysLabel = course.daysOfWeek?.length
+    ? course.daysOfWeek.join(", ")
+    : null;
+  const timeLabel = formatCourseTimeRange(course.startTime, course.endTime);
+  const scheduleLabel =
+    !isPreRecorded && !isWorksheet && (daysLabel || timeLabel)
+      ? [daysLabel, timeLabel].filter(Boolean).join(" • ")
+      : null;
+
+  if (scheduleLabel) {
+    badges.push({
+      icon: Clock,
+      label: scheduleLabel,
     });
   }
 

--- a/apps/web/lib/course-schedule.ts
+++ b/apps/web/lib/course-schedule.ts
@@ -1,0 +1,107 @@
+import type { CourseLike } from "@mindpoint/backend";
+
+function hasText(value?: string | null): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function formatCourseDate(dateValue?: string): string | null {
+  if (!hasText(dateValue)) {
+    return null;
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateValue!);
+  if (!match) {
+    return dateValue!;
+  }
+
+  const date = new Date(
+    Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])),
+  );
+  if (Number.isNaN(date.getTime())) {
+    return dateValue!;
+  }
+
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}
+
+export function formatCourseTime(timeValue?: string): string | null {
+  if (!hasText(timeValue)) {
+    return null;
+  }
+
+  const [hours, minutes] = timeValue!.split(":").map(Number);
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+    return timeValue!;
+  }
+
+  const date = new Date(Date.UTC(1970, 0, 1, hours, minutes));
+  return new Intl.DateTimeFormat("en-IN", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZone: "UTC",
+  }).format(date);
+}
+
+export function formatCourseTimeRange(
+  startTime?: string,
+  endTime?: string,
+): string | null {
+  const start = formatCourseTime(startTime);
+  const end = formatCourseTime(endTime);
+
+  if (start && end) {
+    return `${start} - ${end}`;
+  }
+
+  return start || end;
+}
+
+export function formatCourseDays(daysOfWeek?: string[]): string | null {
+  if (!Array.isArray(daysOfWeek) || daysOfWeek.length === 0) {
+    return null;
+  }
+
+  return daysOfWeek.join(", ");
+}
+
+export function shouldShowCourseTiming(
+  course: Pick<CourseLike, "type">,
+): boolean {
+  return course.type !== "pre-recorded" && course.type !== "worksheet";
+}
+
+export function getCourseScheduleLines(
+  course: Pick<
+    CourseLike,
+    "type" | "startDate" | "endDate" | "startTime" | "endTime" | "daysOfWeek"
+  >,
+): string[] {
+  if (!shouldShowCourseTiming(course)) {
+    return [];
+  }
+
+  const lines: string[] = [];
+  const start = formatCourseDate(course.startDate);
+  const end = formatCourseDate(course.endDate);
+  const dateLine = start && end ? `${start} to ${end}` : start || end;
+  const days = formatCourseDays(course.daysOfWeek);
+  const timeRange = formatCourseTimeRange(course.startTime, course.endTime);
+
+  if (dateLine) {
+    lines.push(dateLine);
+  }
+
+  if (days && timeRange) {
+    lines.push(`${days} • ${timeRange}`);
+  } else if (days || timeRange) {
+    lines.push(days || timeRange || "");
+  }
+
+  return lines.filter(Boolean);
+}

--- a/convex/adminCourses.ts
+++ b/convex/adminCourses.ts
@@ -227,6 +227,68 @@ function validatePublishableCourse(course: {
   }
 }
 
+function getUpperCodePrefix(code?: string) {
+  if (typeof code !== "string") {
+    return null;
+  }
+
+  const normalized = code.trim().toUpperCase();
+  return normalized.length >= 2 ? normalized.slice(0, 2) : null;
+}
+
+function getSuggestedCourseType(course: {
+  type?:
+    | "certificate"
+    | "internship"
+    | "diploma"
+    | "pre-recorded"
+    | "masterclass"
+    | "therapy"
+    | "supervised"
+    | "resume-studio"
+    | "worksheet";
+  code?: string;
+}) {
+  const codePrefix = getUpperCodePrefix(course.code);
+
+  if (codePrefix === "IN" && course.type !== "internship") {
+    return {
+      suggestedType: "internship" as const,
+      reason: "Course code uses the internship prefix `IN`.",
+    };
+  }
+
+  if (codePrefix === "PR" && course.type !== "pre-recorded") {
+    return {
+      suggestedType: "pre-recorded" as const,
+      reason: "Course code uses the pre-recorded prefix `PR`.",
+    };
+  }
+
+  if (codePrefix === "WS" && course.type !== "worksheet") {
+    return {
+      suggestedType: "worksheet" as const,
+      reason: "Course code uses the worksheet prefix `WS`.",
+    };
+  }
+
+  if (codePrefix === "DP" && course.type !== "diploma") {
+    return {
+      suggestedType: "diploma" as const,
+      reason: "Course code uses the diploma prefix `DP`.",
+    };
+  }
+
+  if (codePrefix === "CC" && course.type !== "certificate") {
+    return {
+      suggestedType: "certificate" as const,
+      reason: "Course code uses the certificate prefix `CC`.",
+    };
+  }
+
+  return null;
+}
+
 export const listCourses = query({
   args: {
     search: v.optional(v.string()),
@@ -376,6 +438,53 @@ export const listCourses = query({
   },
 });
 
+export const listCourseTypeIssues = query({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(
+    v.object({
+      courseId: v.id("courses"),
+      name: v.string(),
+      code: v.union(v.string(), v.null()),
+      lifecycleStatus: v.union(CourseLifecycleStatus, v.null()),
+      currentType: v.union(CourseType, v.null()),
+      suggestedType: CourseType,
+      reason: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const courses = await ctx.db.query("courses").order("desc").take(2000);
+    const issues = courses
+      .map((course) => {
+        const suggestion = getSuggestedCourseType(course);
+        if (!suggestion) {
+          return null;
+        }
+
+        return {
+          courseId: course._id,
+          name: course.name,
+          code: course.code ?? null,
+          lifecycleStatus: normalizeCourseLifecycleStatus(course.lifecycleStatus),
+          currentType: course.type ?? null,
+          suggestedType: suggestion.suggestedType,
+          reason: suggestion.reason,
+        };
+      })
+      .filter((issue): issue is NonNullable<typeof issue> => issue !== null)
+      .sort((a, b) => {
+        if (a.currentType === null && b.currentType !== null) return -1;
+        if (a.currentType !== null && b.currentType === null) return 1;
+        return a.name.localeCompare(b.name);
+      });
+
+    return issues.slice(0, args.limit ?? 100);
+  },
+});
+
 export const getCourseById = query({
   args: {
     courseId: v.id("courses"),
@@ -508,6 +617,47 @@ export const updateCourse = mutation({
       entityId: String(args.courseId),
       before: existing,
       after: updated,
+    });
+
+    return updated;
+  },
+});
+
+export const correctCourseType = mutation({
+  args: {
+    courseId: v.id("courses"),
+    type: CourseType,
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const admin = await requireAdmin(ctx);
+    const existing = await ctx.db.get(args.courseId);
+    if (!existing) {
+      throw new Error("Course not found");
+    }
+
+    const patch = {
+      type: args.type,
+      updatedByAdminId: admin.userId,
+      updatedAt: Date.now(),
+    };
+
+    await ctx.db.patch(args.courseId, patch);
+    const updated = await ctx.db.get(args.courseId);
+
+    await createAdminAuditLog(ctx, {
+      actorAdminId: admin.userId,
+      actorEmail: admin.email,
+      action: "course.correct_type",
+      entityType: "course",
+      entityId: String(args.courseId),
+      before: {
+        type: existing.type ?? null,
+      },
+      after: {
+        type: args.type,
+        reason: args.reason ?? "Manual course type correction",
+      },
     });
 
     return updated;


### PR DESCRIPTION
## Summary
- Added public course schedule rendering across cards and hero sections so dates, days, and time ranges are visible for scheduled course types.
- Improved the admin course editor with Safari-friendly schedule inputs and smarter default marketing content when changing course type.
- Expanded admin enrollment and course views with better filtering, cross-links to live pages, and confirmation email history.
- Added an admin course type integrity panel with suggested fixes based on course code prefixes.
- Extended backend admin course tooling to surface and correct mismatched course types.

## Testing
- Not run (not requested).
- Reviewed the diff for affected admin pages, course card rendering, and schedule formatting helpers.
- Verified the new admin course type issue flow is wired to the Convex mutation/query pair in the patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Course pages now display schedule and timing information across all course views.
  * Enrollment management enhanced with course filtering and expanded details including phone, registration source, and email resent history.
  * Admin course management includes course type integrity detection with one-click auto-correction.
  * Added quick links to public course pages from admin interfaces.
  * Course editor improved with default marketing content and Safari device compatibility.

* **Chores**
  * Updated project ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds public schedule display (dates, days, time ranges) to course cards and the hero section via a new `course-schedule.ts` helper, improves the admin course editor with a Safari-compatible plain-text fallback for date/time inputs and smarter per-type marketing defaults, and introduces an admin course-type integrity panel backed by a new `listCourseTypeIssues` query and `correctCourseType` mutation.

- The `correctCourseType` mutation patches a course's type without calling `validatePublishableCourse`, meaning clicking \"Apply Fix\" on an already-published course can leave it live with a type that does not match its stored fields (e.g. correcting a published `certificate` to `worksheet` without any `fileUrl` or `worksheetDescription`).
- `listCourseTypeIssues` performs an unindexed full-table scan of up to 2,000 courses on every admin courses page load.

<h3>Confidence Score: 4/5</h3>

Safe to merge after adding a publish-validation guard in `correctCourseType`; everything else is additive admin tooling.

One P1 finding: `correctCourseType` can leave a published course in an inconsistent type/data state visible to end-users. The fix is a small guard (validate or reject when lifecycle is published). The rest of the changes are clean and well-structured.

convex/adminCourses.ts — `correctCourseType` mutation needs a publish-validation check before patching a live course's type.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. All new Convex queries and mutations go through `requireAdmin`, the `correctCourseType` mutation accepts only a validated `CourseType` enum value, and no user-controlled input is interpolated into queries or rendered as raw HTML.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| convex/adminCourses.ts | Adds `listCourseTypeIssues` (full table scan) and `correctCourseType` (patches type without publish validation) — the latter can leave published courses in an inconsistent state. |
| apps/web/components/admin/CourseEditor.tsx | Adds Safari-compatible plain-text schedule inputs and smarter marketing defaults on type change; both `onChange` and `onInput` are always attached causing redundant updates in non-Safari browsers. |
| apps/web/app/admin/courses/page.tsx | Adds course-type integrity panel and live-page cross-links; UI logic is clean and correctly calls the new mutation. |
| apps/web/lib/course-schedule.ts | New helper module for formatting course dates, times, and schedule lines; correctly uses UTC construction to avoid timezone shifts. |
| .gitignore | Adds `*.zip` exclusion, but the existing `data.zip` in the repo root is already tracked and will not be untracked by this change alone. |
| apps/web/components/course-card.tsx | Integrates `getCourseScheduleLines` to render schedule in both card variants; `UpcomingCourseCard` correctly skips the date line since the card header already renders it. |
| apps/web/components/course/course-hero.tsx | Adds schedule/days/time badges to the hero section using `formatCourseTimeRange`; logic is correct and guarded against pre-recorded/worksheet types. |
| apps/web/app/admin/enrollments/page.tsx | Adds last-resent timestamp column and public course URL to the enrollment list; no logic issues found. |
| apps/web/app/admin/enrollments/[enrollmentId]/page.tsx | New detailed enrollment view with transfer/cancel actions and cross-links to admin/public course pages; action handling looks correct. |
| apps/web/components/CourseTypePage.tsx | Adds schedule display to `CourseGroupCard` and `CourseCard` via the shared `getCourseScheduleLines` helper; straightforward. |
| apps/web/app/admin/courses/[courseId]/page.tsx | Adds an 'Open Course Page' link button alongside the existing lifecycle action buttons; trivial and correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Admin: Courses Page] -->|loads| B[listCourseTypeIssues\ntake 2000 courses]
    B --> C{Has issues?}
    C -->|Yes| D[Show integrity panel]
    C -->|No| E[Hide panel]
    D --> F{Admin clicks\nApply Fix}
    F --> G[correctCourseType mutation]
    G --> H{Course published?}
    H -->|Yes - NOT checked| I[Patches type\nno publish validation]
    H -->|Draft/Archived| J[Safe patch]
    I --> K[(courses DB)]
    J --> K
    L[getCourseScheduleLines] --> M{type?}
    M -->|pre-recorded / worksheet| N[Return empty]
    M -->|other| O[Build date + days/time lines]
    O --> P[CourseCard]
    O --> Q[CourseGroupCard]
    O --> R[CourseHero badges]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aconvex%2FadminCourses.ts%3A626-665%0A**%60correctCourseType%60%20bypasses%20publish%20validation%20on%20live%20courses**%0A%0AThis%20mutation%20patches%20the%20type%20directly%20without%20calling%20%60validatePublishableCourse%60%2C%20so%20an%20already-published%20course%20can%20end%20up%20live%20in%20an%20inconsistent%20state.%20For%20example%3A%20a%20published%20%60certificate%60%20course%20corrected%20to%20%60worksheet%60%20will%20be%20missing%20the%20required%20%60fileUrl%60%2C%20%60worksheetDescription%60%2C%20and%20%60targetAudience%60%20fields%20that%20the%20publish%20guard%20enforces%3B%20a%20course%20corrected%20to%20%60internship%60%20may%20lack%20%60allocation%60%2C%20%60duration%60%2C%20or%20%60sessions%60.%20The%20admin%20UI%20doesn't%20filter%20the%20%22Apply%20Fix%22%20button%20to%20draft-only%20courses%2C%20so%20any%20published%20course%20can%20be%20affected.%0A%0AAdd%20a%20guard%20that%20either%20validates%20or%20blocks%20the%20operation%20for%20published%20courses%3A%0A%0A%60%60%60ts%0Aconst%20currentStatus%20%3D%20normalizeCourseLifecycleStatus%28existing.lifecycleStatus%29%3B%0Aif%20%28currentStatus%20%3D%3D%3D%20%22published%22%29%20%7B%0A%20%20const%20preview%20%3D%20%7B%20...existing%2C%20type%3A%20args.type%20%7D%3B%0A%20%20validatePublishableCourse%28preview%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0A.gitignore%3A4-5%0A**%60data.zip%60%20is%20already%20tracked%20%E2%80%94%20%60.gitignore%60%20won't%20remove%20it**%0A%0A%60data.zip%60%20is%20visible%20in%20the%20repository%20root%20and%20is%20already%20a%20tracked%20file.%20Adding%20%60*.zip%60%20to%20%60.gitignore%60%20only%20prevents%20*future*%20untracked%20zip%20files%20from%20being%20staged%3B%20it%20does%20not%20untrack%20the%20existing%20%60data.zip%60.%20To%20stop%20tracking%20it%2C%20run%3A%0A%0A%60%60%60bash%0Agit%20rm%20--cached%20data.zip%0A%60%60%60%0A%0AThen%20commit%20the%20result%20alongside%20this%20%60.gitignore%60%20change.%0A%0A%23%23%23%20Issue%203%20of%204%0Aconvex%2FadminCourses.ts%3A456-486%0A**Full%20table%20scan%20on%20every%20admin%20page%20load**%0A%0A%60listCourseTypeIssues%60%20fetches%20up%20to%202000%20courses%20unconditionally%20on%20every%20render%20of%20the%20admin%20courses%20page.%20There%20is%20no%20database%20index%20used%20%E2%80%94%20the%20query%20simply%20reads%20the%20entire%20%60courses%60%20table%20ordered%20by%20%60_creationTime%60.%20For%20a%20growing%20catalog%20this%20will%20slow%20down%20noticeably%20and%20consume%20read%20bandwidth%20on%20every%20page%20visit.%0A%0AConsider%20making%20this%20query%20lazy%20%28only%20called%20on%20demand%20via%20a%20dedicated%20button%20or%20tab%29%20or%20adding%20a%20short%20server-side%20cache%20%2F%20stale%20time%2C%20rather%20than%20having%20it%20run%20automatically%20whenever%20the%20page%20mounts.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%3A931-942%0A**Redundant%20%60onInput%60%20fires%20on%20every%20browser%2C%20not%20just%20Safari**%0A%0A%60buildScheduleInputProps%60%20attaches%20both%20%60onChange%60%20and%20%60onInput%60%2C%20both%20writing%20the%20same%20value%20to%20state.%20The%20intent%20is%20to%20work%20around%20Safari's%20%60onChange%60-on-blur%20behaviour%20for%20%60date%60%2F%60time%60%20inputs%2C%20but%20on%20every%20other%20browser%20both%20events%20fire%20on%20each%20interaction%2C%20causing%20an%20extra%20unnecessary%20state%20update%20per%20keystroke.%20The%20%60onInput%60%20binding%20should%20only%20be%20active%20when%20%60usesPlainTextScheduleInputs%60%20is%20true%20%E2%80%94%20i.e.%20spread%20it%20conditionally%20so%20it%20is%20omitted%20for%20native%20date%20pickers.%0A%0A&repo=ayushj1001%2Fmindpoint"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aconvex%2FadminCourses.ts%3A626-665%0A**%60correctCourseType%60%20bypasses%20publish%20validation%20on%20live%20courses**%0A%0AThis%20mutation%20patches%20the%20type%20directly%20without%20calling%20%60validatePublishableCourse%60%2C%20so%20an%20already-published%20course%20can%20end%20up%20live%20in%20an%20inconsistent%20state.%20For%20example%3A%20a%20published%20%60certificate%60%20course%20corrected%20to%20%60worksheet%60%20will%20be%20missing%20the%20required%20%60fileUrl%60%2C%20%60worksheetDescription%60%2C%20and%20%60targetAudience%60%20fields%20that%20the%20publish%20guard%20enforces%3B%20a%20course%20corrected%20to%20%60internship%60%20may%20lack%20%60allocation%60%2C%20%60duration%60%2C%20or%20%60sessions%60.%20The%20admin%20UI%20doesn't%20filter%20the%20%22Apply%20Fix%22%20button%20to%20draft-only%20courses%2C%20so%20any%20published%20course%20can%20be%20affected.%0A%0AAdd%20a%20guard%20that%20either%20validates%20or%20blocks%20the%20operation%20for%20published%20courses%3A%0A%0A%60%60%60ts%0Aconst%20currentStatus%20%3D%20normalizeCourseLifecycleStatus%28existing.lifecycleStatus%29%3B%0Aif%20%28currentStatus%20%3D%3D%3D%20%22published%22%29%20%7B%0A%20%20const%20preview%20%3D%20%7B%20...existing%2C%20type%3A%20args.type%20%7D%3B%0A%20%20validatePublishableCourse%28preview%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0A.gitignore%3A4-5%0A**%60data.zip%60%20is%20already%20tracked%20%E2%80%94%20%60.gitignore%60%20won't%20remove%20it**%0A%0A%60data.zip%60%20is%20visible%20in%20the%20repository%20root%20and%20is%20already%20a%20tracked%20file.%20Adding%20%60*.zip%60%20to%20%60.gitignore%60%20only%20prevents%20*future*%20untracked%20zip%20files%20from%20being%20staged%3B%20it%20does%20not%20untrack%20the%20existing%20%60data.zip%60.%20To%20stop%20tracking%20it%2C%20run%3A%0A%0A%60%60%60bash%0Agit%20rm%20--cached%20data.zip%0A%60%60%60%0A%0AThen%20commit%20the%20result%20alongside%20this%20%60.gitignore%60%20change.%0A%0A%23%23%23%20Issue%203%20of%204%0Aconvex%2FadminCourses.ts%3A456-486%0A**Full%20table%20scan%20on%20every%20admin%20page%20load**%0A%0A%60listCourseTypeIssues%60%20fetches%20up%20to%202000%20courses%20unconditionally%20on%20every%20render%20of%20the%20admin%20courses%20page.%20There%20is%20no%20database%20index%20used%20%E2%80%94%20the%20query%20simply%20reads%20the%20entire%20%60courses%60%20table%20ordered%20by%20%60_creationTime%60.%20For%20a%20growing%20catalog%20this%20will%20slow%20down%20noticeably%20and%20consume%20read%20bandwidth%20on%20every%20page%20visit.%0A%0AConsider%20making%20this%20query%20lazy%20%28only%20called%20on%20demand%20via%20a%20dedicated%20button%20or%20tab%29%20or%20adding%20a%20short%20server-side%20cache%20%2F%20stale%20time%2C%20rather%20than%20having%20it%20run%20automatically%20whenever%20the%20page%20mounts.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%3A931-942%0A**Redundant%20%60onInput%60%20fires%20on%20every%20browser%2C%20not%20just%20Safari**%0A%0A%60buildScheduleInputProps%60%20attaches%20both%20%60onChange%60%20and%20%60onInput%60%2C%20both%20writing%20the%20same%20value%20to%20state.%20The%20intent%20is%20to%20work%20around%20Safari's%20%60onChange%60-on-blur%20behaviour%20for%20%60date%60%2F%60time%60%20inputs%2C%20but%20on%20every%20other%20browser%20both%20events%20fire%20on%20each%20interaction%2C%20causing%20an%20extra%20unnecessary%20state%20update%20per%20keystroke.%20The%20%60onInput%60%20binding%20should%20only%20be%20active%20when%20%60usesPlainTextScheduleInputs%60%20is%20true%20%E2%80%94%20i.e.%20spread%20it%20conditionally%20so%20it%20is%20omitted%20for%20native%20date%20pickers.%0A%0A&repo=ayushj1001%2Fmindpoint"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aconvex%2FadminCourses.ts%3A626-665%0A**%60correctCourseType%60%20bypasses%20publish%20validation%20on%20live%20courses**%0A%0AThis%20mutation%20patches%20the%20type%20directly%20without%20calling%20%60validatePublishableCourse%60%2C%20so%20an%20already-published%20course%20can%20end%20up%20live%20in%20an%20inconsistent%20state.%20For%20example%3A%20a%20published%20%60certificate%60%20course%20corrected%20to%20%60worksheet%60%20will%20be%20missing%20the%20required%20%60fileUrl%60%2C%20%60worksheetDescription%60%2C%20and%20%60targetAudience%60%20fields%20that%20the%20publish%20guard%20enforces%3B%20a%20course%20corrected%20to%20%60internship%60%20may%20lack%20%60allocation%60%2C%20%60duration%60%2C%20or%20%60sessions%60.%20The%20admin%20UI%20doesn't%20filter%20the%20%22Apply%20Fix%22%20button%20to%20draft-only%20courses%2C%20so%20any%20published%20course%20can%20be%20affected.%0A%0AAdd%20a%20guard%20that%20either%20validates%20or%20blocks%20the%20operation%20for%20published%20courses%3A%0A%0A%60%60%60ts%0Aconst%20currentStatus%20%3D%20normalizeCourseLifecycleStatus%28existing.lifecycleStatus%29%3B%0Aif%20%28currentStatus%20%3D%3D%3D%20%22published%22%29%20%7B%0A%20%20const%20preview%20%3D%20%7B%20...existing%2C%20type%3A%20args.type%20%7D%3B%0A%20%20validatePublishableCourse%28preview%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0A.gitignore%3A4-5%0A**%60data.zip%60%20is%20already%20tracked%20%E2%80%94%20%60.gitignore%60%20won't%20remove%20it**%0A%0A%60data.zip%60%20is%20visible%20in%20the%20repository%20root%20and%20is%20already%20a%20tracked%20file.%20Adding%20%60*.zip%60%20to%20%60.gitignore%60%20only%20prevents%20*future*%20untracked%20zip%20files%20from%20being%20staged%3B%20it%20does%20not%20untrack%20the%20existing%20%60data.zip%60.%20To%20stop%20tracking%20it%2C%20run%3A%0A%0A%60%60%60bash%0Agit%20rm%20--cached%20data.zip%0A%60%60%60%0A%0AThen%20commit%20the%20result%20alongside%20this%20%60.gitignore%60%20change.%0A%0A%23%23%23%20Issue%203%20of%204%0Aconvex%2FadminCourses.ts%3A456-486%0A**Full%20table%20scan%20on%20every%20admin%20page%20load**%0A%0A%60listCourseTypeIssues%60%20fetches%20up%20to%202000%20courses%20unconditionally%20on%20every%20render%20of%20the%20admin%20courses%20page.%20There%20is%20no%20database%20index%20used%20%E2%80%94%20the%20query%20simply%20reads%20the%20entire%20%60courses%60%20table%20ordered%20by%20%60_creationTime%60.%20For%20a%20growing%20catalog%20this%20will%20slow%20down%20noticeably%20and%20consume%20read%20bandwidth%20on%20every%20page%20visit.%0A%0AConsider%20making%20this%20query%20lazy%20%28only%20called%20on%20demand%20via%20a%20dedicated%20button%20or%20tab%29%20or%20adding%20a%20short%20server-side%20cache%20%2F%20stale%20time%2C%20rather%20than%20having%20it%20run%20automatically%20whenever%20the%20page%20mounts.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%3A931-942%0A**Redundant%20%60onInput%60%20fires%20on%20every%20browser%2C%20not%20just%20Safari**%0A%0A%60buildScheduleInputProps%60%20attaches%20both%20%60onChange%60%20and%20%60onInput%60%2C%20both%20writing%20the%20same%20value%20to%20state.%20The%20intent%20is%20to%20work%20around%20Safari's%20%60onChange%60-on-blur%20behaviour%20for%20%60date%60%2F%60time%60%20inputs%2C%20but%20on%20every%20other%20browser%20both%20events%20fire%20on%20each%20interaction%2C%20causing%20an%20extra%20unnecessary%20state%20update%20per%20keystroke.%20The%20%60onInput%60%20binding%20should%20only%20be%20active%20when%20%60usesPlainTextScheduleInputs%60%20is%20true%20%E2%80%94%20i.e.%20spread%20it%20conditionally%20so%20it%20is%20omitted%20for%20native%20date%20pickers.%0A%0A"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: convex/adminCourses.ts
Line: 626-665

Comment:
**`correctCourseType` bypasses publish validation on live courses**

This mutation patches the type directly without calling `validatePublishableCourse`, so an already-published course can end up live in an inconsistent state. For example: a published `certificate` course corrected to `worksheet` will be missing the required `fileUrl`, `worksheetDescription`, and `targetAudience` fields that the publish guard enforces; a course corrected to `internship` may lack `allocation`, `duration`, or `sessions`. The admin UI doesn't filter the "Apply Fix" button to draft-only courses, so any published course can be affected.

Add a guard that either validates or blocks the operation for published courses:

```ts
const currentStatus = normalizeCourseLifecycleStatus(existing.lifecycleStatus);
if (currentStatus === "published") {
  const preview = { ...existing, type: args.type };
  validatePublishableCourse(preview);
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .gitignore
Line: 4-5

Comment:
**`data.zip` is already tracked — `.gitignore` won't remove it**

`data.zip` is visible in the repository root and is already a tracked file. Adding `*.zip` to `.gitignore` only prevents *future* untracked zip files from being staged; it does not untrack the existing `data.zip`. To stop tracking it, run:

```bash
git rm --cached data.zip
```

Then commit the result alongside this `.gitignore` change.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: convex/adminCourses.ts
Line: 456-486

Comment:
**Full table scan on every admin page load**

`listCourseTypeIssues` fetches up to 2000 courses unconditionally on every render of the admin courses page. There is no database index used — the query simply reads the entire `courses` table ordered by `_creationTime`. For a growing catalog this will slow down noticeably and consume read bandwidth on every page visit.

Consider making this query lazy (only called on demand via a dedicated button or tab) or adding a short server-side cache / stale time, rather than having it run automatically whenever the page mounts.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/components/admin/CourseEditor.tsx
Line: 931-942

Comment:
**Redundant `onInput` fires on every browser, not just Safari**

`buildScheduleInputProps` attaches both `onChange` and `onInput`, both writing the same value to state. The intent is to work around Safari's `onChange`-on-blur behaviour for `date`/`time` inputs, but on every other browser both events fire on each interaction, causing an extra unnecessary state update per keystroke. The `onInput` binding should only be active when `usesPlainTextScheduleInputs` is true — i.e. spread it conditionally so it is omitted for native date pickers.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add course schedule display and admin co..."](https://github.com/ayushj1001/mindpoint/commit/8f6d9c79cfa599111c2e16cde9360713adfcd814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27855167)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->