### PR TITLE
Add course image previews with removal confirmation

### DIFF
--- a/apps/web/components/admin/CourseEditor.tsx
+++ b/apps/web/components/admin/CourseEditor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import {
   useEffect,
   useMemo,
@@ -9,11 +10,22 @@ import {
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@mindpoint/backend/api";
 import type { Doc, Id } from "@mindpoint/backend/data-model";
+import { Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { toast } from "sonner";
 import { UploadDropzone } from "@/lib/uploadthing";
 import { getUserFacingErrorMessage } from "@/lib/convex-error";
@@ -310,6 +322,9 @@ export function CourseEditor({
   const [isSaving, setIsSaving] = useState(false);
   const [emotionalContentOpen, setEmotionalContentOpen] = useState(false);
   const [selectedCampaignId, setSelectedCampaignId] = useState("");
+  const [imagePendingRemoval, setImagePendingRemoval] = useState<string | null>(
+    null,
+  );
   const [usesPlainTextScheduleInputs, setUsesPlainTextScheduleInputs] =
     useState(false);
   const courseVersion = course
@@ -941,6 +956,19 @@ export function CourseEditor({
       onInput: (e: React.FormEvent<HTMLInputElement>) =>
         updateScheduleField(e.currentTarget?.value),
     };
+  };
+
+  const confirmRemoveImage = () => {
+    if (!imagePendingRemoval) {
+      return;
+    }
+
+    setState((prev) => ({
+      ...prev,
+      imageUrls: prev.imageUrls.filter((url) => url !== imagePendingRemoval),
+    }));
+    setImagePendingRemoval(null);
+    toast.success("Image removed from this draft");
   };
 
   return (
@@ -1711,6 +1739,7 @@ export function CourseEditor({
 
         <UploadDropzone
           endpoint="courseImageUploader"
+          config={{ mode: "auto" }}
           onClientUploadComplete={(files) => {
             setState((prev) => ({
               ...prev,
@@ -1731,15 +1760,37 @@ export function CourseEditor({
         />
 
         {state.imageUrls.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
-            {state.imageUrls.map((url) => (
-              <Badge
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {state.imageUrls.map((url, index) => (
+              <div
                 key={url}
-                variant="outline"
-                className="max-w-full truncate"
+                className="overflow-hidden rounded-md border bg-slate-50"
               >
-                {url}
-              </Badge>
+                <div className="relative aspect-[4/5] w-full bg-white">
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="icon-sm"
+                    className="absolute top-2 right-2 z-10 shadow-sm"
+                    onClick={() => setImagePendingRemoval(url)}
+                    aria-label={`Remove course image ${index + 1}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                  <Image
+                    src={url}
+                    alt={`Course image ${index + 1}`}
+                    fill
+                    className="object-contain"
+                    sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"
+                  />
+                </div>
+                <div className="border-t bg-white px-3 py-2 text-xs text-slate-600">
+                  <p className="truncate" title={url}>
+                    {url}
+                  </p>
+                </div>
+              </div>
             ))}
           </div>
         ) : null}
@@ -1751,6 +1802,7 @@ export function CourseEditor({
 
           <UploadDropzone
             endpoint="worksheetPdfUploader"
+            config={{ mode: "auto" }}
             onClientUploadComplete={(files) => {
               const first = files[0];
               if (!first) return;
@@ -1937,6 +1989,35 @@ export function CourseEditor({
           {isSaving ? "Saving..." : "Save Course"}
         </Button>
       </div>
+
+      <AlertDialog
+        open={imagePendingRemoval !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setImagePendingRemoval(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove image?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the image from the course draft. The file stays in
+              UploadThing, but it will no longer appear on the course after you
+              save.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-white hover:bg-destructive/90"
+              onClick={confirmRemoveImage}
+            >
+              Remove image
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -58,7 +58,7 @@ const nextConfig = {
       },
       {
         protocol: "https",
-        hostname: "pw6ih6yl8k.ufs.sh",
+        hostname: "**.ufs.sh",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Replace image URL badges in the course editor with visual previews in a responsive grid.
- Add per-image remove actions with a confirmation dialog before removing an image from the draft state.
- Update UploadThing usage to auto mode and allow remote `ufs.sh` image hosts in Next.js image config.

## Testing
- Not run (not requested).
- Manual check: upload course images and confirm previews render correctly in the editor.
- Manual check: remove an image, cancel the dialog, and confirm the draft state is unchanged.
- Manual check: confirm `next/image` loads images from `*.ufs.sh` without config errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added thumbnail preview grid for course images in the editor, displaying images in a responsive layout.
  * Added the ability to remove individual course images with a confirmation dialog.
  * Expanded remote image source compatibility to support a broader range of image hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds visual image previews to the course editor, replacing URL text badges with a responsive grid of `next/image` thumbnails, and introduces a per-image remove button with an `AlertDialog` confirmation. It also upgrades `UploadDropzone` to `mode: \"auto\"` (switching the file URL field from `url` to `ufsUrl`) and adds a wildcard `**.ufs.sh` remote pattern to the Next.js image config.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style and defensive-coding suggestions with no impact on normal use

The URL-based duplicate removal and key collision concerns are theoretical edge cases (UploadThing produces unique URLs per upload in practice). The core feature — preview grid, confirmation dialog, ufs.sh allowlist — is implemented correctly.

apps/web/components/admin/CourseEditor.tsx — confirm the URL-based removal behavior is acceptable for your use case

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/components/admin/CourseEditor.tsx | Adds image preview grid, per-image remove with confirmation dialog, and UploadThing auto mode; URL-based removal filter silently drops all duplicate URLs at once |
| apps/web/next.config.ts | Adds `**.ufs.sh` wildcard remote pattern for UploadThing CDN; change is intentional and correctly scoped to HTTPS |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Trash icon on image card] --> B[setImagePendingRemoval called with URL]
    B --> C{AlertDialog opens}
    C --> D[User clicks Cancel]
    C --> E[User clicks Remove image]
    D --> F[onOpenChange false - setImagePendingRemoval null]
    F --> G[Draft unchanged]
    E --> H[confirmRemoveImage runs]
    H --> I[filter imageUrls removes ALL matching URLs]
    I --> J[setImagePendingRemoval null + toast]
    J --> K[Draft updated]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fcourse-image-previews%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fcourse-image-previews%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%3A966-969%0A**URL-based%20removal%20silently%20drops%20all%20duplicates**%0A%0A%60filter%28%28url%29%20%3D%3E%20url%20!%3D%3D%20imagePendingRemoval%29%60%20removes%20every%20array%20entry%20that%20matches%20the%20pending%20URL%2C%20not%20just%20the%20card%20the%20user%20clicked.%20If%20UploadThing%20ever%20deduplicates%20files%20by%20content%20hash%20and%20returns%20the%20same%20%60ufsUrl%60%20for%20two%20uploads%20of%20the%20same%20file%2C%20clicking%20%22Remove%22%20on%20one%20card%20would%20silently%20remove%20both%20%E2%80%94%20and%20the%20user%20would%20only%20see%20a%20single%20toast.%20Storing%20the%20index%20instead%20of%20the%20URL%20eliminates%20this%20ambiguity%20entirely.%0A%0AYou'll%20also%20need%20to%20change%20the%20state%20type%20and%20the%20setter%20call%20sites%3A%0A%0A%60%60%60ts%0A%2F%2F%20state%20type%20change%0Aconst%20%5BimagePendingRemoval%2C%20setImagePendingRemoval%5D%20%3D%20useState%3Cnumber%20%7C%20null%3E%28null%29%3B%0A%0A%2F%2F%20in%20the%20remove%20button%20onClick%0AonClick%3D%7B%28%29%20%3D%3E%20setImagePendingRemoval%28index%29%7D%0A%0A%2F%2F%20in%20confirmRemoveImage%0AimageUrls%3A%20prev.imageUrls.filter%28%28_%2C%20i%29%20%3D%3E%20i%20!%3D%3D%20imagePendingRemoval%29%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%3A1766%0A**Duplicate%20URL%20may%20cause%20a%20React%20key%20collision**%0A%0AUsing%20the%20raw%20URL%20as%20the%20list%20key%20works%20fine%20when%20all%20URLs%20are%20unique%2C%20but%20a%20duplicate%20upload%20of%20the%20same%20file%20could%20produce%20two%20cards%20sharing%20an%20identical%20key.%20Consider%20using%20the%20array%20index%20%28or%20a%20composite%20of%20index%20%2B%20url%29%20to%20guarantee%20uniqueness.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%3A966-969%0A**URL-based%20removal%20silently%20drops%20all%20duplicates**%0A%0A%60filter%28%28url%29%20%3D%3E%20url%20!%3D%3D%20imagePendingRemoval%29%60%20removes%20every%20array%20entry%20that%20matches%20the%20pending%20URL%2C%20not%20just%20the%20card%20the%20user%20clicked.%20If%20UploadThing%20ever%20deduplicates%20files%20by%20content%20hash%20and%20returns%20the%20same%20%60ufsUrl%60%20for%20two%20uploads%20of%20the%20same%20file%2C%20clicking%20%22Remove%22%20on%20one%20card%20would%20silently%20remove%20both%20%E2%80%94%20and%20the%20user%20would%20only%20see%20a%20single%20toast.%20Storing%20the%20index%20instead%20of%20the%20URL%20eliminates%20this%20ambiguity%20entirely.%0A%0AYou'll%20also%20need%20to%20change%20the%20state%20type%20and%20the%20setter%20call%20sites%3A%0A%0A%60%60%60ts%0A%2F%2F%20state%20type%20change%0Aconst%20%5BimagePendingRemoval%2C%20setImagePendingRemoval%5D%20%3D%20useState%3Cnumber%20%7C%20null%3E%28null%29%3B%0A%0A%2F%2F%20in%20the%20remove%20button%20onClick%0AonClick%3D%7B%28%29%20%3D%3E%20setImagePendingRemoval%28index%29%7D%0A%0A%2F%2F%20in%20confirmRemoveImage%0AimageUrls%3A%20prev.imageUrls.filter%28%28_%2C%20i%29%20%3D%3E%20i%20!%3D%3D%20imagePendingRemoval%29%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%3A1766%0A**Duplicate%20URL%20may%20cause%20a%20React%20key%20collision**%0A%0AUsing%20the%20raw%20URL%20as%20the%20list%20key%20works%20fine%20when%20all%20URLs%20are%20unique%2C%20but%20a%20duplicate%20upload%20of%20the%20same%20file%20could%20produce%20two%20cards%20sharing%20an%20identical%20key.%20Consider%20using%20the%20array%20index%20%28or%20a%20composite%20of%20index%20%2B%20url%29%20to%20guarantee%20uniqueness.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%3A966-969%0A**URL-based%20removal%20silently%20drops%20all%20duplicates**%0A%0A%60filter%28%28url%29%20%3D%3E%20url%20!%3D%3D%20imagePendingRemoval%29%60%20removes%20every%20array%20entry%20that%20matches%20the%20pending%20URL%2C%20not%20just%20the%20card%20the%20user%20clicked.%20If%20UploadThing%20ever%20deduplicates%20files%20by%20content%20hash%20and%20returns%20the%20same%20%60ufsUrl%60%20for%20two%20uploads%20of%20the%20same%20file%2C%20clicking%20%22Remove%22%20on%20one%20card%20would%20silently%20remove%20both%20%E2%80%94%20and%20the%20user%20would%20only%20see%20a%20single%20toast.%20Storing%20the%20index%20instead%20of%20the%20URL%20eliminates%20this%20ambiguity%20entirely.%0A%0AYou'll%20also%20need%20to%20change%20the%20state%20type%20and%20the%20setter%20call%20sites%3A%0A%0A%60%60%60ts%0A%2F%2F%20state%20type%20change%0Aconst%20%5BimagePendingRemoval%2C%20setImagePendingRemoval%5D%20%3D%20useState%3Cnumber%20%7C%20null%3E%28null%29%3B%0A%0A%2F%2F%20in%20the%20remove%20button%20onClick%0AonClick%3D%7B%28%29%20%3D%3E%20setImagePendingRemoval%28index%29%7D%0A%0A%2F%2F%20in%20confirmRemoveImage%0AimageUrls%3A%20prev.imageUrls.filter%28%28_%2C%20i%29%20%3D%3E%20i%20!%3D%3D%20imagePendingRemoval%29%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fcomponents%2Fadmin%2FCourseEditor.tsx%3A1766%0A**Duplicate%20URL%20may%20cause%20a%20React%20key%20collision**%0A%0AUsing%20the%20raw%20URL%20as%20the%20list%20key%20works%20fine%20when%20all%20URLs%20are%20unique%2C%20but%20a%20duplicate%20upload%20of%20the%20same%20file%20could%20produce%20two%20cards%20sharing%20an%20identical%20key.%20Consider%20using%20the%20array%20index%20%28or%20a%20composite%20of%20index%20%2B%20url%29%20to%20guarantee%20uniqueness.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/components/admin/CourseEditor.tsx
Line: 966-969

Comment:
**URL-based removal silently drops all duplicates**

`filter((url) => url !== imagePendingRemoval)` removes every array entry that matches the pending URL, not just the card the user clicked. If UploadThing ever deduplicates files by content hash and returns the same `ufsUrl` for two uploads of the same file, clicking "Remove" on one card would silently remove both — and the user would only see a single toast. Storing the index instead of the URL eliminates this ambiguity entirely.

You'll also need to change the state type and the setter call sites:

```ts
// state type change
const [imagePendingRemoval, setImagePendingRemoval] = useState<number | null>(null);

// in the remove button onClick
onClick={() => setImagePendingRemoval(index)}

// in confirmRemoveImage
imageUrls: prev.imageUrls.filter((_, i) => i !== imagePendingRemoval),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/components/admin/CourseEditor.tsx
Line: 1766

Comment:
**Duplicate URL may cause a React key collision**

Using the raw URL as the list key works fine when all URLs are unique, but a duplicate upload of the same file could produce two cards sharing an identical key. Consider using the array index (or a composite of index + url) to guarantee uniqueness.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add course image previews and removal fl..."](https://github.com/ayushj1001/mindpoint/commit/d7ef89da3a116d6d957a1f82cbb3cc3632749ba4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28252053)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->