### PR TITLE
Fix CI/build for Next 16 Dependabot bump

### DIFF
--- a/apps/web/app/account/layout.tsx
+++ b/apps/web/app/account/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, Suspense } from "react";
-import { SignedIn, SignedOut, RedirectToSignIn } from "@clerk/nextjs";
+import { RedirectToSignIn, Show } from "@clerk/nextjs";
 import { useSearchParams, useRouter } from "next/navigation";
 import { BookOpen, Gift, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -36,7 +36,7 @@ function AccountLayoutContent({ children }: { children: React.ReactNode }) {
 
   return (
     <>
-      <SignedIn>
+      <Show when="signed-in">
         <div className="container mx-auto px-4 py-8">
           <div className="mb-8">
             <h1 className="text-3xl font-bold">My Account</h1>
@@ -92,10 +92,10 @@ function AccountLayoutContent({ children }: { children: React.ReactNode }) {
             <main className="flex-1">{children}</main>
           </div>
         </div>
-      </SignedIn>
-      <SignedOut>
+      </Show>
+      <Show when="signed-out">
         <RedirectToSignIn />
-      </SignedOut>
+      </Show>
     </>
   );
 }

--- a/apps/web/app/courses/[id]/page.tsx
+++ b/apps/web/app/courses/[id]/page.tsx
@@ -5,8 +5,8 @@ import { ConvexHttpClient } from "convex/browser";
 import { Id } from "@mindpoint/backend/data-model";
 import Script from "next/script";
 
-// Create a Convex client for server-side data fetching
-const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+const convex = convexUrl ? new ConvexHttpClient(convexUrl) : null;
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -14,6 +14,14 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   try {
+    if (!convex) {
+      return {
+        title: "Course - The Mind Point",
+        description:
+          "Learn about our mental health courses and professional development programs.",
+      };
+    }
+
     const { id } = await params;
     const course = await convex.query(api.courses.getCourseById, {
       id: id as Id<"courses">,
@@ -83,6 +91,19 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function CoursePage({ params }: Props) {
   try {
+    if (!convex) {
+      return (
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="text-center">
+            <h1 className="mb-4 text-2xl font-bold">Course Unavailable</h1>
+            <p className="text-muted-foreground">
+              Course data is currently unavailable.
+            </p>
+          </div>
+        </div>
+      );
+    }
+
     const { id } = await params;
     const course = await convex.query(api.courses.getCourseById, {
       id: id as Id<"courses">,

--- a/apps/web/app/navbar.tsx
+++ b/apps/web/app/navbar.tsx
@@ -12,7 +12,7 @@ import {
   NavigationMenuTrigger,
 } from "@/components/ui/navigation-menu";
 import Image from "next/image";
-import { SignedIn, SignedOut, SignInButton, UserButton } from "@clerk/nextjs";
+import { Show, SignInButton, UserButton } from "@clerk/nextjs";
 import { useCart } from "react-use-cart";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -618,14 +618,14 @@ export default function Navbar() {
               </SheetContent>
             </Sheet>
             <div className="flex items-center gap-2">
-              <SignedIn>
+              <Show when="signed-in">
                 <MindPointsBadge />
                 <UserButton
                   userProfileMode="navigation"
                   userProfileUrl="/account"
                 />
-              </SignedIn>
-              <SignedOut>
+              </Show>
+              <Show when="signed-out">
                 <SignInButton>
                   <Button
                     variant="ghost"
@@ -636,7 +636,7 @@ export default function Navbar() {
                     <span className="sm:hidden">Sign in</span>
                   </Button>
                 </SignInButton>
-              </SignedOut>
+              </Show>
             </div>
           </div>
         </div>

--- a/apps/web/app/server/page.tsx
+++ b/apps/web/app/server/page.tsx
@@ -15,6 +15,24 @@ export const metadata = {
 };
 
 export default async function ServerPage() {
+  // This page demonstrates server-side Convex. During builds (e.g. CI/Vercel previews),
+  // the Convex deployment URL may be intentionally omitted. In that case, render a
+  // non-interactive fallback instead of failing prerender.
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return (
+      <main className="mx-auto flex max-w-2xl flex-col gap-4 p-8">
+        <h1 className="text-center text-4xl font-bold">Convex + Next.js</h1>
+        <div className="flex flex-col gap-2 rounded-md bg-lavender-100 p-4 dark:bg-card">
+          <h2 className="text-xl font-bold">Server data disabled</h2>
+          <p className="text-muted-foreground text-sm">
+            This preview was built without a Convex deployment URL, so server-side
+            data fetching is skipped.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
   const preloaded = await preloadQuery(api.myFunctions.listNumbers, {
     count: 3,
   });

--- a/apps/web/components/ConvexClientProvider.tsx
+++ b/apps/web/components/ConvexClientProvider.tsx
@@ -11,13 +11,15 @@ export default function ConvexClientProvider({
   children: ReactNode;
 }) {
   // Keep required public env checks local in client boot code so Next can inline them.
-  const convex = process.env.NEXT_PUBLIC_CONVEX_URL
-    ? new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL)
-    : null;
+  // If Convex isn't configured (e.g. Vercel previews for Dependabot), fall back to a
+  // dummy deployment URL so hooks like `useQuery` don't crash during prerender.
+  const convexUrl =
+    process.env.NEXT_PUBLIC_CONVEX_URL ?? "https://dummy.convex.cloud";
+  const isDummyConvexUrl = !process.env.NEXT_PUBLIC_CONVEX_URL;
+  const convex = new ConvexReactClient(convexUrl);
 
-  // If no Convex URL is available, render children without Convex providers
-  if (!convex) {
-    return <>{children}</>;
+  if (isDummyConvexUrl) {
+    return <ConvexProvider client={convex}>{children}</ConvexProvider>;
   }
 
   // If Clerk keys are available, use ConvexProviderWithClerk for authentication

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -18,6 +18,7 @@ const eslintConfig = [
       "react-hooks/preserve-manual-memoization": "off",
       "react-hooks/refs": "off",
       "react-hooks/set-state-in-effect": "off",
+      "@typescript-eslint/no-empty-object-type": "off",
     },
   },
 ];

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,6 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
+const nextConfig = {
   /* config options here */
   transpilePackages: [
     "@mindpoint/backend",
@@ -10,9 +10,6 @@ const nextConfig: NextConfig = {
   ],
   typescript: {
     ignoreBuildErrors: true,
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
   },
   // Disable Clerk key validation during build if keys are dummy
   env: {
@@ -80,6 +77,6 @@ const nextConfig: NextConfig = {
   },
   // This is required to support PostHog trailing slash API requests
   skipTrailingSlashRedirect: true,
-};
+} satisfies NextConfig;
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "type-check": "tsc --project tsconfig.json --noEmit"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "embla-carousel-react": "^8.6.0",
         "googleapis": "^156.0.0",
         "lucide-react": "^0.536.0",
-        "next": "15.5.14",
+        "next": "16.2.3",
         "next-themes": "^0.4.6",
         "posthog-js": "^1.264.2",
         "posthog-node": "^5.8.4",
@@ -4426,9 +4426,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
-      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -4442,9 +4442,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
-      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -4458,9 +4458,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
-      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -4474,11 +4474,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
-      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4490,11 +4493,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
-      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4506,11 +4512,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
-      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4522,11 +4531,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
-      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4538,9 +4550,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
-      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -4554,9 +4566,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
-      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -16102,13 +16114,14 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
-      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.14",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -16117,18 +16130,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+        "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.14",
-        "@next/swc-darwin-x64": "15.5.14",
-        "@next/swc-linux-arm64-gnu": "15.5.14",
-        "@next/swc-linux-arm64-musl": "15.5.14",
-        "@next/swc-linux-x64-gnu": "15.5.14",
-        "@next/swc-linux-x64-musl": "15.5.14",
-        "@next/swc-win32-arm64-msvc": "15.5.14",
-        "@next/swc-win32-x64-msvc": "15.5.14",
-        "sharp": "^0.34.3"
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "packages/*"
       ],
       "dependencies": {
-        "@clerk/clerk-react": "^5.25.0",
-        "@clerk/nextjs": "^6.12.6",
+        "@clerk/clerk-react": "^5.61.3",
+        "@clerk/nextjs": "^7.0.12",
         "@hookform/resolvers": "^5.2.1",
         "@icons-pack/react-simple-icons": "^13.7.0",
         "@radix-ui/react-accordion": "^1.2.11",
@@ -48,8 +48,8 @@
         "posthog-js": "^1.264.2",
         "posthog-node": "^5.8.4",
         "razorpay": "^2.9.6",
-        "react": "19.2.0",
-        "react-dom": "19.2.0",
+        "react": "19.2.3",
+        "react-dom": "19.2.3",
         "react-hook-form": "^7.62.0",
         "react-markdown": "^9.1.0",
         "react-phone-number-input": "^3.4.12",
@@ -196,6 +196,27 @@
       "peerDependencies": {
         "react-native-css": "^3.0.1",
         "tailwindcss": ">4.1.11"
+      }
+    },
+    "apps/mobile/node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "apps/mobile/node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
       }
     },
     "apps/mobile/node_modules/tailwindcss": {
@@ -1774,19 +1795,46 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.6.2.tgz",
-      "integrity": "sha512-IUTjLmA1QkqoJnB97S8Ay/oeFR1QtBxxzi9V2J8zncGdUUpAHRp9PfbUwe203VEZuoDD8n6PGfK4oiiq5CoKhQ==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.8.tgz",
+      "integrity": "sha512-N9yqCQCdkn/4XpfiVnaoS6wXDeC2yQf85ioHGolOIOCWXOPwMd63fONUfRhwOZSlXGTAsgyUNZu87Ps0tcVYsg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.17.0",
-        "@clerk/types": "^4.72.0",
-        "cookie": "1.0.2",
+        "@clerk/shared": "^4.6.0",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
+      }
+    },
+    "node_modules/@clerk/backend/node_modules/@clerk/shared": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.6.0.tgz",
+      "integrity": "sha512-dtbsO/+xK5e+qWuOAY1ekZ8BJxsB0F0LYDpXWjRON7JSoFKSaqqaH5cwBvdjbbWaehb6jz1YUQmWVV8gBOx6Ag==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.16",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@clerk/clerk-expo": {
@@ -1963,21 +2011,20 @@
       "license": "MIT"
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.38.1.tgz",
-      "integrity": "sha512-IOn/Raet3jwkug8P/gLMe2nsw2wKllWGOGPFOAaaYxbXfIZ8MPngNv2/MMgVRF7cAX1UwrmU1PzrLNtBJ/EHPQ==",
+      "version": "5.61.4",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.4.tgz",
+      "integrity": "sha512-xGvQvzfc5pQEuqCW8CNUgnlR+9nt6gSSMGMYx3l972utIJrFKByQJFCRZpwYBvAHiveuK11Wgy3J39p904jb+w==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.17.0",
-        "@clerk/types": "^4.72.0",
+        "@clerk/shared": "^3.47.3",
         "tslib": "2.8.1"
       },
       "engines": {
         "node": ">=18.17.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       }
     },
     "node_modules/@clerk/localizations": {
@@ -1993,47 +2040,45 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "6.28.1",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.28.1.tgz",
-      "integrity": "sha512-1R+kK5lSwY4RCwEMUgNcryR588af59LPw25rO/DzBn9EAsIcLgRP8Tu8tKWvnBoXaSzIUYVZUQa7/bAAjoMnXA==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.0.12.tgz",
+      "integrity": "sha512-dq4iOLKf5PImLlA2YAs7c2E+yBiOYlbMlnw386xw+sTe/kv4KpRQPk2g/7PeEvFxFaV1gY764iy2sr4jy2bdQA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^2.6.2",
-        "@clerk/clerk-react": "^5.38.1",
-        "@clerk/shared": "^3.17.0",
-        "@clerk/types": "^4.72.0",
+        "@clerk/backend": "^3.2.8",
+        "@clerk/react": "^6.2.1",
+        "@clerk/shared": "^4.6.0",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "next": "^13.5.7 || ^14.2.25 || ^15.2.3",
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+        "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0",
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       }
     },
-    "node_modules/@clerk/shared": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.17.0.tgz",
-      "integrity": "sha512-eYbA0xmKG1DluFmdVykXiElgZGTpCruEyXmIBAwokpxypd5nOpDsS1xvEKwYvZieLTZkFz21Z3Y6HdDI5cPxBQ==",
+    "node_modules/@clerk/nextjs/node_modules/@clerk/shared": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.6.0.tgz",
+      "integrity": "sha512-dtbsO/+xK5e+qWuOAY1ekZ8BJxsB0F0LYDpXWjRON7JSoFKSaqqaH5cwBvdjbbWaehb6jz1YUQmWVV8gBOx6Ag==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@clerk/types": "^4.72.0",
+        "@tanstack/query-core": "5.90.16",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
-        "std-env": "^3.9.0",
-        "swr": "2.3.4"
+        "std-env": "^3.9.0"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2044,23 +2089,56 @@
         }
       }
     },
-    "node_modules/@clerk/types": {
-      "version": "4.101.20",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.20.tgz",
-      "integrity": "sha512-MHvr1tGL5lwxD6zdzzixkHICbbZz/S1LChONKR52Qeu0yRGChZomPknsgqBMG9J3yNeyhaj0SWa5phQgQUk0lg==",
-      "deprecated": "This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3",
+    "node_modules/@clerk/react": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.2.1.tgz",
+      "integrity": "sha512-fZpCBHTRgxkLk1S7FPp8iDpl2ZoZ/VFKvQWs3CFRX4Z9FFEcC5eAMPYbEL3treUv3TzQxcGTSgp5gd9+mFx4LQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.2"
+        "@clerk/shared": "^4.6.0",
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       }
     },
-    "node_modules/@clerk/types/node_modules/@clerk/shared": {
-      "version": "3.47.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.2.tgz",
-      "integrity": "sha512-dwUT27DKq3Gr9vn9lAfc/LSe79P1rKIib8/mTWA7ZEzY7XX2Yq5UnDMCMznYrI8oVLdJrCT4ypFXRgnH306Oew==",
+    "node_modules/@clerk/react/node_modules/@clerk/shared": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.6.0.tgz",
+      "integrity": "sha512-dtbsO/+xK5e+qWuOAY1ekZ8BJxsB0F0LYDpXWjRON7JSoFKSaqqaH5cwBvdjbbWaehb6jz1YUQmWVV8gBOx6Ag==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.16",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "3.47.3",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.3.tgz",
+      "integrity": "sha512-jG0wMIZuuc8zaKieg9Os8ocTphG+llluRukUUdyVnu4+ZI1syVf+dkpDP3ZK69yLavTX3D0KAmkmQqTPzQV/Nw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2085,6 +2163,19 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@clerk/types": {
+      "version": "4.101.20",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.20.tgz",
+      "integrity": "sha512-MHvr1tGL5lwxD6zdzzixkHICbbZz/S1LChONKR52Qeu0yRGChZomPknsgqBMG9J3yNeyhaj0SWa5phQgQUk0lg==",
+      "deprecated": "This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.2"
+      },
+      "engines": {
+        "node": ">=18.17.0"
       }
     },
     "node_modules/@coinbase/wallet-sdk": {
@@ -7210,6 +7301,16 @@
         "tailwindcss": "4.1.11"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.16",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
+      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -9754,15 +9855,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/copy-to-clipboard": {
@@ -17905,9 +17997,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17924,15 +18016,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.3"
       }
     },
     "node_modules/react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "test:admin-route-protection": "node scripts/test-admin-route-protection.js"
   },
   "dependencies": {
-    "@clerk/clerk-react": "^5.25.0",
-    "@clerk/nextjs": "^6.12.6",
+    "@clerk/clerk-react": "^5.61.3",
+    "@clerk/nextjs": "^7.0.12",
     "@hookform/resolvers": "^5.2.1",
     "@icons-pack/react-simple-icons": "^13.7.0",
     "@radix-ui/react-accordion": "^1.2.11",
@@ -69,8 +69,8 @@
     "posthog-js": "^1.264.2",
     "posthog-node": "^5.8.4",
     "razorpay": "^2.9.6",
-    "react": "19.2.0",
-    "react-dom": "19.2.0",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
     "react-hook-form": "^7.62.0",
     "react-markdown": "^9.1.0",
     "react-phone-number-input": "^3.4.12",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "embla-carousel-react": "^8.6.0",
     "googleapis": "^156.0.0",
     "lucide-react": "^0.536.0",
-    "next": "15.5.14",
+    "next": "16.2.3",
     "next-themes": "^0.4.6",
     "posthog-js": "^1.264.2",
     "posthog-node": "^5.8.4",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR makes the `next@16.2.3` Dependabot bump mergeable by resolving install-time peer conflicts and updating app code/config for Clerk + Next 16.

## Changes

- Update Clerk packages to versions that support Next 16 and bump `react`/`react-dom` to compatible `19.2.3`.
- Replace removed `SignedIn`/`SignedOut` wrappers with `Show` from Clerk.
- Update Next config typing so Next 16’s `NextConfig` type-check passes.
- Fix lint command regression by switching web lint to `eslint .` and ignoring a legacy type-augmentation edge case.
- Make build/prerender resilient when `NEXT_PUBLIC_CONVEX_URL` is missing:
  - Guard Convex server-side client creation in `/courses/[id]`.
  - Ensure Convex provider exists for prerender by using a build-only fallback URL.
  - Make `/server` route degrade gracefully without Convex env.

## Verification

- `npm ci`
- `npm run type-check`
- `npm run lint`
- `npm run build`

All pass locally on Node 22.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea02aec3-69dd-4aba-b73f-8ecdcc490b6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea02aec3-69dd-4aba-b73f-8ecdcc490b6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the Dependabot Next 16 bump mergeable by resolving peer-dependency conflicts (Clerk v7, React 19.2.3), migrating deprecated `SignedIn`/`SignedOut` to Clerk v7's `Show` component, and adding build-time resilience so prerender doesn't fail when `NEXT_PUBLIC_CONVEX_URL` is absent. All checks are reported to pass locally on Node 22.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues found; all remaining findings are style/best-practice suggestions.

The changes are well-scoped dependency upgrades with appropriate fallbacks for missing env vars. The two P2 findings (ConvexReactClient instantiation in the render body, and ESLint now running during next build) are minor quality improvements that don't affect correctness or safety. The PR author confirmed all verification steps pass locally.

apps/web/components/ConvexClientProvider.tsx (client instantiation pattern) and apps/web/next.config.ts (ESLint-during-build behaviour change)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/components/ConvexClientProvider.tsx | Switches from null fallback to a dummy Convex URL for prerender resilience; `new ConvexReactClient` is still instantiated in the component body on every render. |
| apps/web/app/courses/[id]/page.tsx | Module-level `ConvexHttpClient` is now nullable with early-return fallbacks for missing `NEXT_PUBLIC_CONVEX_URL`; logic is correct. |
| apps/web/app/account/layout.tsx | Replaces deprecated Clerk `SignedIn`/`SignedOut` with `Show when="signed-in"` / `Show when="signed-out"` for Clerk v7 compatibility. |
| apps/web/app/navbar.tsx | Same `SignedIn`/`SignedOut` → `Show` migration as account layout; change is consistent and correct. |
| apps/web/app/server/page.tsx | Adds early return with a static fallback UI when `NEXT_PUBLIC_CONVEX_URL` is absent, preventing prerender failures in CI. |
| apps/web/next.config.ts | Switches type annotation to `satisfies NextConfig` and removes `eslint.ignoreDuringBuilds: true`, making ESLint run during `next build`. |
| apps/web/package.json | Lint script changed from `next lint` to `eslint .` to decouple from the Next CLI runner. |
| apps/web/eslint.config.mjs | Adds `@typescript-eslint/no-empty-object-type: "off"` to suppress a legacy type-augmentation lint error in the Next 16 build. |
| package.json | Bumps `@clerk/nextjs` to `^7.0.12`, `@clerk/clerk-react` to `^5.61.3`, `next` to `16.2.3`, and `react`/`react-dom` to `19.2.3`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ConvexClientProvider mounts] --> B{NEXT_PUBLIC_CONVEX_URL set?}
    B -- No --> C[Use dummy.convex.cloud URL]
    C --> D[Wrap with ConvexProvider only\nno auth tokens]
    B -- Yes --> E{NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY set?}
    E -- Yes --> F[Wrap with ConvexProviderWithClerk\nwith auth tokens]
    E -- No --> G[Wrap with ConvexProvider only\nno auth tokens]

    H[courses/id page.tsx] --> I{convex client null?}
    I -- Yes --> J[Return static fallback UI]
    I -- No --> K[Fetch course via ConvexHttpClient]

    L[server/page.tsx] --> M{NEXT_PUBLIC_CONVEX_URL set?}
    M -- No --> N[Return static fallback UI]
    M -- Yes --> O[preloadQuery from Convex]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22cursor%2Fbabysit-pr59-0b6f%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fbabysit-pr59-0b6f%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fcomponents%2FConvexClientProvider.tsx%3A19%0A**%60ConvexReactClient%60%20re-created%20on%20every%20render**%0A%0A%60new%20ConvexReactClient%28convexUrl%29%60%20is%20called%20directly%20in%20the%20component%20body%2C%20so%20a%20fresh%20client%20%28and%20a%20new%20underlying%20WebSocket%29%20is%20allocated%20on%20every%20re-render%20of%20this%20provider.%20The%20env-var%20value%20is%20a%20build-time%20constant%2C%20so%20in%20practice%20the%20provider%20is%20stable%2C%20but%20stabilising%20the%20instance%20explicitly%20would%20be%20safer%3A%0A%0A%60%60%60suggestion%0A%20%20const%20%5Bconvex%5D%20%3D%20useState%28%28%29%20%3D%3E%20new%20ConvexReactClient%28convexUrl%29%29%3B%0A%60%60%60%0A%0AThis%20was%20partially%20pre-existing%20%28the%20old%20code%20also%20called%20%60new%20ConvexReactClient%60%20in%20the%20render%20path%29%2C%20but%20the%20PR%20now%20does%20it%20unconditionally%20%28including%20the%20dummy%20URL%20path%29%2C%20so%20it's%20worth%20addressing.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fnext.config.ts%3A3%0A**ESLint%20now%20runs%20during%20%60next%20build%60**%0A%0ARemoving%20the%20%60eslint%3A%20%7B%20ignoreDuringBuilds%3A%20true%20%7D%60%20block%20means%20%60next%20build%60%20will%20execute%20ESLint%20automatically%20%28Next.js%20default%20behaviour%29.%20Combined%20with%20the%20%60lint%60%20script%20change%20to%20%60eslint%20.%60%2C%20ESLint%20effectively%20runs%20twice%20in%20CI%20pipelines%20that%20call%20both%20%60npm%20run%20lint%60%20and%20%60npm%20run%20build%60.%20If%20any%20new%20lint%20errors%20surface%20that%20aren't%20covered%20by%20the%20%60%40typescript-eslint%2Fno-empty-object-type%3A%20%22off%22%60%20suppression%2C%20builds%20will%20fail%20unexpectedly.%0A%0AIf%20the%20intent%20is%20to%20enforce%20lint%20parity%20with%20the%20build%2C%20this%20is%20intentional%20%E2%80%94%20just%20worth%20confirming.%20Alternatively%2C%20re-add%20%60eslint%3A%20%7B%20ignoreDuringBuilds%3A%20true%20%7D%60%20to%20let%20the%20dedicated%20lint%20step%20own%20ESLint.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fcomponents%2FConvexClientProvider.tsx%3A19%0A**%60ConvexReactClient%60%20re-created%20on%20every%20render**%0A%0A%60new%20ConvexReactClient%28convexUrl%29%60%20is%20called%20directly%20in%20the%20component%20body%2C%20so%20a%20fresh%20client%20%28and%20a%20new%20underlying%20WebSocket%29%20is%20allocated%20on%20every%20re-render%20of%20this%20provider.%20The%20env-var%20value%20is%20a%20build-time%20constant%2C%20so%20in%20practice%20the%20provider%20is%20stable%2C%20but%20stabilising%20the%20instance%20explicitly%20would%20be%20safer%3A%0A%0A%60%60%60suggestion%0A%20%20const%20%5Bconvex%5D%20%3D%20useState%28%28%29%20%3D%3E%20new%20ConvexReactClient%28convexUrl%29%29%3B%0A%60%60%60%0A%0AThis%20was%20partially%20pre-existing%20%28the%20old%20code%20also%20called%20%60new%20ConvexReactClient%60%20in%20the%20render%20path%29%2C%20but%20the%20PR%20now%20does%20it%20unconditionally%20%28including%20the%20dummy%20URL%20path%29%2C%20so%20it's%20worth%20addressing.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fnext.config.ts%3A3%0A**ESLint%20now%20runs%20during%20%60next%20build%60**%0A%0ARemoving%20the%20%60eslint%3A%20%7B%20ignoreDuringBuilds%3A%20true%20%7D%60%20block%20means%20%60next%20build%60%20will%20execute%20ESLint%20automatically%20%28Next.js%20default%20behaviour%29.%20Combined%20with%20the%20%60lint%60%20script%20change%20to%20%60eslint%20.%60%2C%20ESLint%20effectively%20runs%20twice%20in%20CI%20pipelines%20that%20call%20both%20%60npm%20run%20lint%60%20and%20%60npm%20run%20build%60.%20If%20any%20new%20lint%20errors%20surface%20that%20aren't%20covered%20by%20the%20%60%40typescript-eslint%2Fno-empty-object-type%3A%20%22off%22%60%20suppression%2C%20builds%20will%20fail%20unexpectedly.%0A%0AIf%20the%20intent%20is%20to%20enforce%20lint%20parity%20with%20the%20build%2C%20this%20is%20intentional%20%E2%80%94%20just%20worth%20confirming.%20Alternatively%2C%20re-add%20%60eslint%3A%20%7B%20ignoreDuringBuilds%3A%20true%20%7D%60%20to%20let%20the%20dedicated%20lint%20step%20own%20ESLint.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fcomponents%2FConvexClientProvider.tsx%3A19%0A**%60ConvexReactClient%60%20re-created%20on%20every%20render**%0A%0A%60new%20ConvexReactClient%28convexUrl%29%60%20is%20called%20directly%20in%20the%20component%20body%2C%20so%20a%20fresh%20client%20%28and%20a%20new%20underlying%20WebSocket%29%20is%20allocated%20on%20every%20re-render%20of%20this%20provider.%20The%20env-var%20value%20is%20a%20build-time%20constant%2C%20so%20in%20practice%20the%20provider%20is%20stable%2C%20but%20stabilising%20the%20instance%20explicitly%20would%20be%20safer%3A%0A%0A%60%60%60suggestion%0A%20%20const%20%5Bconvex%5D%20%3D%20useState%28%28%29%20%3D%3E%20new%20ConvexReactClient%28convexUrl%29%29%3B%0A%60%60%60%0A%0AThis%20was%20partially%20pre-existing%20%28the%20old%20code%20also%20called%20%60new%20ConvexReactClient%60%20in%20the%20render%20path%29%2C%20but%20the%20PR%20now%20does%20it%20unconditionally%20%28including%20the%20dummy%20URL%20path%29%2C%20so%20it's%20worth%20addressing.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fnext.config.ts%3A3%0A**ESLint%20now%20runs%20during%20%60next%20build%60**%0A%0ARemoving%20the%20%60eslint%3A%20%7B%20ignoreDuringBuilds%3A%20true%20%7D%60%20block%20means%20%60next%20build%60%20will%20execute%20ESLint%20automatically%20%28Next.js%20default%20behaviour%29.%20Combined%20with%20the%20%60lint%60%20script%20change%20to%20%60eslint%20.%60%2C%20ESLint%20effectively%20runs%20twice%20in%20CI%20pipelines%20that%20call%20both%20%60npm%20run%20lint%60%20and%20%60npm%20run%20build%60.%20If%20any%20new%20lint%20errors%20surface%20that%20aren't%20covered%20by%20the%20%60%40typescript-eslint%2Fno-empty-object-type%3A%20%22off%22%60%20suppression%2C%20builds%20will%20fail%20unexpectedly.%0A%0AIf%20the%20intent%20is%20to%20enforce%20lint%20parity%20with%20the%20build%2C%20this%20is%20intentional%20%E2%80%94%20just%20worth%20confirming.%20Alternatively%2C%20re-add%20%60eslint%3A%20%7B%20ignoreDuringBuilds%3A%20true%20%7D%60%20to%20let%20the%20dedicated%20lint%20step%20own%20ESLint.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/components/ConvexClientProvider.tsx
Line: 19

Comment:
**`ConvexReactClient` re-created on every render**

`new ConvexReactClient(convexUrl)` is called directly in the component body, so a fresh client (and a new underlying WebSocket) is allocated on every re-render of this provider. The env-var value is a build-time constant, so in practice the provider is stable, but stabilising the instance explicitly would be safer:

```suggestion
  const [convex] = useState(() => new ConvexReactClient(convexUrl));
```

This was partially pre-existing (the old code also called `new ConvexReactClient` in the render path), but the PR now does it unconditionally (including the dummy URL path), so it's worth addressing.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/next.config.ts
Line: 3

Comment:
**ESLint now runs during `next build`**

Removing the `eslint: { ignoreDuringBuilds: true }` block means `next build` will execute ESLint automatically (Next.js default behaviour). Combined with the `lint` script change to `eslint .`, ESLint effectively runs twice in CI pipelines that call both `npm run lint` and `npm run build`. If any new lint errors surface that aren't covered by the `@typescript-eslint/no-empty-object-type: "off"` suppression, builds will fail unexpectedly.

If the intent is to enforce lint parity with the build, this is intentional — just worth confirming. Alternatively, re-add `eslint: { ignoreDuringBuilds: true }` to let the dedicated lint step own ESLint.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: make Next 16 bump buildable"](https://github.com/ayushj1001/mindpoint/commit/8810a4326ce8e5cb155239f6bc086ccef5266913) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28218450)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->