### PR TITLE
Add admin-managed bundle campaign pricing

### DIFF
--- a/apps/web/app/admin/enrollments/[enrollmentId]/page.tsx
+++ b/apps/web/app/admin/enrollments/[enrollmentId]/page.tsx
@@ -171,6 +171,9 @@ export default function AdminEnrollmentDetailPage() {
             <strong>Coupon Code:</strong> {detail.couponCode || "-"}
           </p>
           <p>
+            <strong>Bundle Campaign:</strong> {detail.bundleCampaignName || "-"}
+          </p>
+          <p>
             <strong>Registration Source:</strong>{" "}
             {detail.registrationSource || "checkout"}
           </p>

--- a/apps/web/app/admin/enrollments/page.tsx
+++ b/apps/web/app/admin/enrollments/page.tsx
@@ -89,6 +89,7 @@ export default function AdminEnrollmentsPage() {
         listedPrice: row.listedPrice ?? 0,
         mindPointsRedeemed: row.mindPointsRedeemed ?? 0,
         couponCode: row.couponCode ?? "",
+        bundleCampaignName: row.bundleCampaignName ?? "",
         registeredAt: new Date(row._creationTime).toISOString(),
         lastConfirmationSentAt: row.lastConfirmationSentAt
           ? new Date(row.lastConfirmationSentAt).toISOString()
@@ -404,6 +405,9 @@ export default function AdminEnrollmentsPage() {
                       <p className="text-slate-500">
                         from {showRupees(row.checkoutPrice)}
                       </p>
+                    ) : null}
+                    {row.bundleCampaignName ? (
+                      <p className="text-blue-700">{row.bundleCampaignName}</p>
                     ) : null}
                   </td>
                   <td className="px-3 py-2 text-xs text-slate-700">

--- a/apps/web/app/admin/offers/page.tsx
+++ b/apps/web/app/admin/offers/page.tsx
@@ -22,6 +22,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
+import { BundleCampaignManager } from "@/components/admin/BundleCampaignManager";
 import { toast } from "sonner";
 import { formatDateWindow } from "@/lib/admin-timezone";
 import { isBogoActive, isDiscountActive, showRupees } from "@/lib/utils";
@@ -79,6 +80,9 @@ const courseTypeOptions: CourseTypeFilter[] = [
 const MAX_COURSES_PER_APPLY = 150;
 
 export default function AdminOffersPage() {
+  const [pricingMode, setPricingMode] = useState<"offers" | "bundles">(
+    "offers",
+  );
   const [search, setSearch] = useState("");
   const [courseType, setCourseType] = useState<CourseTypeFilter>("all");
   const [selectedCourseIds, setSelectedCourseIds] = useState<string[]>([]);
@@ -416,7 +420,25 @@ export default function AdminOffersPage() {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant={pricingMode === "offers" ? "default" : "outline"}
+          onClick={() => setPricingMode("offers")}
+        >
+          Course Offers
+        </Button>
+        <Button
+          variant={pricingMode === "bundles" ? "default" : "outline"}
+          onClick={() => setPricingMode("bundles")}
+        >
+          Bundle Campaigns
+        </Button>
+      </div>
+      {pricingMode === "bundles" ? (
+        <BundleCampaignManager />
+      ) : (
+        <div className="space-y-6">
       <AdminPageHeader
         title="Offer Manager"
         description="Use a saved campaign or a simple draft, then apply it to selected courses."
@@ -889,6 +911,8 @@ export default function AdminOffersPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/app/footer.tsx
+++ b/apps/web/app/footer.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function Footer() {
   return (
     <footer
-      className="border-border z-10 mt-auto border-t bg-secondary/40"
+      className="border-border relative z-20 mt-auto border-t bg-secondary/40"
       role="contentinfo"
       aria-label="Footer"
     >

--- a/apps/web/components/CartClient.tsx
+++ b/apps/web/components/CartClient.tsx
@@ -2,6 +2,7 @@
 
 import type { Id } from "@mindpoint/backend/data-model";
 import { REFERRAL_COOKIE_KEY } from "@mindpoint/domain/referrals";
+import { evaluateBundleCampaigns } from "@mindpoint/domain/bundles";
 import { requestPaymentOrder } from "@mindpoint/services/payments";
 import { useCart } from "react-use-cart";
 import { Suspense } from "react";
@@ -58,7 +59,6 @@ const CartContent = () => {
     items,
     removeItem,
     updateItemQuantity,
-    cartTotal,
     isEmpty,
     emptyCart,
   } = useCart();
@@ -99,6 +99,39 @@ const CartContent = () => {
 
   const markCouponUsed = useMutation(api.mindPoints.markCouponUsed);
   const now = useNow();
+  const cartCourseIds = useMemo(
+    () => items.map((item) => item.id as Id<"courses">),
+    [items],
+  );
+  const bundleCampaigns = useQuery(
+    api.bundleCampaigns.listActiveBundleCampaignsForCourses,
+    cartCourseIds.length > 0 ? { courseIds: cartCourseIds } : "skip",
+  );
+  const bundleEvaluation = useMemo(
+    () =>
+      evaluateBundleCampaigns(
+        items.map((item) => ({
+          courseId: String(item.id),
+          listedPrice: Math.round(item.originalPrice ?? item.price ?? 0),
+          quantity: item.quantity ?? 1,
+        })),
+        (bundleCampaigns ?? []).map((campaign) => ({
+          ...campaign,
+          _id: String(campaign._id),
+          eligibleCourseIds: campaign.eligibleCourseIds.map((courseId) =>
+            String(courseId),
+          ),
+        })),
+      ),
+    [bundleCampaigns, items],
+  );
+  const appliedBundle = bundleEvaluation.appliedCampaign;
+  const bundleProgressCampaign =
+    appliedBundle ? null : bundleEvaluation.progressCampaign;
+  const coveredCourseIdSet = useMemo(
+    () => new Set(appliedBundle?.coveredCourseIds ?? []),
+    [appliedBundle],
+  );
 
   // Update offer details for cart items using shared time
   // Use now to create a minute-based key that changes every minute, forcing recalculation
@@ -142,29 +175,41 @@ const CartContent = () => {
     return newOfferDetails;
   }, [items, minuteKey]);
 
-  const hasBogoItems = items.some((item) => itemOfferDetails[item.id]?.hasBogo);
+  const hasBogoItems = items.some(
+    (item) =>
+      !coveredCourseIdSet.has(String(item.id)) &&
+      itemOfferDetails[item.id]?.hasBogo,
+  );
 
   const activeBogoTypes = useMemo(() => {
     const types = new Set<string>();
     items.forEach((item) => {
       const details = itemOfferDetails[item.id];
-      if (details?.hasBogo && item.courseType) {
+      if (
+        !coveredCourseIdSet.has(String(item.id)) &&
+        details?.hasBogo &&
+        item.courseType
+      ) {
         types.add(item.courseType);
       }
     });
     return Array.from(types);
-  }, [items, itemOfferDetails]);
+  }, [coveredCourseIdSet, items, itemOfferDetails]);
 
   const bogoLabels = useMemo(() => {
     const labels = new Set<string>();
     items.forEach((item) => {
       const details = itemOfferDetails[item.id];
-      if (details?.hasBogo && details.bogoLabel) {
+      if (
+        !coveredCourseIdSet.has(String(item.id)) &&
+        details?.hasBogo &&
+        details.bogoLabel
+      ) {
         labels.add(details.bogoLabel);
       }
     });
     return Array.from(labels);
-  }, [items, itemOfferDetails]);
+  }, [coveredCourseIdSet, items, itemOfferDetails]);
 
   const couponEligible = useMemo(() => {
     if (!appliedCoupon) {
@@ -173,10 +218,11 @@ const CartContent = () => {
 
     return items.some(
       (item) =>
+        !coveredCourseIdSet.has(String(item.id)) &&
         item.courseType === appliedCoupon.courseType &&
         Math.round(item.price ?? 0) > 0,
     );
-  }, [appliedCoupon, items]);
+  }, [appliedCoupon, coveredCourseIdSet, items]);
 
   useEffect(() => {
     if (appliedCoupon && !couponEligible) {
@@ -186,19 +232,42 @@ const CartContent = () => {
   }, [appliedCoupon, couponEligible]);
 
   const checkoutPricing = useMemo(() => {
+    const bundleAllocationMap = new Map(
+      (appliedBundle?.allocations ?? []).map((allocation) => [
+        String(allocation.courseId),
+        allocation,
+      ]),
+    );
+
     const baseItems = items.map((item) => {
       const listedPrice = Math.round(item.originalPrice ?? item.price ?? 0);
-      const checkoutPrice = Math.round(item.price ?? 0);
+      const defaultCheckoutPrice = Math.round(item.price ?? 0);
+      const bundleAllocation = bundleAllocationMap.get(String(item.id));
+      const checkoutPrice = bundleAllocation
+        ? Math.round(bundleAllocation.checkoutPrice)
+        : defaultCheckoutPrice;
+      const amountPaid = bundleAllocation
+        ? Math.round(bundleAllocation.amountPaid)
+        : defaultCheckoutPrice;
+      const redemptionDiscountAmount = bundleAllocation
+        ? Math.max(0, checkoutPrice - amountPaid)
+        : 0;
 
       return {
         courseId: item.id as Id<"courses">,
         courseType: item.courseType,
         listedPrice,
         checkoutPrice,
-        amountPaid: checkoutPrice,
-        redemptionDiscountAmount: 0,
+        amountPaid,
+        redemptionDiscountAmount,
         couponCode: undefined as string | undefined,
         mindPointsRedeemed: undefined as number | undefined,
+        bundleCampaignId: bundleAllocation
+          ? (appliedBundle!.campaignId as Id<"bundleCampaigns">)
+          : undefined,
+        bundleCampaignName: bundleAllocation
+          ? appliedBundle!.campaignName
+          : undefined,
       };
     });
 
@@ -210,6 +279,8 @@ const CartContent = () => {
       redemptionDiscountAmount: item.redemptionDiscountAmount,
       couponCode: item.couponCode,
       mindPointsRedeemed: item.mindPointsRedeemed,
+      bundleCampaignId: item.bundleCampaignId,
+      bundleCampaignName: item.bundleCampaignName,
     });
 
     if (!appliedCoupon) {
@@ -228,6 +299,7 @@ const CartContent = () => {
 
       baseItems.forEach((item, index) => {
         if (
+          !item.bundleCampaignId &&
           item.courseType === appliedCoupon.courseType &&
           item.checkoutPrice > 0 &&
           item.checkoutPrice > bestPrice
@@ -279,9 +351,28 @@ const CartContent = () => {
       ),
       items: pricedItems,
     };
-  }, [items, appliedCoupon]);
+  }, [items, appliedBundle, appliedCoupon]);
 
   const discountedTotal = checkoutPricing.totalAmountPaid;
+  const checkoutPricingByCourseId = useMemo(
+    () =>
+      new Map(
+        checkoutPricing.items.map((pricingItem) => [
+          String(pricingItem.courseId),
+          pricingItem,
+        ]),
+      ),
+    [checkoutPricing.items],
+  );
+  const listedCartTotal = useMemo(
+    () =>
+      items.reduce(
+        (total, item) =>
+          total + Math.round(item.originalPrice ?? item.price ?? 0),
+        0,
+      ),
+    [items],
+  );
   const totalPointsEarned = useMemo(() => {
     if (!user?.id) return 0;
 
@@ -414,7 +505,11 @@ const CartContent = () => {
 
               // Extract BOGO selections from cart items
               const bogoSelections = items
-                .filter((item) => item.selectedFreeCourse)
+                .filter(
+                  (item) =>
+                    item.selectedFreeCourse &&
+                    !coveredCourseIdSet.has(String(item.id)),
+                )
                 .map((item) => ({
                   sourceCourseId: item.id as Id<"courses">,
                   selectedFreeCourseId: item.selectedFreeCourse!.id,
@@ -725,6 +820,7 @@ const CartContent = () => {
       emptyCart,
       setIsProcessing,
       Razorpay,
+      coveredCourseIdSet,
     ],
   );
 
@@ -869,9 +965,20 @@ const CartContent = () => {
             </CardHeader>
             <CardContent className="space-y-4">
               {items.map((item) => {
-                const offerDetails = itemOfferDetails[item.id];
+                const pricingItem = checkoutPricingByCourseId.get(
+                  String(item.id),
+                );
+                const itemHasBundle = Boolean(pricingItem?.bundleCampaignId);
+                const offerDetails = itemHasBundle
+                  ? undefined
+                  : itemOfferDetails[item.id];
                 const itemTotal = Math.round(
-                  (item.price || 0) * (item.quantity || 1),
+                  pricingItem?.amountPaid ??
+                    (item.price || 0) * (item.quantity || 1),
+                );
+                const originalLinePrice = Math.round(
+                  pricingItem?.checkoutPrice ??
+                    (item.originalPrice ?? item.price ?? 0),
                 );
 
                 return (
@@ -896,6 +1003,16 @@ const CartContent = () => {
                         <p className="text-muted-foreground text-sm capitalize">
                           {item.courseType}
                         </p>
+                        {itemHasBundle && pricingItem?.bundleCampaignName ? (
+                          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+                            <span className="rounded bg-blue-100 px-2 py-1 text-[11px] font-semibold text-blue-800">
+                              Bundle Applied
+                            </span>
+                            <span className="font-medium text-blue-700">
+                              {pricingItem.bundleCampaignName}
+                            </span>
+                          </div>
+                        ) : null}
                         {offerDetails && (
                           <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
                             {offerDetails.hasDiscount && (
@@ -927,13 +1044,12 @@ const CartContent = () => {
                         <div className="font-semibold">
                           {showRupees(itemTotal)}
                         </div>
-                        {offerDetails?.hasDiscount && (
+                        {(itemHasBundle ||
+                          (offerDetails?.hasDiscount &&
+                            originalLinePrice > itemTotal)) && (
                           <div className="text-muted-foreground text-xs">
                             <span className="line-through">
-                              {showRupees(
-                                (offerDetails.originalPrice || 0) *
-                                  (item.quantity || 1),
-                              )}
+                              {showRupees(originalLinePrice)}
                             </span>
                           </div>
                         )}
@@ -977,7 +1093,11 @@ const CartContent = () => {
               })}
               {/* Display selected free course if BOGO is applied */}
               {items
-                .filter((item) => item.selectedFreeCourse)
+                .filter(
+                  (item) =>
+                    item.selectedFreeCourse &&
+                    !coveredCourseIdSet.has(String(item.id)),
+                )
                 .map((item) => (
                   <div
                     key={`bogo-${item.id}`}
@@ -1035,6 +1155,35 @@ const CartContent = () => {
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
+              {appliedBundle ? (
+                <div className="space-y-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-3 text-sm text-blue-900">
+                  <div className="flex items-center gap-2 font-semibold">
+                    <Sparkles className="h-4 w-4" />
+                    <span>{appliedBundle.campaignName}</span>
+                  </div>
+                  <p>
+                    {appliedBundle.coveredCourseIds.length} course
+                    {appliedBundle.coveredCourseIds.length === 1 ? "" : "s"}{" "}
+                    covered for {showRupees(appliedBundle.flatFee)}.
+                  </p>
+                  <p className="text-xs text-blue-700">
+                    Existing discounts, BOGO, and coupon reductions do not
+                    apply to the covered courses.
+                  </p>
+                </div>
+              ) : bundleProgressCampaign ? (
+                <div className="space-y-1 rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
+                  <div className="flex items-center gap-2 font-semibold">
+                    <Sparkles className="h-4 w-4" />
+                    <span>{bundleProgressCampaign.campaignName}</span>
+                  </div>
+                  <p>
+                    {bundleProgressCampaign.progress.selectedCount} of{" "}
+                    {bundleProgressCampaign.progress.minCount} selected for the
+                    flat-fee bundle.
+                  </p>
+                </div>
+              ) : null}
               {hasBogoItems && (
                 <div className="space-y-2">
                   <div className="flex items-start gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-medium text-emerald-700">
@@ -1051,7 +1200,11 @@ const CartContent = () => {
                   {/* List specific free courses */}
                   <div className="space-y-1">
                     {items
-                      .filter((item) => item.selectedFreeCourse)
+                      .filter(
+                        (item) =>
+                          item.selectedFreeCourse &&
+                          !coveredCourseIdSet.has(String(item.id)),
+                      )
                       .map((item) => (
                         <div
                           key={`free-${item.id}`}
@@ -1071,8 +1224,30 @@ const CartContent = () => {
               )}
               <div className="flex justify-between">
                 <span>Subtotal ({items.length} items)</span>
-                <span>{showRupees(Math.round(cartTotal))}</span>
+                <span>{showRupees(listedCartTotal)}</span>
               </div>
+              {appliedBundle ? (
+                <div className="flex justify-between text-blue-700">
+                  <span>Bundle savings</span>
+                  <span>-{showRupees(appliedBundle.coveredSavings)}</span>
+                </div>
+              ) : null}
+              {appliedCoupon ? (
+                <div className="flex justify-between text-green-700">
+                  <span>Coupon savings</span>
+                  <span>
+                    -
+                    {showRupees(
+                      checkoutPricing.items.reduce(
+                        (total, item) =>
+                          total +
+                          (item.couponCode ? item.redemptionDiscountAmount ?? 0 : 0),
+                        0,
+                      ),
+                    )}
+                  </span>
+                </div>
+              ) : null}
               <div className="flex justify-between">
                 <span>Tax</span>
                 <span>₹0.00</span>
@@ -1101,6 +1276,7 @@ const CartContent = () => {
                         ) {
                           const hasEligibleCourse = items.some(
                             (item) =>
+                              !coveredCourseIdSet.has(String(item.id)) &&
                               item.courseType ===
                                 couponValidation.coupon.courseType &&
                               Math.round(item.price ?? 0) > 0,

--- a/apps/web/components/admin/BundleCampaignManager.tsx
+++ b/apps/web/components/admin/BundleCampaignManager.tsx
@@ -1,0 +1,605 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@mindpoint/backend/api";
+import type { Id } from "@mindpoint/backend/data-model";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { useAdminTimeZone } from "@/components/admin/AdminTimeZoneProvider";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
+import { formatDateWindow } from "@/lib/admin-timezone";
+import { showRupees } from "@/lib/utils";
+
+type CourseTypeFilter =
+  | "all"
+  | "certificate"
+  | "internship"
+  | "diploma"
+  | "pre-recorded"
+  | "masterclass"
+  | "therapy"
+  | "supervised"
+  | "resume-studio"
+  | "worksheet";
+
+type BundleCampaignRecord = {
+  _id: Id<"bundleCampaigns">;
+  name: string;
+  description?: string;
+  flatFee: number;
+  requiredCourseCountMin: number;
+  requiredCourseCountMax: number;
+  eligibleCourseIds: Id<"courses">[];
+  priority: number;
+  enabled: boolean;
+  isArchived: boolean;
+  startDate?: string;
+  endDate?: string;
+  updatedAt: number;
+};
+
+const courseTypeOptions: CourseTypeFilter[] = [
+  "all",
+  "certificate",
+  "internship",
+  "diploma",
+  "pre-recorded",
+  "masterclass",
+  "therapy",
+  "supervised",
+  "resume-studio",
+  "worksheet",
+];
+
+export function BundleCampaignManager() {
+  const [search, setSearch] = useState("");
+  const [courseType, setCourseType] = useState<CourseTypeFilter>("all");
+  const [selectedCourseIds, setSelectedCourseIds] = useState<string[]>([]);
+  const [campaignSearch, setCampaignSearch] = useState("");
+  const [includeArchived, setIncludeArchived] = useState(false);
+  const [activeCampaignId, setActiveCampaignId] = useState<string | null>(null);
+  const [campaignName, setCampaignName] = useState("");
+  const [campaignDescription, setCampaignDescription] = useState("");
+  const [flatFee, setFlatFee] = useState("");
+  const [priority, setPriority] = useState("100");
+  const [enabled, setEnabled] = useState(true);
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [requiredCourseCountMin, setRequiredCourseCountMin] = useState("1");
+  const [requiredCourseCountMax, setRequiredCourseCountMax] = useState("1");
+  const [isSaving, setIsSaving] = useState(false);
+  const [campaignActionId, setCampaignActionId] = useState<string | null>(null);
+  const { formatDate, formatTimestamp } = useAdminTimeZone();
+
+  const courses = useQuery(api.adminCourses.listCourses, {
+    search: search || undefined,
+    type: courseType === "all" ? undefined : courseType,
+    limit: 500,
+    sortBy: "updatedAt",
+  });
+  const campaigns = useQuery(api.adminBundles.listBundleCampaigns, {
+    search: campaignSearch || undefined,
+    includeArchived,
+    limit: 100,
+  });
+
+  const saveBundleCampaign = useMutation(api.adminBundles.saveBundleCampaign);
+  const setBundleCampaignArchived = useMutation(
+    api.adminBundles.setBundleCampaignArchived,
+  );
+  const setBundleCampaignEnabled = useMutation(
+    api.adminBundles.setBundleCampaignEnabled,
+  );
+
+  const rows = useMemo(() => courses ?? [], [courses]);
+  const campaignRows = useMemo(() => campaigns ?? [], [campaigns]);
+  const selectedCount = selectedCourseIds.length;
+  const selectedIdSet = useMemo(
+    () => new Set(selectedCourseIds),
+    [selectedCourseIds],
+  );
+  const allVisibleSelected =
+    rows.length > 0 &&
+    rows.every((course) => selectedIdSet.has(String(course._id)));
+  const schedulePreview = formatDateWindow(startDate, endDate, formatDate);
+
+  const resetBuilder = () => {
+    setActiveCampaignId(null);
+    setCampaignName("");
+    setCampaignDescription("");
+    setFlatFee("");
+    setPriority("100");
+    setEnabled(true);
+    setStartDate("");
+    setEndDate("");
+    setRequiredCourseCountMin("1");
+    setRequiredCourseCountMax("1");
+    setSelectedCourseIds([]);
+  };
+
+  const loadCampaign = (campaign: BundleCampaignRecord) => {
+    setActiveCampaignId(String(campaign._id));
+    setCampaignName(campaign.name);
+    setCampaignDescription(campaign.description || "");
+    setFlatFee(String(campaign.flatFee));
+    setPriority(String(campaign.priority));
+    setEnabled(campaign.enabled);
+    setStartDate(campaign.startDate || "");
+    setEndDate(campaign.endDate || "");
+    setRequiredCourseCountMin(String(campaign.requiredCourseCountMin));
+    setRequiredCourseCountMax(String(campaign.requiredCourseCountMax));
+    setSelectedCourseIds(campaign.eligibleCourseIds.map((courseId) => String(courseId)));
+  };
+
+  const toggleCourse = (courseId: string, checked: boolean) => {
+    setSelectedCourseIds((prev) =>
+      checked
+        ? Array.from(new Set([...prev, courseId]))
+        : prev.filter((id) => id !== courseId),
+    );
+  };
+
+  const toggleAllVisible = (checked: boolean) => {
+    setSelectedCourseIds((prev) => {
+      if (checked) {
+        return Array.from(
+          new Set([...prev, ...rows.map((course) => String(course._id))]),
+        );
+      }
+
+      const visibleIds = new Set(rows.map((course) => String(course._id)));
+      return prev.filter((id) => !visibleIds.has(id));
+    });
+  };
+
+  const saveCampaign = async (mode: "create" | "update") => {
+    if (mode === "update" && !activeCampaignId) {
+      toast.error("Load a saved campaign before updating it");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const result = await saveBundleCampaign({
+        campaignId:
+          mode === "update" && activeCampaignId
+            ? (activeCampaignId as Id<"bundleCampaigns">)
+            : undefined,
+        name: campaignName,
+        description: campaignDescription || undefined,
+        flatFee: Number(flatFee),
+        priority: Number(priority),
+        enabled,
+        startDate: startDate || undefined,
+        endDate: endDate || undefined,
+        requiredCourseCountMin: Number(requiredCourseCountMin),
+        requiredCourseCountMax: Number(requiredCourseCountMax),
+        eligibleCourseIds: selectedCourseIds as Id<"courses">[],
+      });
+
+      if (!result) {
+        throw new Error("Campaign could not be reloaded after saving");
+      }
+
+      loadCampaign(result);
+      toast.success(mode === "create" ? "Bundle campaign saved" : "Bundle campaign updated");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to save bundle campaign",
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const toggleArchived = async (campaignId: string, isArchived: boolean) => {
+    setCampaignActionId(campaignId);
+    try {
+      await setBundleCampaignArchived({
+        campaignId: campaignId as Id<"bundleCampaigns">,
+        isArchived,
+      });
+      toast.success(isArchived ? "Bundle campaign archived" : "Bundle campaign restored");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to update bundle campaign",
+      );
+    } finally {
+      setCampaignActionId(null);
+    }
+  };
+
+  const toggleEnabled = async (campaignId: string, nextEnabled: boolean) => {
+    setCampaignActionId(campaignId);
+    try {
+      await setBundleCampaignEnabled({
+        campaignId: campaignId as Id<"bundleCampaigns">,
+        enabled: nextEnabled,
+      });
+      toast.success(nextEnabled ? "Bundle campaign enabled" : "Bundle campaign disabled");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to update bundle campaign",
+      );
+    } finally {
+      setCampaignActionId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        title="Bundle Campaigns"
+        description="Configure flat-fee bundles across explicit course selections."
+        actions={
+          <Button variant="outline" onClick={resetBuilder}>
+            New Bundle Draft
+          </Button>
+        }
+      />
+
+      <div className="grid gap-6 xl:grid-cols-[0.95fr_1.15fr]">
+        <Card className="min-w-0">
+          <CardHeader>
+            <CardTitle>Saved Bundle Campaigns</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-3">
+              <Input
+                placeholder="Search bundle campaign name or notes"
+                value={campaignSearch}
+                onChange={(e) => setCampaignSearch(e.target.value)}
+              />
+              <div className="flex items-center gap-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+                <Checkbox
+                  id="include-archived-bundle-campaigns"
+                  checked={includeArchived}
+                  onCheckedChange={(checked) =>
+                    setIncludeArchived(checked === true)
+                  }
+                />
+                <Label htmlFor="include-archived-bundle-campaigns">
+                  Show archived campaigns
+                </Label>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              {!campaigns ? (
+                <p className="text-sm text-slate-600">
+                  Loading bundle campaigns...
+                </p>
+              ) : campaignRows.length === 0 ? (
+                <p className="text-sm text-slate-600">
+                  No bundle campaigns found.
+                </p>
+              ) : (
+                campaignRows.map((campaign) => {
+                  const campaignId = String(campaign._id);
+                  const isBusy = campaignActionId === campaignId;
+                  const isLoaded = activeCampaignId === campaignId;
+                  return (
+                    <div
+                      key={campaign._id}
+                      className={`rounded-2xl border p-4 ${
+                        isLoaded
+                          ? "border-blue-300 bg-blue-50/70"
+                          : "border-slate-200 bg-white"
+                      }`}
+                    >
+                      <div className="space-y-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="font-medium break-words text-slate-900">
+                            {campaign.name}
+                          </p>
+                          <Badge
+                            variant={campaign.enabled ? "default" : "secondary"}
+                          >
+                            {campaign.enabled ? "Enabled" : "Disabled"}
+                          </Badge>
+                          <Badge
+                            variant={campaign.isArchived ? "outline" : "secondary"}
+                          >
+                            {campaign.isArchived ? "Archived" : "Live"}
+                          </Badge>
+                        </div>
+                        {campaign.description ? (
+                          <p className="text-xs leading-5 break-words text-slate-600">
+                            {campaign.description}
+                          </p>
+                        ) : null}
+                        <div className="flex flex-wrap gap-2">
+                          <Badge variant="outline">
+                            {showRupees(campaign.flatFee)}
+                          </Badge>
+                          <Badge variant="outline">
+                            {campaign.requiredCourseCountMin ===
+                            campaign.requiredCourseCountMax
+                              ? `${campaign.requiredCourseCountMin} courses`
+                              : `${campaign.requiredCourseCountMin}-${campaign.requiredCourseCountMax} courses`}
+                          </Badge>
+                          <Badge variant="outline">
+                            {campaign.eligibleCourseIds.length} eligible
+                          </Badge>
+                          <Badge variant="outline">
+                            Priority {campaign.priority}
+                          </Badge>
+                        </div>
+                        <div className="space-y-1 text-xs text-slate-500">
+                          <p>
+                            Schedule:{" "}
+                            {formatDateWindow(
+                              campaign.startDate ?? "",
+                              campaign.endDate ?? "",
+                              formatDate,
+                            ) || "Always active when enabled"}
+                          </p>
+                          <p>Updated {formatTimestamp(campaign.updatedAt)}</p>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => loadCampaign(campaign)}
+                          >
+                            Load
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={isBusy || campaign.isArchived}
+                            onClick={() =>
+                              toggleEnabled(campaignId, !campaign.enabled)
+                            }
+                          >
+                            {campaign.enabled ? "Disable" : "Enable"}
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={isBusy}
+                            onClick={() =>
+                              toggleArchived(campaignId, !campaign.isArchived)
+                            }
+                          >
+                            {campaign.isArchived ? "Restore" : "Archive"}
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="min-w-0">
+          <CardHeader>
+            <CardTitle>
+              {activeCampaignId ? "Bundle Builder" : "New Bundle Builder"}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+              Eligible courses selected: <strong>{selectedCount}</strong>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="space-y-3">
+                <Label>Campaign Name</Label>
+                <Input
+                  placeholder="Campaign name"
+                  value={campaignName}
+                  onChange={(e) => setCampaignName(e.target.value)}
+                />
+              </div>
+              <div className="space-y-3">
+                <Label>Internal Notes</Label>
+                <Textarea
+                  rows={3}
+                  placeholder="Optional notes for the admin team"
+                  value={campaignDescription}
+                  onChange={(e) => setCampaignDescription(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4">
+                <Label>Flat Fee</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={flatFee}
+                  onChange={(e) => setFlatFee(e.target.value)}
+                  placeholder="7000"
+                />
+                <Label>Priority</Label>
+                <Input
+                  type="number"
+                  step={1}
+                  value={priority}
+                  onChange={(e) => setPriority(e.target.value)}
+                />
+                <div className="flex items-center gap-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+                  <Checkbox
+                    id="bundle-enabled"
+                    checked={enabled}
+                    onCheckedChange={(checked) => setEnabled(checked === true)}
+                  />
+                  <Label htmlFor="bundle-enabled">Enable campaign</Label>
+                </div>
+              </div>
+
+              <div className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4">
+                <Label>Required Course Count</Label>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Input
+                    type="number"
+                    min={1}
+                    value={requiredCourseCountMin}
+                    onChange={(e) => setRequiredCourseCountMin(e.target.value)}
+                    placeholder="Min"
+                  />
+                  <Input
+                    type="number"
+                    min={1}
+                    value={requiredCourseCountMax}
+                    onChange={(e) => setRequiredCourseCountMax(e.target.value)}
+                    placeholder="Max"
+                  />
+                </div>
+                <Label>Schedule</Label>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Input
+                    type="date"
+                    value={startDate}
+                    onChange={(e) => setStartDate(e.target.value)}
+                  />
+                  <Input
+                    type="date"
+                    value={endDate}
+                    onChange={(e) => setEndDate(e.target.value)}
+                  />
+                </div>
+                {schedulePreview ? (
+                  <p className="text-xs text-slate-500">
+                    Active window: {schedulePreview}
+                  </p>
+                ) : (
+                  <p className="text-xs text-slate-500">
+                    Active whenever the campaign is enabled.
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Button disabled={isSaving} onClick={() => saveCampaign("create")}>
+                Save New
+              </Button>
+              <Button
+                variant="outline"
+                disabled={isSaving || !activeCampaignId}
+                onClick={() => saveCampaign("update")}
+              >
+                Update Loaded
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="min-w-0">
+        <CardHeader>
+          <CardTitle>Course Targeting</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 lg:grid-cols-[1.3fr_220px_220px]">
+            <Input
+              placeholder="Search courses, type, code"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            <select
+              className="h-10 rounded-md border bg-white px-3 text-sm"
+              value={courseType}
+              onChange={(e) =>
+                setCourseType(e.target.value as CourseTypeFilter)
+              }
+            >
+              {courseTypeOptions.map((type) => (
+                <option key={type} value={type}>
+                  {type === "all" ? "All course types" : type}
+                </option>
+              ))}
+            </select>
+            <div className="flex items-center gap-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+              <Checkbox
+                id="select-all-visible-bundle-courses"
+                checked={allVisibleSelected}
+                onCheckedChange={(checked) =>
+                  toggleAllVisible(checked === true)
+                }
+              />
+              <Label htmlFor="select-all-visible-bundle-courses">
+                Select all visible
+              </Label>
+            </div>
+          </div>
+
+          <div className="grid gap-3">
+            {!courses ? (
+              <p className="text-sm text-slate-600">Loading courses...</p>
+            ) : rows.length === 0 ? (
+              <p className="text-sm text-slate-600">
+                No courses matched your filter.
+              </p>
+            ) : (
+              rows.map((course) => {
+                const courseId = String(course._id);
+                const isSelected = selectedIdSet.has(courseId);
+
+                return (
+                  <div
+                    key={course._id}
+                    className={`rounded-2xl border p-4 transition-colors ${
+                      isSelected
+                        ? "border-blue-300 bg-blue-50/60"
+                        : "border-slate-200 bg-white"
+                    }`}
+                  >
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-3">
+                          <Checkbox
+                            checked={isSelected}
+                            onCheckedChange={(checked) =>
+                              toggleCourse(courseId, checked === true)
+                            }
+                          />
+                          <div className="min-w-0">
+                            <p className="font-medium break-words text-slate-900">
+                              {course.name}
+                            </p>
+                            <p className="text-xs break-words text-slate-600">
+                              {course.type || "course"} • {course.code}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
+                        <span className="font-medium text-slate-900">
+                          {showRupees(course.price)}
+                        </span>
+                        <span>
+                          {(course.enrolledUsers || []).length}/
+                          {course.capacity} seats
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/components/admin/CourseEditor.tsx
+++ b/apps/web/components/admin/CourseEditor.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import {
-  type ChangeEvent,
-  type FormEvent,
   useEffect,
   useMemo,
   useRef,
@@ -930,16 +928,20 @@ export function CourseEditor({
 
   const buildScheduleInputProps = (
     key: "startDate" | "endDate" | "startTime" | "endTime",
-  ) => ({
-    value: state[key],
-    onChange: (e: ChangeEvent<HTMLInputElement>) =>
-      setState((prev) => ({ ...prev, [key]: e.target.value })),
-    onInput: (e: FormEvent<HTMLInputElement>) =>
-      setState((prev) => ({
-        ...prev,
-        [key]: e.currentTarget.value,
-      })),
-  });
+  ) => {
+    const updateScheduleField = (nextValue: string | null | undefined) => {
+      const normalizedValue = nextValue ?? "";
+      setState((prev) => ({ ...prev, [key]: normalizedValue }));
+    };
+
+    return {
+      value: state[key],
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+        updateScheduleField(e.currentTarget?.value),
+      onInput: (e: React.FormEvent<HTMLInputElement>) =>
+        updateScheduleField(e.currentTarget?.value),
+    };
+  };
 
   return (
     <div className="space-y-6">

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type {
 import type * as _publicCourse from "../_publicCourse.js";
 import type * as adminAudit from "../adminAudit.js";
 import type * as adminAuth from "../adminAuth.js";
+import type * as adminBundles from "../adminBundles.js";
 import type * as adminCourses from "../adminCourses.js";
 import type * as adminDashboard from "../adminDashboard.js";
 import type * as adminEnrollments from "../adminEnrollments.js";
@@ -25,6 +26,7 @@ import type * as adminOffers from "../adminOffers.js";
 import type * as adminReviews from "../adminReviews.js";
 import type * as adminUsers from "../adminUsers.js";
 import type * as adminUtils from "../adminUtils.js";
+import type * as bundleCampaigns from "../bundleCampaigns.js";
 import type * as courses from "../courses.js";
 import type * as emailActions from "../emailActions.js";
 import type * as emailActionsWithRateLimit from "../emailActionsWithRateLimit.js";
@@ -49,6 +51,7 @@ declare const fullApi: ApiFromModules<{
   _publicCourse: typeof _publicCourse;
   adminAudit: typeof adminAudit;
   adminAuth: typeof adminAuth;
+  adminBundles: typeof adminBundles;
   adminCourses: typeof adminCourses;
   adminDashboard: typeof adminDashboard;
   adminEnrollments: typeof adminEnrollments;
@@ -58,6 +61,7 @@ declare const fullApi: ApiFromModules<{
   adminReviews: typeof adminReviews;
   adminUsers: typeof adminUsers;
   adminUtils: typeof adminUtils;
+  bundleCampaigns: typeof bundleCampaigns;
   courses: typeof courses;
   emailActions: typeof emailActions;
   emailActionsWithRateLimit: typeof emailActionsWithRateLimit;

--- a/convex/adminBundles.ts
+++ b/convex/adminBundles.ts
@@ -1,0 +1,310 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+import { requireAdmin } from "./adminAuth";
+import { createAdminAuditLog } from "./adminAudit";
+
+const MAX_ELIGIBLE_COURSES = 500;
+
+const bundleCampaignPayload = {
+  name: v.string(),
+  description: v.optional(v.string()),
+  flatFee: v.number(),
+  requiredCourseCountMin: v.number(),
+  requiredCourseCountMax: v.number(),
+  eligibleCourseIds: v.array(v.id("courses")),
+  priority: v.number(),
+  enabled: v.boolean(),
+  startDate: v.optional(v.string()),
+  endDate: v.optional(v.string()),
+};
+
+type BundleCampaignInput = {
+  name: string;
+  description?: string;
+  flatFee: number;
+  requiredCourseCountMin: number;
+  requiredCourseCountMax: number;
+  eligibleCourseIds: Id<"courses">[];
+  priority: number;
+  enabled: boolean;
+  startDate?: string;
+  endDate?: string;
+};
+
+function normalizeString(value?: string | null) {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function toInteger(value: number, field: string) {
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new Error(`${field} must be an integer`);
+  }
+
+  return value;
+}
+
+function assertValidBundleCampaign(input: BundleCampaignInput) {
+  const name = normalizeString(input.name);
+  if (!name) {
+    throw new Error("Campaign name is required");
+  }
+
+  const flatFee = Math.round(input.flatFee);
+  if (!Number.isFinite(flatFee) || flatFee <= 0) {
+    throw new Error("Flat fee must be greater than 0");
+  }
+
+  const minCount = toInteger(
+    Math.round(input.requiredCourseCountMin),
+    "Minimum course count",
+  );
+  const maxCount = toInteger(
+    Math.round(input.requiredCourseCountMax),
+    "Maximum course count",
+  );
+  if (minCount < 1) {
+    throw new Error("Minimum course count must be at least 1");
+  }
+  if (maxCount < minCount) {
+    throw new Error("Maximum course count must be greater than or equal to minimum course count");
+  }
+
+  const uniqueEligibleCourseIds = Array.from(
+    new Set(input.eligibleCourseIds.map((courseId) => String(courseId))),
+  ).map((courseId) => courseId as Id<"courses">);
+  if (uniqueEligibleCourseIds.length === 0) {
+    throw new Error("Select at least one eligible course");
+  }
+  if (uniqueEligibleCourseIds.length > MAX_ELIGIBLE_COURSES) {
+    throw new Error(
+      `Cannot target more than ${MAX_ELIGIBLE_COURSES} courses in one bundle campaign`,
+    );
+  }
+  if (maxCount > uniqueEligibleCourseIds.length) {
+    throw new Error("Maximum course count cannot exceed the number of eligible courses");
+  }
+
+  toInteger(Math.round(input.priority), "Priority");
+
+  const startTimestamp = input.startDate
+    ? new Date(input.startDate).getTime()
+    : null;
+  const endTimestamp = input.endDate ? new Date(input.endDate).getTime() : null;
+  if (startTimestamp !== null && Number.isNaN(startTimestamp)) {
+    throw new Error("Start date is invalid");
+  }
+  if (endTimestamp !== null && Number.isNaN(endTimestamp)) {
+    throw new Error("End date is invalid");
+  }
+  if (
+    startTimestamp !== null &&
+    endTimestamp !== null &&
+    startTimestamp > endTimestamp
+  ) {
+    throw new Error("End date must be on or after the start date");
+  }
+
+  return {
+    name,
+    description: normalizeString(input.description),
+    flatFee,
+    requiredCourseCountMin: minCount,
+    requiredCourseCountMax: maxCount,
+    eligibleCourseIds: uniqueEligibleCourseIds,
+    priority: Math.round(input.priority),
+    enabled: input.enabled,
+    startDate: input.startDate || undefined,
+    endDate: input.endDate || undefined,
+  };
+}
+
+export const listBundleCampaigns = query({
+  args: {
+    search: v.optional(v.string()),
+    includeArchived: v.optional(v.boolean()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const limit = Math.min(args.limit ?? 100, 200);
+    const scanLimit = args.search
+      ? Math.min(Math.max(limit * 10, 500), 1500)
+      : Math.min(Math.max(limit * 5, 200), 1000);
+
+    let campaigns = args.includeArchived
+      ? await ctx.db
+          .query("bundleCampaigns")
+          .withIndex("by_updatedAt")
+          .order("desc")
+          .take(scanLimit)
+      : await ctx.db
+          .query("bundleCampaigns")
+          .withIndex("by_isArchived_updatedAt", (q) =>
+            q.eq("isArchived", false),
+          )
+          .order("desc")
+          .take(scanLimit);
+
+    if (args.search) {
+      const search = args.search.toLowerCase();
+      campaigns = campaigns.filter((campaign) =>
+        [campaign.name, campaign.description ?? ""].some((part) =>
+          part.toLowerCase().includes(search),
+        ),
+      );
+    }
+
+    return campaigns.slice(0, limit);
+  },
+});
+
+export const getBundleCampaignById = query({
+  args: {
+    campaignId: v.id("bundleCampaigns"),
+  },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+    return await ctx.db.get(args.campaignId);
+  },
+});
+
+export const saveBundleCampaign = mutation({
+  args: {
+    campaignId: v.optional(v.id("bundleCampaigns")),
+    ...bundleCampaignPayload,
+  },
+  handler: async (ctx, args) => {
+    const admin = await requireAdmin(ctx);
+    const now = Date.now();
+    const normalized = assertValidBundleCampaign(args);
+
+    if (args.campaignId) {
+      const existing = await ctx.db.get(args.campaignId);
+      if (!existing) {
+        throw new Error("Bundle campaign not found");
+      }
+      if (existing.isArchived && normalized.enabled) {
+        throw new Error("Archived campaigns must be restored before they can be enabled");
+      }
+
+      await ctx.db.patch(args.campaignId, {
+        ...normalized,
+        updatedAt: now,
+        updatedByAdminId: admin.userId,
+      });
+      const updated = await ctx.db.get(args.campaignId);
+
+      await createAdminAuditLog(ctx, {
+        actorAdminId: admin.userId,
+        actorEmail: admin.email,
+        action: "bundle_campaign.update",
+        entityType: "bundleCampaign",
+        entityId: String(args.campaignId),
+        before: existing,
+        after: updated,
+      });
+
+      return updated;
+    }
+
+    const campaignId = await ctx.db.insert("bundleCampaigns", {
+      ...normalized,
+      isArchived: false,
+      createdAt: now,
+      updatedAt: now,
+      createdByAdminId: admin.userId,
+      updatedByAdminId: admin.userId,
+    });
+    const created = await ctx.db.get(campaignId);
+
+    await createAdminAuditLog(ctx, {
+      actorAdminId: admin.userId,
+      actorEmail: admin.email,
+      action: "bundle_campaign.create",
+      entityType: "bundleCampaign",
+      entityId: String(campaignId),
+      after: created,
+    });
+
+    return created;
+  },
+});
+
+export const setBundleCampaignArchived = mutation({
+  args: {
+    campaignId: v.id("bundleCampaigns"),
+    isArchived: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const admin = await requireAdmin(ctx);
+    const existing = await ctx.db.get(args.campaignId);
+
+    if (!existing) {
+      throw new Error("Bundle campaign not found");
+    }
+
+    await ctx.db.patch(args.campaignId, {
+      isArchived: args.isArchived,
+      enabled: args.isArchived ? false : existing.enabled,
+      updatedAt: Date.now(),
+      updatedByAdminId: admin.userId,
+    });
+    const updated = await ctx.db.get(args.campaignId);
+
+    await createAdminAuditLog(ctx, {
+      actorAdminId: admin.userId,
+      actorEmail: admin.email,
+      action: args.isArchived
+        ? "bundle_campaign.archive"
+        : "bundle_campaign.restore",
+      entityType: "bundleCampaign",
+      entityId: String(args.campaignId),
+      before: existing,
+      after: updated,
+    });
+
+    return updated;
+  },
+});
+
+export const setBundleCampaignEnabled = mutation({
+  args: {
+    campaignId: v.id("bundleCampaigns"),
+    enabled: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const admin = await requireAdmin(ctx);
+    const existing = await ctx.db.get(args.campaignId);
+
+    if (!existing) {
+      throw new Error("Bundle campaign not found");
+    }
+    if (existing.isArchived && args.enabled) {
+      throw new Error("Archived campaigns must be restored before they can be enabled");
+    }
+
+    await ctx.db.patch(args.campaignId, {
+      enabled: args.enabled,
+      updatedAt: Date.now(),
+      updatedByAdminId: admin.userId,
+    });
+    const updated = await ctx.db.get(args.campaignId);
+
+    await createAdminAuditLog(ctx, {
+      actorAdminId: admin.userId,
+      actorEmail: admin.email,
+      action: args.enabled
+        ? "bundle_campaign.enable"
+        : "bundle_campaign.disable",
+      entityType: "bundleCampaign",
+      entityId: String(args.campaignId),
+      before: existing,
+      after: updated,
+    });
+
+    return updated;
+  },
+});

--- a/convex/adminEnrollments.ts
+++ b/convex/adminEnrollments.ts
@@ -284,6 +284,7 @@ export const listEnrollments = query({
           row.courseName ?? "",
           row.enrollmentNumber,
           row.couponCode ?? "",
+          row.bundleCampaignName ?? "",
         ];
 
         return fields.some((field) => field.toLowerCase().includes(search));
@@ -960,6 +961,8 @@ export const transferEnrollment = mutation({
       redemptionDiscountAmount: sourceEnrollment.redemptionDiscountAmount,
       couponCode: sourceEnrollment.couponCode,
       mindPointsRedeemed: sourceEnrollment.mindPointsRedeemed,
+      bundleCampaignId: sourceEnrollment.bundleCampaignId,
+      bundleCampaignName: sourceEnrollment.bundleCampaignName,
       registrationSource: "admin_transfer",
       status: "active",
       statusReason: `Transfer from ${sourceEnrollment.courseName || String(sourceEnrollment.courseId)}`,

--- a/convex/bundleCampaigns.ts
+++ b/convex/bundleCampaigns.ts
@@ -45,7 +45,9 @@ export const listActiveBundleCampaignsForCourses = query({
     const courseIdSet = new Set(uniqueCourseIds);
     const campaigns = await ctx.db
       .query("bundleCampaigns")
-      .withIndex("by_enabled_priority", (q) => q.eq("enabled", true))
+      .withIndex("by_enabled_isArchived_priority", (q) =>
+        q.eq("enabled", true).eq("isArchived", false),
+      )
       .order("desc")
       .take(500);
 

--- a/convex/bundleCampaigns.ts
+++ b/convex/bundleCampaigns.ts
@@ -1,0 +1,75 @@
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+
+function isBundleCampaignActive(campaign: {
+  enabled: boolean;
+  isArchived: boolean;
+  startDate?: string;
+  endDate?: string;
+}) {
+  if (!campaign.enabled || campaign.isArchived) {
+    return false;
+  }
+
+  const now = Date.now();
+
+  if (campaign.startDate) {
+    const start = new Date(campaign.startDate).getTime();
+    if (Number.isNaN(start) || now < start) {
+      return false;
+    }
+  }
+
+  if (campaign.endDate) {
+    const end = new Date(campaign.endDate).getTime();
+    if (Number.isNaN(end) || now > end) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export const listActiveBundleCampaignsForCourses = query({
+  args: {
+    courseIds: v.array(v.id("courses")),
+  },
+  handler: async (ctx, args) => {
+    const uniqueCourseIds = Array.from(
+      new Set(args.courseIds.map((courseId) => String(courseId))),
+    );
+    if (uniqueCourseIds.length === 0) {
+      return [];
+    }
+
+    const courseIdSet = new Set(uniqueCourseIds);
+    const campaigns = await ctx.db
+      .query("bundleCampaigns")
+      .withIndex("by_enabled_priority", (q) => q.eq("enabled", true))
+      .order("desc")
+      .take(500);
+
+    return campaigns
+      .filter((campaign) => isBundleCampaignActive(campaign))
+      .filter((campaign) =>
+        campaign.eligibleCourseIds.some((courseId) =>
+          courseIdSet.has(String(courseId)),
+        ),
+      )
+      .map((campaign) => ({
+        _id: campaign._id,
+        _creationTime: campaign._creationTime,
+        name: campaign.name,
+        description: campaign.description,
+        flatFee: campaign.flatFee,
+        requiredCourseCountMin: campaign.requiredCourseCountMin,
+        requiredCourseCountMax: campaign.requiredCourseCountMax,
+        eligibleCourseIds: campaign.eligibleCourseIds,
+        priority: campaign.priority,
+        enabled: campaign.enabled,
+        isArchived: campaign.isArchived,
+        startDate: campaign.startDate,
+        endDate: campaign.endDate,
+      }));
+  },
+});

--- a/convex/myFunctions.ts
+++ b/convex/myFunctions.ts
@@ -254,6 +254,8 @@ const checkoutPricingItemValidator = v.object({
   redemptionDiscountAmount: v.optional(v.number()),
   couponCode: v.optional(v.string()),
   mindPointsRedeemed: v.optional(v.number()),
+  bundleCampaignId: v.optional(v.id("bundleCampaigns")),
+  bundleCampaignName: v.optional(v.string()),
 });
 
 const checkoutPricingValidator = v.object({
@@ -305,6 +307,8 @@ function buildEnrollmentPricingFields(
       pricingItem?.mindPointsRedeemed && pricingItem.mindPointsRedeemed > 0
         ? roundCurrency(pricingItem.mindPointsRedeemed)
         : undefined,
+    bundleCampaignId: pricingItem?.bundleCampaignId,
+    bundleCampaignName: pricingItem?.bundleCampaignName?.trim() || undefined,
   };
 }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -46,6 +46,24 @@ export const CourseBogoValue = v.object({
   label: v.optional(v.string()),
 });
 
+export const BundleCampaignValue = v.object({
+  name: v.string(),
+  description: v.optional(v.string()),
+  flatFee: v.number(),
+  requiredCourseCountMin: v.number(),
+  requiredCourseCountMax: v.number(),
+  eligibleCourseIds: v.array(v.id("courses")),
+  priority: v.number(),
+  enabled: v.boolean(),
+  isArchived: v.boolean(),
+  startDate: v.optional(v.string()),
+  endDate: v.optional(v.string()),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+  createdByAdminId: v.string(),
+  updatedByAdminId: v.string(),
+});
+
 export const EnrollmentSessionType = v.union(
   v.literal("focus"),
   v.literal("flow"),
@@ -149,6 +167,8 @@ const publicEnrollmentFields = {
   redemptionDiscountAmount: v.optional(v.number()),
   couponCode: v.optional(v.string()),
   mindPointsRedeemed: v.optional(v.number()),
+  bundleCampaignId: v.optional(v.id("bundleCampaigns")),
+  bundleCampaignName: v.optional(v.string()),
   registrationSource: v.optional(EnrollmentRegistrationSource),
   status: v.optional(EnrollmentStatus),
   statusReason: v.optional(v.string()),
@@ -196,6 +216,11 @@ export default defineSchema({
   })
     .index("by_updatedAt", ["updatedAt"])
     .index("by_isArchived_updatedAt", ["isArchived", "updatedAt"]),
+
+  bundleCampaigns: defineTable(BundleCampaignValue)
+    .index("by_updatedAt", ["updatedAt"])
+    .index("by_isArchived_updatedAt", ["isArchived", "updatedAt"])
+    .index("by_enabled_priority", ["enabled", "priority"]),
 
   reviews: defineTable({
     userId: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -220,7 +220,12 @@ export default defineSchema({
   bundleCampaigns: defineTable(BundleCampaignValue)
     .index("by_updatedAt", ["updatedAt"])
     .index("by_isArchived_updatedAt", ["isArchived", "updatedAt"])
-    .index("by_enabled_priority", ["enabled", "priority"]),
+    .index("by_enabled_priority", ["enabled", "priority"])
+    .index("by_enabled_isArchived_priority", [
+      "enabled",
+      "isArchived",
+      "priority",
+    ]),
 
   reviews: defineTable({
     userId: v.string(),

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./bundles": "./src/bundles.ts",
     "./cart": "./src/cart.ts",
     "./checkout": "./src/checkout.ts",
     "./forms": "./src/forms.ts",

--- a/packages/domain/src/bundles.ts
+++ b/packages/domain/src/bundles.ts
@@ -222,7 +222,9 @@ export function evaluateBundleCampaigns(
     };
     const qualifies =
       progress.selectedCount >= progress.minCount &&
-      progress.selectedCount <= progress.maxCount;
+      progress.selectedCount <= progress.maxCount &&
+      coveredListedSubtotal > 0 &&
+      Math.max(0, Math.round(campaign.flatFee)) < coveredListedSubtotal;
     const allocations = qualifies
       ? allocateFlatFeeAcrossCourses(coveredItems, campaign.flatFee)
       : [];
@@ -249,18 +251,18 @@ export function evaluateBundleCampaigns(
     .map(({ qualifies: _qualifies, ...campaign }) => campaign);
 
   const appliedCampaign = pickWinningBundleCampaign(qualifyingCampaigns);
-  const progressCampaign =
-    appliedCampaign ??
-    evaluated
-      .filter(
-        (campaign) =>
-          !campaign.qualifies &&
-          campaign.progress.selectedCount > 0 &&
-          campaign.progress.selectedCount < campaign.progress.minCount,
-      )
-      .map(({ qualifies: _qualifies, ...campaign }) => campaign)
-      .sort(compareEvaluatedPrecedence)[0] ??
-    null;
+  const progressCampaign = appliedCampaign
+    ? null
+    : evaluated
+        .filter(
+          (campaign) =>
+            !campaign.qualifies &&
+            campaign.progress.selectedCount > 0 &&
+            campaign.progress.selectedCount < campaign.progress.minCount,
+        )
+        .map(({ qualifies: _qualifies, ...campaign }) => campaign)
+        .sort(compareEvaluatedPrecedence)[0] ??
+      null;
 
   return {
     qualifyingCampaigns,

--- a/packages/domain/src/bundles.ts
+++ b/packages/domain/src/bundles.ts
@@ -1,0 +1,270 @@
+export type BundleCampaignLike = {
+  _id: string;
+  _creationTime?: number;
+  name: string;
+  description?: string;
+  flatFee: number;
+  requiredCourseCountMin: number;
+  requiredCourseCountMax: number;
+  eligibleCourseIds: string[];
+  priority: number;
+  enabled: boolean;
+  isArchived?: boolean;
+  startDate?: string;
+  endDate?: string;
+};
+
+export type BundleCartItem = {
+  courseId: string;
+  listedPrice: number;
+  quantity?: number;
+};
+
+export type BundleAllocation = {
+  courseId: string;
+  listedPrice: number;
+  checkoutPrice: number;
+  amountPaid: number;
+  savings: number;
+};
+
+export type EvaluatedBundleCampaign = {
+  campaignId: string;
+  campaignName: string;
+  flatFee: number;
+  priority: number;
+  coveredCourseIds: string[];
+  coveredListedSubtotal: number;
+  coveredSavings: number;
+  progress: {
+    selectedCount: number;
+    minCount: number;
+    maxCount: number;
+  };
+  allocations: BundleAllocation[];
+};
+
+export type BundleEvaluationResult = {
+  qualifyingCampaigns: EvaluatedBundleCampaign[];
+  appliedCampaign: EvaluatedBundleCampaign | null;
+  progressCampaign: EvaluatedBundleCampaign | null;
+};
+
+function toTimestamp(value?: string): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const timestamp = new Date(value).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function compareCampaignPrecedence(
+  left: BundleCampaignLike,
+  right: BundleCampaignLike,
+): number {
+  if (left.priority !== right.priority) {
+    return right.priority - left.priority;
+  }
+
+  const leftCreationTime = left._creationTime ?? Number.MAX_SAFE_INTEGER;
+  const rightCreationTime = right._creationTime ?? Number.MAX_SAFE_INTEGER;
+  if (leftCreationTime !== rightCreationTime) {
+    return leftCreationTime - rightCreationTime;
+  }
+
+  return String(left._id).localeCompare(String(right._id));
+}
+
+function compareEvaluatedPrecedence(
+  left: EvaluatedBundleCampaign,
+  right: EvaluatedBundleCampaign,
+): number {
+  if (left.priority !== right.priority) {
+    return right.priority - left.priority;
+  }
+
+  return String(left.campaignId).localeCompare(String(right.campaignId));
+}
+
+export function isBundleCampaignActive(
+  campaign: BundleCampaignLike,
+  now: number | Date = Date.now(),
+): boolean {
+  if (!campaign.enabled || campaign.isArchived) {
+    return false;
+  }
+
+  const nowTimestamp = now instanceof Date ? now.getTime() : now;
+  const startTimestamp = toTimestamp(campaign.startDate);
+  const endTimestamp = toTimestamp(campaign.endDate);
+
+  if (startTimestamp !== null && nowTimestamp < startTimestamp) {
+    return false;
+  }
+
+  if (endTimestamp !== null && nowTimestamp > endTimestamp) {
+    return false;
+  }
+
+  return true;
+}
+
+export function allocateFlatFeeAcrossCourses(
+  coveredItems: Array<{ courseId: string; listedPrice: number }>,
+  flatFee: number,
+): BundleAllocation[] {
+  const normalizedFlatFee = Math.max(0, Math.round(flatFee));
+  const normalizedItems = coveredItems
+    .map((item) => ({
+      courseId: String(item.courseId),
+      listedPrice: Math.max(0, Math.round(item.listedPrice)),
+    }))
+    .sort((left, right) => left.courseId.localeCompare(right.courseId));
+
+  if (normalizedItems.length === 0) {
+    return [];
+  }
+
+  const totalListedPrice = normalizedItems.reduce(
+    (sum, item) => sum + item.listedPrice,
+    0,
+  );
+  const useEqualWeights = totalListedPrice <= 0;
+  const denominator = useEqualWeights ? normalizedItems.length : totalListedPrice;
+  const provisional = normalizedItems.map((item) => {
+    const numerator = useEqualWeights ? 1 : item.listedPrice;
+    const rawAmount = (normalizedFlatFee * numerator) / denominator;
+    const baseAmount = Math.floor(rawAmount);
+
+    return {
+      ...item,
+      baseAmount,
+      remainder: rawAmount - baseAmount,
+    };
+  });
+
+  let remaining = normalizedFlatFee - provisional.reduce((sum, item) => sum + item.baseAmount, 0);
+  provisional.sort((left, right) => {
+    if (left.remainder !== right.remainder) {
+      return right.remainder - left.remainder;
+    }
+
+    return left.courseId.localeCompare(right.courseId);
+  });
+
+  for (let index = 0; index < provisional.length && remaining > 0; index += 1) {
+    provisional[index]!.baseAmount += 1;
+    remaining -= 1;
+  }
+
+  return provisional
+    .sort((left, right) => left.courseId.localeCompare(right.courseId))
+    .map((item) => ({
+      courseId: item.courseId,
+      listedPrice: item.listedPrice,
+      checkoutPrice: item.listedPrice,
+      amountPaid: item.baseAmount,
+      savings: Math.max(0, item.listedPrice - item.baseAmount),
+    }));
+}
+
+export function pickWinningBundleCampaign(
+  qualifyingCampaigns: EvaluatedBundleCampaign[],
+): EvaluatedBundleCampaign | null {
+  if (qualifyingCampaigns.length === 0) {
+    return null;
+  }
+
+  return [...qualifyingCampaigns].sort(compareEvaluatedPrecedence)[0] ?? null;
+}
+
+export function evaluateBundleCampaigns(
+  cartItems: BundleCartItem[],
+  campaigns: BundleCampaignLike[],
+  now: number | Date = Date.now(),
+): BundleEvaluationResult {
+  const distinctItems = new Map<string, { courseId: string; listedPrice: number }>();
+
+  for (const item of cartItems) {
+    const quantity = Math.max(0, Math.floor(item.quantity ?? 1));
+    if (quantity <= 0) {
+      continue;
+    }
+
+    const courseId = String(item.courseId);
+    if (!distinctItems.has(courseId)) {
+      distinctItems.set(courseId, {
+        courseId,
+        listedPrice: Math.max(0, Math.round(item.listedPrice)),
+      });
+    }
+  }
+
+  const activeCampaigns = campaigns
+    .filter((campaign) => isBundleCampaignActive(campaign, now))
+    .sort(compareCampaignPrecedence);
+
+  const evaluated = activeCampaigns.map((campaign) => {
+    const eligibleIdSet = new Set(campaign.eligibleCourseIds.map((courseId) => String(courseId)));
+    const coveredItems = Array.from(distinctItems.values()).filter((item) =>
+      eligibleIdSet.has(item.courseId),
+    );
+    const coveredCourseIds = coveredItems.map((item) => item.courseId);
+    const coveredListedSubtotal = coveredItems.reduce(
+      (sum, item) => sum + item.listedPrice,
+      0,
+    );
+    const progress = {
+      selectedCount: coveredCourseIds.length,
+      minCount: Math.max(0, Math.round(campaign.requiredCourseCountMin)),
+      maxCount: Math.max(0, Math.round(campaign.requiredCourseCountMax)),
+    };
+    const qualifies =
+      progress.selectedCount >= progress.minCount &&
+      progress.selectedCount <= progress.maxCount;
+    const allocations = qualifies
+      ? allocateFlatFeeAcrossCourses(coveredItems, campaign.flatFee)
+      : [];
+    const coveredSavings = qualifies
+      ? Math.max(0, coveredListedSubtotal - Math.max(0, Math.round(campaign.flatFee)))
+      : 0;
+
+    return {
+      campaignId: String(campaign._id),
+      campaignName: campaign.name,
+      flatFee: Math.max(0, Math.round(campaign.flatFee)),
+      priority: Math.round(campaign.priority),
+      coveredCourseIds,
+      coveredListedSubtotal,
+      coveredSavings,
+      progress,
+      allocations,
+      qualifies,
+    };
+  });
+
+  const qualifyingCampaigns = evaluated
+    .filter((campaign) => campaign.qualifies)
+    .map(({ qualifies: _qualifies, ...campaign }) => campaign);
+
+  const appliedCampaign = pickWinningBundleCampaign(qualifyingCampaigns);
+  const progressCampaign =
+    appliedCampaign ??
+    evaluated
+      .filter(
+        (campaign) =>
+          !campaign.qualifies &&
+          campaign.progress.selectedCount > 0 &&
+          campaign.progress.selectedCount < campaign.progress.minCount,
+      )
+      .map(({ qualifies: _qualifies, ...campaign }) => campaign)
+      .sort(compareEvaluatedPrecedence)[0] ??
+    null;
+
+  return {
+    qualifyingCampaigns,
+    appliedCampaign,
+    progressCampaign,
+  };
+}

--- a/packages/domain/src/checkout.ts
+++ b/packages/domain/src/checkout.ts
@@ -8,6 +8,8 @@ export type CheckoutPricingItem = {
   redemptionDiscountAmount?: number;
   couponCode?: string;
   mindPointsRedeemed?: number;
+  bundleCampaignId?: Id<"bundleCampaigns">;
+  bundleCampaignName?: string;
 };
 
 export type CheckoutPricing = {

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./cart";
+export * from "./bundles";
 export * from "./checkout";
 export * from "./forms";
 export * from "./mind-points";

--- a/test-bundle-campaigns.js
+++ b/test-bundle-campaigns.js
@@ -1,0 +1,210 @@
+const assert = require("node:assert/strict");
+
+async function main() {
+  const {
+    allocateFlatFeeAcrossCourses,
+    evaluateBundleCampaigns,
+    isBundleCampaignActive,
+    pickWinningBundleCampaign,
+  } = await import("./packages/domain/src/bundles.ts");
+
+  assert.equal(
+    isBundleCampaignActive(
+      {
+        _id: "bundle-1",
+        name: "April Workshops",
+        flatFee: 7000,
+        requiredCourseCountMin: 7,
+        requiredCourseCountMax: 7,
+        eligibleCourseIds: ["a"],
+        priority: 100,
+        enabled: true,
+        isArchived: false,
+        startDate: "2026-04-01",
+        endDate: "2026-04-30",
+      },
+      new Date("2026-04-15T00:00:00Z"),
+    ),
+    true,
+  );
+  assert.equal(
+    isBundleCampaignActive(
+      {
+        _id: "bundle-2",
+        name: "Future Bundle",
+        flatFee: 5000,
+        requiredCourseCountMin: 3,
+        requiredCourseCountMax: 3,
+        eligibleCourseIds: ["a"],
+        priority: 100,
+        enabled: true,
+        isArchived: false,
+        startDate: "2026-05-01",
+      },
+      new Date("2026-04-15T00:00:00Z"),
+    ),
+    false,
+  );
+
+  const exactBundle = {
+    _id: "exact-7",
+    _creationTime: 10,
+    name: "7 Workshop Pass",
+    flatFee: 7000,
+    requiredCourseCountMin: 7,
+    requiredCourseCountMax: 7,
+    eligibleCourseIds: ["w1", "w2", "w3", "w4", "w5", "w6", "w7"],
+    priority: 100,
+    enabled: true,
+    isArchived: false,
+  };
+
+  const exactResult = evaluateBundleCampaigns(
+    [
+      { courseId: "w1", listedPrice: 1200, quantity: 1 },
+      { courseId: "w2", listedPrice: 1200, quantity: 1 },
+      { courseId: "w3", listedPrice: 1200, quantity: 1 },
+      { courseId: "w4", listedPrice: 1200, quantity: 1 },
+      { courseId: "w5", listedPrice: 1200, quantity: 1 },
+      { courseId: "w6", listedPrice: 1200, quantity: 1 },
+      { courseId: "w7", listedPrice: 1200, quantity: 1 },
+    ],
+    [exactBundle],
+    new Date("2026-04-15T00:00:00Z"),
+  );
+  assert.equal(exactResult.appliedCampaign?.campaignName, "7 Workshop Pass");
+  assert.equal(exactResult.appliedCampaign?.coveredCourseIds.length, 7);
+  assert.equal(exactResult.appliedCampaign?.coveredSavings, 1400);
+
+  const overExactResult = evaluateBundleCampaigns(
+    [
+      { courseId: "w1", listedPrice: 1200, quantity: 2 },
+      { courseId: "w2", listedPrice: 1200, quantity: 1 },
+      { courseId: "w3", listedPrice: 1200, quantity: 1 },
+      { courseId: "w4", listedPrice: 1200, quantity: 1 },
+      { courseId: "w5", listedPrice: 1200, quantity: 1 },
+      { courseId: "w6", listedPrice: 1200, quantity: 1 },
+      { courseId: "w7", listedPrice: 1200, quantity: 1 },
+      { courseId: "w8", listedPrice: 1200, quantity: 1 },
+    ],
+    [
+      {
+        _id: "range-3-5",
+        _creationTime: 20,
+        name: "5 Course Pick",
+        flatFee: 4500,
+        requiredCourseCountMin: 3,
+        requiredCourseCountMax: 5,
+        eligibleCourseIds: ["w1", "w2", "w3", "w4", "w5", "w6", "w7", "w8"],
+        priority: 90,
+        enabled: true,
+        isArchived: false,
+      },
+      {
+        _id: "exact-7-wide-pool",
+        _creationTime: 21,
+        name: "Exact 7 From 8",
+        flatFee: 6500,
+        requiredCourseCountMin: 7,
+        requiredCourseCountMax: 7,
+        eligibleCourseIds: ["w1", "w2", "w3", "w4", "w5", "w6", "w7", "w8"],
+        priority: 110,
+        enabled: true,
+        isArchived: false,
+      },
+    ],
+    new Date("2026-04-15T00:00:00Z"),
+  );
+  assert.equal(overExactResult.appliedCampaign, null);
+
+  const overlapResult = evaluateBundleCampaigns(
+    [
+      { courseId: "c1", listedPrice: 1000, quantity: 1 },
+      { courseId: "c2", listedPrice: 2000, quantity: 1 },
+      { courseId: "c3", listedPrice: 3000, quantity: 1 },
+    ],
+    [
+      {
+        _id: "low-priority",
+        _creationTime: 5,
+        name: "Lower Priority",
+        flatFee: 5000,
+        requiredCourseCountMin: 3,
+        requiredCourseCountMax: 3,
+        eligibleCourseIds: ["c1", "c2", "c3"],
+        priority: 100,
+        enabled: true,
+        isArchived: false,
+      },
+      {
+        _id: "high-priority",
+        _creationTime: 6,
+        name: "Higher Priority",
+        flatFee: 4500,
+        requiredCourseCountMin: 3,
+        requiredCourseCountMax: 3,
+        eligibleCourseIds: ["c1", "c2", "c3"],
+        priority: 200,
+        enabled: true,
+        isArchived: false,
+      },
+    ],
+    new Date("2026-04-15T00:00:00Z"),
+  );
+  assert.equal(overlapResult.qualifyingCampaigns.length, 2);
+  assert.equal(
+    pickWinningBundleCampaign(overlapResult.qualifyingCampaigns)?.campaignName,
+    "Higher Priority",
+  );
+  assert.equal(overlapResult.appliedCampaign?.campaignName, "Higher Priority");
+
+  const progressResult = evaluateBundleCampaigns(
+    [
+      { courseId: "c1", listedPrice: 1000, quantity: 2 },
+      { courseId: "c2", listedPrice: 1000, quantity: 1 },
+    ],
+    [
+      {
+        _id: "progress-bundle",
+        _creationTime: 1,
+        name: "3 Course Bundle",
+        flatFee: 2500,
+        requiredCourseCountMin: 3,
+        requiredCourseCountMax: 3,
+        eligibleCourseIds: ["c1", "c2", "c3"],
+        priority: 100,
+        enabled: true,
+        isArchived: false,
+      },
+    ],
+    new Date("2026-04-15T00:00:00Z"),
+  );
+  assert.equal(progressResult.appliedCampaign, null);
+  assert.equal(progressResult.progressCampaign?.progress.selectedCount, 2);
+  assert.equal(progressResult.progressCampaign?.progress.minCount, 3);
+
+  const allocation = allocateFlatFeeAcrossCourses(
+    [
+      { courseId: "c1", listedPrice: 1000 },
+      { courseId: "c2", listedPrice: 2000 },
+      { courseId: "c3", listedPrice: 3000 },
+    ],
+    5000,
+  );
+  assert.equal(
+    allocation.reduce((sum, item) => sum + item.amountPaid, 0),
+    5000,
+  );
+  assert.deepEqual(
+    allocation.map((item) => item.amountPaid),
+    [833, 1667, 2500],
+  );
+
+  console.log("bundle campaign tests passed");
+}
+
+main().catch((error) => {
+  console.error("bundle campaign tests failed");
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add bundle campaign modeling, evaluation, and checkout pricing support for flat-fee course bundles.
- Introduce a new admin bundle campaign manager and add bundle/offers navigation in the offers admin page.
- Update cart, enrollment admin views, and footer layering to reflect bundle-applied pricing and metadata.
- Add domain and Convex backend functions for saving, listing, archiving, and enabling bundle campaigns.
- Include a bundle campaign smoke test script for pricing and eligibility behavior.

## Testing
- Not run (not requested).
- Added `test-bundle-campaigns.js` to cover bundle evaluation scenarios.
- Recommend running `npm run lint` and `npm run type-check` before merging.
- Recommend verifying the cart UI with a qualifying bundle campaign and a standard coupon/BOGO combination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced bundle campaigns—administrators can now create, manage, and schedule promotional bundles for courses with flat-fee pricing
  * Bundle discounts automatically apply to eligible items in the cart with pricing adjustments and savings clearly displayed
  * Bundle campaign information now appears in enrollment details and admin dashboards
  * Added toggle in admin pricing section to switch between course offers and bundle campaigns management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds admin-managed bundle campaigns — flat-fee pricing across a curated set of courses — with full backend modeling in Convex, domain-layer evaluation logic, cart UI integration, and enrollment metadata tracking. Prior review concerns (flat-fee-exceeds-subtotal guard, `progressCampaign` null semantics, composite index for active-campaign queries) are all addressed in this revision.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all prior P0/P1 concerns are resolved and only minor cleanup items remain.

The three previously flagged issues (flat-fee guard, progressCampaign semantics, composite index) are all correctly addressed in this revision. The only remaining findings are a dead index and a smoke-test runner incompatibility, both P2.

convex/schema.ts (unused by_enabled_priority index), test-bundle-campaigns.js (module system mismatch)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/domain/src/bundles.ts | Core bundle evaluation logic: allocation, qualification guard (flatFee < coveredSubtotal), and progress tracking are all correct. Previous concerns resolved. |
| convex/schema.ts | Adds bundleCampaigns table with correct indexes, but by_enabled_priority is never queried and can be removed. |
| convex/bundleCampaigns.ts | Public query uses the correct composite index (by_enabled_isArchived_priority); JS-layer date and course filtering is appropriate. |
| convex/adminBundles.ts | Admin CRUD mutations with robust validation, audit logging, and archived-before-enable guard — well structured. |
| apps/web/components/CartClient.tsx | Bundle evaluation, pricing overlay, BOGO/coupon exclusion for covered courses, and summary line items all integrate cleanly. |
| apps/web/components/admin/BundleCampaignManager.tsx | Admin UI for creating/updating bundle campaigns; mirrors existing CourseOffers pattern with correct optimistic state handling. |
| test-bundle-campaigns.js | Smoke test mixes CJS require() with ESM await import() of a .ts file; will fail with plain node, needs tsx or similar runner. |
| packages/domain/src/checkout.ts | Adds optional bundleCampaignId/Name fields to CheckoutPricingItem type — minimal, correct change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cart as CartClient (browser)
    participant Convex as Convex DB
    participant Domain as domain/bundles.ts
    participant Checkout as myFunctions/checkout

    Cart->>Convex: listActiveBundleCampaignsForCourses(courseIds)
    Note over Convex: by_enabled_isArchived_priority index<br/>JS filter: isBundleCampaignActive + courseId overlap
    Convex-->>Cart: active campaigns[]

    Cart->>Domain: evaluateBundleCampaigns(cartItems, campaigns)
    Note over Domain: qualify: count in [min,max] AND flatFee < subtotal<br/>pick winner by priority
    Domain-->>Cart: { appliedCampaign, progressCampaign }

    Cart->>Cart: build checkoutPricing<br/>(bundle allocations override amountPaid,<br/>coupon skips covered courses)

    Cart->>Checkout: processCheckout(pricedItems with bundleCampaignId/Name)
    Note over Checkout: buildEnrollmentPricingFields stores<br/>bundleCampaignId + bundleCampaignName on enrollment
    Checkout-->>Cart: enrollment created
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fbundle-campaigns%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fbundle-campaigns%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aconvex%2Fschema.ts%3A223%0A**Unused%20index%20%60by_enabled_priority%60**%0A%0AThis%20index%20is%20never%20referenced%20in%20any%20query%20%E2%80%94%20%60bundleCampaigns.ts%60%20uses%20%60by_enabled_isArchived_priority%60%20and%20%60adminBundles.ts%60%20uses%20%60by_updatedAt%60%20%2F%20%60by_isArchived_updatedAt%60.%20Convex%20maintains%20all%20defined%20indexes%20on%20every%20write%2C%20so%20this%20is%20unnecessary%20write%20overhead.%0A%0A%60%60%60suggestion%0A%20%20%20%20.index%28%22by_enabled_isArchived_priority%22%2C%20%5B%0A%60%60%60%0A%0A%28i.e.%20remove%20the%20%60by_enabled_priority%60%20line%20entirely%2C%20keeping%20the%20three%20indexes%20that%20are%20actually%20used.%29%0A%0A%23%23%23%20Issue%202%20of%202%0Atest-bundle-campaigns.js%3A1-9%0A**CJS%20%60require%60%20%2B%20ESM%20%60await%20import%60%20of%20a%20%60.ts%60%20file%20won't%20run%20with%20plain%20%60node%60**%0A%0A%60require%28%22node%3Aassert%2Fstrict%22%29%60%20is%20CommonJS%3B%20%60await%20import%28%22.%2Fpackages%2Fdomain%2Fsrc%2Fbundles.ts%22%29%60%20is%20ESM%20and%20also%20imports%20a%20TypeScript%20source%20file%20directly.%20Plain%20%60node%20test-bundle-campaigns.js%60%20will%20fail%20on%20both%20counts.%20You%20need%20a%20runner%20like%20%60tsx%60%20%28e.g.%20%60npx%20tsx%20test-bundle-campaigns.js%60%29%20or%20convert%20the%20file%20to%20a%20proper%20ESM%20%60.mjs%60%2F%60.ts%60%20test.%0A%0AConsider%20converting%20to%20a%20self-contained%20ESM%20script%3A%0A%60%60%60js%0Aimport%20assert%20from%20%22node%3Aassert%2Fstrict%22%3B%0Aimport%20%7B%20%2F*%20...%20*%2F%20%7D%20from%20%22.%2Fpackages%2Fdomain%2Fsrc%2Fbundles.ts%22%3B%0A%60%60%60%0Aand%20running%20with%20%60tsx%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aconvex%2Fschema.ts%3A223%0A**Unused%20index%20%60by_enabled_priority%60**%0A%0AThis%20index%20is%20never%20referenced%20in%20any%20query%20%E2%80%94%20%60bundleCampaigns.ts%60%20uses%20%60by_enabled_isArchived_priority%60%20and%20%60adminBundles.ts%60%20uses%20%60by_updatedAt%60%20%2F%20%60by_isArchived_updatedAt%60.%20Convex%20maintains%20all%20defined%20indexes%20on%20every%20write%2C%20so%20this%20is%20unnecessary%20write%20overhead.%0A%0A%60%60%60suggestion%0A%20%20%20%20.index%28%22by_enabled_isArchived_priority%22%2C%20%5B%0A%60%60%60%0A%0A%28i.e.%20remove%20the%20%60by_enabled_priority%60%20line%20entirely%2C%20keeping%20the%20three%20indexes%20that%20are%20actually%20used.%29%0A%0A%23%23%23%20Issue%202%20of%202%0Atest-bundle-campaigns.js%3A1-9%0A**CJS%20%60require%60%20%2B%20ESM%20%60await%20import%60%20of%20a%20%60.ts%60%20file%20won't%20run%20with%20plain%20%60node%60**%0A%0A%60require%28%22node%3Aassert%2Fstrict%22%29%60%20is%20CommonJS%3B%20%60await%20import%28%22.%2Fpackages%2Fdomain%2Fsrc%2Fbundles.ts%22%29%60%20is%20ESM%20and%20also%20imports%20a%20TypeScript%20source%20file%20directly.%20Plain%20%60node%20test-bundle-campaigns.js%60%20will%20fail%20on%20both%20counts.%20You%20need%20a%20runner%20like%20%60tsx%60%20%28e.g.%20%60npx%20tsx%20test-bundle-campaigns.js%60%29%20or%20convert%20the%20file%20to%20a%20proper%20ESM%20%60.mjs%60%2F%60.ts%60%20test.%0A%0AConsider%20converting%20to%20a%20self-contained%20ESM%20script%3A%0A%60%60%60js%0Aimport%20assert%20from%20%22node%3Aassert%2Fstrict%22%3B%0Aimport%20%7B%20%2F*%20...%20*%2F%20%7D%20from%20%22.%2Fpackages%2Fdomain%2Fsrc%2Fbundles.ts%22%3B%0A%60%60%60%0Aand%20running%20with%20%60tsx%60.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aconvex%2Fschema.ts%3A223%0A**Unused%20index%20%60by_enabled_priority%60**%0A%0AThis%20index%20is%20never%20referenced%20in%20any%20query%20%E2%80%94%20%60bundleCampaigns.ts%60%20uses%20%60by_enabled_isArchived_priority%60%20and%20%60adminBundles.ts%60%20uses%20%60by_updatedAt%60%20%2F%20%60by_isArchived_updatedAt%60.%20Convex%20maintains%20all%20defined%20indexes%20on%20every%20write%2C%20so%20this%20is%20unnecessary%20write%20overhead.%0A%0A%60%60%60suggestion%0A%20%20%20%20.index%28%22by_enabled_isArchived_priority%22%2C%20%5B%0A%60%60%60%0A%0A%28i.e.%20remove%20the%20%60by_enabled_priority%60%20line%20entirely%2C%20keeping%20the%20three%20indexes%20that%20are%20actually%20used.%29%0A%0A%23%23%23%20Issue%202%20of%202%0Atest-bundle-campaigns.js%3A1-9%0A**CJS%20%60require%60%20%2B%20ESM%20%60await%20import%60%20of%20a%20%60.ts%60%20file%20won't%20run%20with%20plain%20%60node%60**%0A%0A%60require%28%22node%3Aassert%2Fstrict%22%29%60%20is%20CommonJS%3B%20%60await%20import%28%22.%2Fpackages%2Fdomain%2Fsrc%2Fbundles.ts%22%29%60%20is%20ESM%20and%20also%20imports%20a%20TypeScript%20source%20file%20directly.%20Plain%20%60node%20test-bundle-campaigns.js%60%20will%20fail%20on%20both%20counts.%20You%20need%20a%20runner%20like%20%60tsx%60%20%28e.g.%20%60npx%20tsx%20test-bundle-campaigns.js%60%29%20or%20convert%20the%20file%20to%20a%20proper%20ESM%20%60.mjs%60%2F%60.ts%60%20test.%0A%0AConsider%20converting%20to%20a%20self-contained%20ESM%20script%3A%0A%60%60%60js%0Aimport%20assert%20from%20%22node%3Aassert%2Fstrict%22%3B%0Aimport%20%7B%20%2F*%20...%20*%2F%20%7D%20from%20%22.%2Fpackages%2Fdomain%2Fsrc%2Fbundles.ts%22%3B%0A%60%60%60%0Aand%20running%20with%20%60tsx%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: convex/schema.ts
Line: 223

Comment:
**Unused index `by_enabled_priority`**

This index is never referenced in any query — `bundleCampaigns.ts` uses `by_enabled_isArchived_priority` and `adminBundles.ts` uses `by_updatedAt` / `by_isArchived_updatedAt`. Convex maintains all defined indexes on every write, so this is unnecessary write overhead.

```suggestion
    .index("by_enabled_isArchived_priority", [
```

(i.e. remove the `by_enabled_priority` line entirely, keeping the three indexes that are actually used.)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test-bundle-campaigns.js
Line: 1-9

Comment:
**CJS `require` + ESM `await import` of a `.ts` file won't run with plain `node`**

`require("node:assert/strict")` is CommonJS; `await import("./packages/domain/src/bundles.ts")` is ESM and also imports a TypeScript source file directly. Plain `node test-bundle-campaigns.js` will fail on both counts. You need a runner like `tsx` (e.g. `npx tsx test-bundle-campaigns.js`) or convert the file to a proper ESM `.mjs`/`.ts` test.

Consider converting to a self-contained ESM script:
```js
import assert from "node:assert/strict";
import { /* ... */ } from "./packages/domain/src/bundles.ts";
```
and running with `tsx`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Refine bundle campaign eligibility and i..."](https://github.com/ayushj1001/mindpoint/commit/f1b5ed346239cd18a568443aebb6fa71f3fac287) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28215587)</sub>

<!-- /greptile_comment -->