### PR TITLE
Add masterclass code repair workflow

### DIFF
--- a/apps/web/app/admin/courses/page.tsx
+++ b/apps/web/app/admin/courses/page.tsx
@@ -47,6 +47,17 @@ type CourseTypeIssue = {
   reason: string;
 };
 
+type MasterclassCodeRepairCandidate = {
+  courseId: Id<"courses">;
+  name: string;
+  lifecycleStatus: "draft" | "published" | "archived";
+  currentType: Exclude<CourseTypeFilter, "all"> | null;
+  suggestedType: "masterclass";
+  currentCode: string;
+  suggestedCode: string;
+  reason: string;
+};
+
 const courseTypeOptions: CourseTypeFilter[] = [
   "all",
   "certificate",
@@ -78,6 +89,9 @@ export default function AdminCoursesPage() {
   const [fixingCourseId, setFixingCourseId] = useState<Id<"courses"> | null>(
     null,
   );
+  const [repairingCourseId, setRepairingCourseId] =
+    useState<Id<"courses"> | null>(null);
+  const [isRepairingAll, setIsRepairingAll] = useState(false);
 
   const courses = useQuery(api.adminCourses.listCourses, {
     search: search || undefined,
@@ -88,10 +102,19 @@ export default function AdminCoursesPage() {
   const courseTypeIssues = useQuery(api.adminCourses.listCourseTypeIssues, {
     limit: 50,
   }) as CourseTypeIssue[] | undefined;
+  const masterclassCodeRepairCandidates = useQuery(
+    api.adminCourses.listMasterclassCodeRepairCandidates,
+    {
+      limit: 100,
+    },
+  ) as MasterclassCodeRepairCandidate[] | undefined;
   const transitionCourse = useMutation(
     api.adminCourses.transitionCourseLifecycle,
   );
   const correctCourseType = useMutation(api.adminCourses.correctCourseType);
+  const repairMasterclassCourseCodes = useMutation(
+    api.adminCourses.repairMasterclassCourseCodes,
+  );
 
   const rows = useMemo(() => courses ?? [], [courses]);
 
@@ -176,6 +199,48 @@ export default function AdminCoursesPage() {
     }
   };
 
+  const applyMasterclassCodeRepair = async (
+    candidate: MasterclassCodeRepairCandidate,
+  ) => {
+    try {
+      setRepairingCourseId(candidate.courseId);
+      const result = await repairMasterclassCourseCodes({
+        courseIds: [candidate.courseId],
+      });
+      toast.success(
+        `Updated ${result.updated} course code${result.updated === 1 ? "" : "s"}; skipped ${result.skipped}`,
+      );
+    } catch (error) {
+      toast.error(
+        getUserFacingErrorMessage(error, "Failed to repair course code"),
+      );
+    } finally {
+      setRepairingCourseId(null);
+    }
+  };
+
+  const applyAllMasterclassCodeRepairs = async () => {
+    if (!masterclassCodeRepairCandidates?.length) return;
+
+    try {
+      setIsRepairingAll(true);
+      const result = await repairMasterclassCourseCodes({
+        courseIds: masterclassCodeRepairCandidates.map(
+          (candidate) => candidate.courseId,
+        ),
+      });
+      toast.success(
+        `Updated ${result.updated} course code${result.updated === 1 ? "" : "s"}; skipped ${result.skipped}`,
+      );
+    } catch (error) {
+      toast.error(
+        getUserFacingErrorMessage(error, "Failed to repair course codes"),
+      );
+    } finally {
+      setIsRepairingAll(false);
+    }
+  };
+
   return (
     <div>
       <AdminPageHeader
@@ -220,11 +285,103 @@ export default function AdminCoursesPage() {
             {courseTypeIssues.length === 1 ? "" : "s"}
           </Badge>
         ) : null}
+        {masterclassCodeRepairCandidates &&
+        masterclassCodeRepairCandidates.length > 0 ? (
+          <Badge variant="outline" className="self-center">
+            {masterclassCodeRepairCandidates.length} code repair
+            {masterclassCodeRepairCandidates.length === 1 ? "" : "s"}
+          </Badge>
+        ) : null}
       </div>
 
       {view === "catalog" &&
-      courseTypeIssues &&
-      courseTypeIssues.length > 0 ? (
+      masterclassCodeRepairCandidates &&
+      masterclassCodeRepairCandidates.length > 0 ? (
+        <div className="mb-4 overflow-hidden rounded-lg border border-amber-200 bg-white">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-3">
+            <div>
+              <h2 className="text-sm font-semibold text-amber-950">
+                Course Code Integrity
+              </h2>
+              <p className="mt-0.5 text-xs text-amber-800">
+                Review likely workshops using the legacy WS prefix. Fixes update
+                the stored type to masterclass and rewrite only the code prefix
+                to MC.
+              </p>
+            </div>
+            <Button
+              size="sm"
+              disabled={isRepairingAll}
+              onClick={() => void applyAllMasterclassCodeRepairs()}
+            >
+              {isRepairingAll ? "Applying..." : "Apply All"}
+            </Button>
+          </div>
+          <table className="w-full text-left text-sm">
+            <thead className="bg-slate-50 text-xs tracking-wide text-slate-600 uppercase">
+              <tr>
+                <th className="px-3 py-2">Course</th>
+                <th className="px-3 py-2">Current</th>
+                <th className="px-3 py-2">Proposed</th>
+                <th className="px-3 py-2">Reason</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {masterclassCodeRepairCandidates.map((candidate) => (
+                <tr key={candidate.courseId} className="border-t">
+                  <td className="px-3 py-2">
+                    <p className="font-medium text-slate-900">
+                      {candidate.name}
+                    </p>
+                    <p className="text-xs text-slate-600">
+                      {candidate.lifecycleStatus}
+                    </p>
+                  </td>
+                  <td className="px-3 py-2">
+                    <p>{candidate.currentType || "-"}</p>
+                    <p className="text-xs text-slate-600">
+                      {candidate.currentCode}
+                    </p>
+                  </td>
+                  <td className="px-3 py-2 font-medium text-amber-950">
+                    <p>{candidate.suggestedType}</p>
+                    <p className="text-xs">{candidate.suggestedCode}</p>
+                  </td>
+                  <td className="px-3 py-2 text-xs text-slate-700">
+                    {candidate.reason}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button variant="outline" size="sm" asChild>
+                        <Link href={`/admin/courses/${candidate.courseId}`}>
+                          Open
+                        </Link>
+                      </Button>
+                      <Button
+                        size="sm"
+                        disabled={
+                          isRepairingAll ||
+                          repairingCourseId === candidate.courseId
+                        }
+                        onClick={() =>
+                          void applyMasterclassCodeRepair(candidate)
+                        }
+                      >
+                        {repairingCourseId === candidate.courseId
+                          ? "Applying..."
+                          : "Apply Fix"}
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+
+      {view === "catalog" && courseTypeIssues && courseTypeIssues.length > 0 ? (
         <div className="mb-4 overflow-hidden rounded-lg border border-amber-200 bg-white">
           <div className="border-b border-amber-200 bg-amber-50 px-4 py-3">
             <h2 className="text-sm font-semibold text-amber-950">
@@ -533,7 +690,10 @@ export default function AdminCoursesPage() {
                             </Link>
                           </Button>
                           <Button variant="outline" size="sm" asChild>
-                            <Link href={`/courses/${course._id}`} target="_blank">
+                            <Link
+                              href={`/courses/${course._id}`}
+                              target="_blank"
+                            >
                               View Page
                             </Link>
                           </Button>

--- a/apps/web/app/admin/courses/page.tsx
+++ b/apps/web/app/admin/courses/page.tsx
@@ -58,6 +58,18 @@ type MasterclassCodeRepairCandidate = {
   reason: string;
 };
 
+type CourseTypeIssuesResult = {
+  issues: CourseTypeIssue[];
+  scanned: number;
+  truncated: boolean;
+};
+
+type MasterclassCodeRepairResult = {
+  candidates: MasterclassCodeRepairCandidate[];
+  scanned: number;
+  truncated: boolean;
+};
+
 const courseTypeOptions: CourseTypeFilter[] = [
   "all",
   "certificate",
@@ -92,6 +104,7 @@ export default function AdminCoursesPage() {
   const [repairingCourseId, setRepairingCourseId] =
     useState<Id<"courses"> | null>(null);
   const [isRepairingAll, setIsRepairingAll] = useState(false);
+  const [isRepairAllConfirmOpen, setIsRepairAllConfirmOpen] = useState(false);
 
   const courses = useQuery(api.adminCourses.listCourses, {
     search: search || undefined,
@@ -101,13 +114,13 @@ export default function AdminCoursesPage() {
   });
   const courseTypeIssues = useQuery(api.adminCourses.listCourseTypeIssues, {
     limit: 50,
-  }) as CourseTypeIssue[] | undefined;
-  const masterclassCodeRepairCandidates = useQuery(
+  }) as CourseTypeIssuesResult | undefined;
+  const masterclassCodeRepairResult = useQuery(
     api.adminCourses.listMasterclassCodeRepairCandidates,
     {
       limit: 100,
     },
-  ) as MasterclassCodeRepairCandidate[] | undefined;
+  ) as MasterclassCodeRepairResult | undefined;
   const transitionCourse = useMutation(
     api.adminCourses.transitionCourseLifecycle,
   );
@@ -117,6 +130,9 @@ export default function AdminCoursesPage() {
   );
 
   const rows = useMemo(() => courses ?? [], [courses]);
+  const courseTypeIssueRows = courseTypeIssues?.issues ?? [];
+  const masterclassCodeRepairCandidates =
+    masterclassCodeRepairResult?.candidates ?? [];
 
   const exportRows = useMemo(
     () =>
@@ -220,7 +236,7 @@ export default function AdminCoursesPage() {
   };
 
   const applyAllMasterclassCodeRepairs = async () => {
-    if (!masterclassCodeRepairCandidates?.length) return;
+    if (masterclassCodeRepairCandidates.length === 0) return;
 
     try {
       setIsRepairingAll(true);
@@ -232,6 +248,7 @@ export default function AdminCoursesPage() {
       toast.success(
         `Updated ${result.updated} course code${result.updated === 1 ? "" : "s"}; skipped ${result.skipped}`,
       );
+      setIsRepairAllConfirmOpen(false);
     } catch (error) {
       toast.error(
         getUserFacingErrorMessage(error, "Failed to repair course codes"),
@@ -279,14 +296,13 @@ export default function AdminCoursesPage() {
         >
           Offers
         </Button>
-        {courseTypeIssues && courseTypeIssues.length > 0 ? (
+        {courseTypeIssueRows.length > 0 ? (
           <Badge variant="outline" className="self-center">
-            {courseTypeIssues.length} type issue
-            {courseTypeIssues.length === 1 ? "" : "s"}
+            {courseTypeIssueRows.length} type issue
+            {courseTypeIssueRows.length === 1 ? "" : "s"}
           </Badge>
         ) : null}
-        {masterclassCodeRepairCandidates &&
-        masterclassCodeRepairCandidates.length > 0 ? (
+        {masterclassCodeRepairCandidates.length > 0 ? (
           <Badge variant="outline" className="self-center">
             {masterclassCodeRepairCandidates.length} code repair
             {masterclassCodeRepairCandidates.length === 1 ? "" : "s"}
@@ -294,9 +310,7 @@ export default function AdminCoursesPage() {
         ) : null}
       </div>
 
-      {view === "catalog" &&
-      masterclassCodeRepairCandidates &&
-      masterclassCodeRepairCandidates.length > 0 ? (
+      {view === "catalog" && masterclassCodeRepairCandidates.length > 0 ? (
         <div className="mb-4 overflow-hidden rounded-lg border border-amber-200 bg-white">
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-3">
             <div>
@@ -312,11 +326,17 @@ export default function AdminCoursesPage() {
             <Button
               size="sm"
               disabled={isRepairingAll}
-              onClick={() => void applyAllMasterclassCodeRepairs()}
+              onClick={() => setIsRepairAllConfirmOpen(true)}
             >
-              {isRepairingAll ? "Applying..." : "Apply All"}
+              Apply All
             </Button>
           </div>
+          {masterclassCodeRepairResult?.truncated ? (
+            <div className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs font-medium text-amber-900">
+              Scanned the latest {masterclassCodeRepairResult.scanned} courses;
+              more courses exist, so additional candidates may not be shown.
+            </div>
+          ) : null}
           <table className="w-full text-left text-sm">
             <thead className="bg-slate-50 text-xs tracking-wide text-slate-600 uppercase">
               <tr>
@@ -381,7 +401,7 @@ export default function AdminCoursesPage() {
         </div>
       ) : null}
 
-      {view === "catalog" && courseTypeIssues && courseTypeIssues.length > 0 ? (
+      {view === "catalog" && courseTypeIssueRows.length > 0 ? (
         <div className="mb-4 overflow-hidden rounded-lg border border-amber-200 bg-white">
           <div className="border-b border-amber-200 bg-amber-50 px-4 py-3">
             <h2 className="text-sm font-semibold text-amber-950">
@@ -392,6 +412,12 @@ export default function AdminCoursesPage() {
               prefix. Fixes patch the DB record directly.
             </p>
           </div>
+          {courseTypeIssues?.truncated ? (
+            <div className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs font-medium text-amber-900">
+              Scanned the latest {courseTypeIssues.scanned} courses; more
+              courses exist, so additional type issues may not be shown.
+            </div>
+          ) : null}
           <table className="w-full text-left text-sm">
             <thead className="bg-slate-50 text-xs tracking-wide text-slate-600 uppercase">
               <tr>
@@ -403,7 +429,7 @@ export default function AdminCoursesPage() {
               </tr>
             </thead>
             <tbody>
-              {courseTypeIssues.map((issue) => (
+              {courseTypeIssueRows.map((issue) => (
                 <tr key={issue.courseId} className="border-t">
                   <td className="px-3 py-2">
                     <p className="font-medium text-slate-900">{issue.name}</p>
@@ -707,6 +733,37 @@ export default function AdminCoursesPage() {
           </table>
         </div>
       )}
+
+      <AlertDialog
+        open={isRepairAllConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open && !isRepairingAll) {
+            setIsRepairAllConfirmOpen(false);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Apply all code repairs?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will update up to 50 visible repair candidates in this batch,
+              including any published courses that still pass publish
+              validation. Codes will keep their suffix and switch from WS to MC.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRepairingAll}>
+              Cancel
+            </AlertDialogCancel>
+            <Button
+              disabled={isRepairingAll}
+              onClick={() => void applyAllMasterclassCodeRepairs()}
+            >
+              {isRepairingAll ? "Applying..." : "Apply Repairs"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <AlertDialog
         open={pendingTransition !== null}

--- a/apps/web/app/courses/layout.tsx
+++ b/apps/web/app/courses/layout.tsx
@@ -6,6 +6,7 @@ import {
   Award,
   Briefcase,
   CirclePlay,
+  FileText,
   FileUser,
   GraduationCap,
   LayoutGrid,
@@ -63,6 +64,12 @@ const courseTypes = [
     href: "/courses/masterclass",
     label: "Masterclass",
     icon: Mic2,
+  },
+  {
+    name: "Worksheets",
+    href: "/courses/worksheet",
+    label: "Worksheets",
+    icon: FileText,
   },
   {
     name: "Therapy",

--- a/apps/web/components/admin/CourseEditor.tsx
+++ b/apps/web/components/admin/CourseEditor.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@mindpoint/backend/api";
 import type { Doc, Id } from "@mindpoint/backend/data-model";
@@ -206,6 +201,15 @@ function defaultSessionVariants(): SessionVariantInput[] {
 
 function hasText(value: string | undefined | null): boolean {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function getUpperCodePrefix(code?: string) {
+  if (typeof code !== "string") {
+    return null;
+  }
+
+  const normalized = code.trim().toUpperCase();
+  return normalized.length >= 2 ? normalized.slice(0, 2) : null;
 }
 
 function getDefaultMarketingState(type: CourseType) {
@@ -781,6 +785,29 @@ export function CourseEditor({
   const validateForPublish = () => {
     if (state.lifecycleStatus !== "published") return;
 
+    const codePrefix = getUpperCodePrefix(state.code);
+    if (!hasText(state.code)) {
+      throw new Error("Course code is required before publishing");
+    }
+    if (state.type === "masterclass" && codePrefix !== "MC") {
+      throw new Error(
+        "Masterclass and workshop course codes must start with MC before publishing.",
+      );
+    }
+    if (state.type === "worksheet" && codePrefix !== "WS") {
+      throw new Error(
+        "Worksheet course codes must start with WS before publishing.",
+      );
+    }
+    if (codePrefix === "WS" && state.type !== "worksheet") {
+      throw new Error("Only worksheet course codes can start with WS.");
+    }
+    if (codePrefix === "MC" && state.type !== "masterclass") {
+      throw new Error(
+        "Only masterclass and workshop course codes can start with MC.",
+      );
+    }
+
     if (!hasText(state.description)) {
       throw new Error("Description is required before publishing");
     }
@@ -1069,6 +1096,16 @@ export function CourseEditor({
                   setState((prev) => ({ ...prev, code: e.target.value }))
                 }
               />
+              {state.type === "masterclass" ? (
+                <p className="text-xs text-slate-600">
+                  Use MC for masterclass and workshop courses.
+                </p>
+              ) : null}
+              {state.type === "worksheet" ? (
+                <p className="text-xs text-slate-600">
+                  Use WS for worksheet courses.
+                </p>
+              ) : null}
             </div>
 
             <div className="space-y-2">
@@ -1572,9 +1609,7 @@ export function CourseEditor({
                 </Button>
               </div>
               {state.outcomes.length === 0 ? (
-                <p className="text-sm text-slate-600">
-                  No outcomes added yet.
-                </p>
+                <p className="text-sm text-slate-600">No outcomes added yet.</p>
               ) : (
                 <div className="space-y-2">
                   {state.outcomes.map((item, index) => (
@@ -1633,9 +1668,7 @@ export function CourseEditor({
                 </Button>
               </div>
               {state.whyDifferent.length === 0 ? (
-                <p className="text-sm text-slate-600">
-                  No items added yet.
-                </p>
+                <p className="text-sm text-slate-600">No items added yet.</p>
               ) : (
                 <div className="space-y-2">
                   {state.whyDifferent.map((item, index) => (
@@ -2010,7 +2043,7 @@ export function CourseEditor({
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              className="bg-destructive text-white hover:bg-destructive/90"
+              className="bg-destructive hover:bg-destructive/90 text-white"
               onClick={confirmRemoveImage}
             >
               Remove image

--- a/convex/adminCourses.ts
+++ b/convex/adminCourses.ts
@@ -6,6 +6,9 @@ import { requireAdmin } from "./adminAuth";
 import { normalizeCourseLifecycleStatus } from "./adminUtils";
 import { createAdminAuditLog } from "./adminAudit";
 
+const COURSE_INTEGRITY_SCAN_LIMIT = 2000;
+const MASTERCLASS_REPAIR_BATCH_LIMIT = 50;
+
 const coursePatchValidator = {
   name: v.optional(v.string()),
   description: v.optional(v.string()),
@@ -560,22 +563,30 @@ export const listCourseTypeIssues = query({
   args: {
     limit: v.optional(v.number()),
   },
-  returns: v.array(
-    v.object({
-      courseId: v.id("courses"),
-      name: v.string(),
-      code: v.union(v.string(), v.null()),
-      lifecycleStatus: v.union(CourseLifecycleStatus, v.null()),
-      currentType: v.union(CourseType, v.null()),
-      suggestedType: CourseType,
-      reason: v.string(),
-    }),
-  ),
+  returns: v.object({
+    issues: v.array(
+      v.object({
+        courseId: v.id("courses"),
+        name: v.string(),
+        code: v.union(v.string(), v.null()),
+        lifecycleStatus: v.union(CourseLifecycleStatus, v.null()),
+        currentType: v.union(CourseType, v.null()),
+        suggestedType: CourseType,
+        reason: v.string(),
+      }),
+    ),
+    scanned: v.number(),
+    truncated: v.boolean(),
+  }),
   handler: async (ctx, args) => {
     await requireAdmin(ctx);
 
-    const courses = await ctx.db.query("courses").order("desc").take(2000);
-    const issues = courses
+    const courses = await ctx.db
+      .query("courses")
+      .order("desc")
+      .take(COURSE_INTEGRITY_SCAN_LIMIT + 1);
+    const scannedCourses = courses.slice(0, COURSE_INTEGRITY_SCAN_LIMIT);
+    const issues = scannedCourses
       .map((course) => {
         const suggestion = getSuggestedCourseType(course);
         if (!suggestion) {
@@ -601,7 +612,11 @@ export const listCourseTypeIssues = query({
         return a.name.localeCompare(b.name);
       });
 
-    return issues.slice(0, args.limit ?? 100);
+    return {
+      issues: issues.slice(0, args.limit ?? 100),
+      scanned: scannedCourses.length,
+      truncated: courses.length > COURSE_INTEGRITY_SCAN_LIMIT,
+    };
   },
 });
 
@@ -609,18 +624,22 @@ export const listMasterclassCodeRepairCandidates = query({
   args: {
     limit: v.optional(v.number()),
   },
-  returns: v.array(
-    v.object({
-      courseId: v.id("courses"),
-      name: v.string(),
-      lifecycleStatus: CourseLifecycleStatus,
-      currentType: v.union(CourseType, v.null()),
-      suggestedType: v.literal("masterclass"),
-      currentCode: v.string(),
-      suggestedCode: v.string(),
-      reason: v.string(),
-    }),
-  ),
+  returns: v.object({
+    candidates: v.array(
+      v.object({
+        courseId: v.id("courses"),
+        name: v.string(),
+        lifecycleStatus: CourseLifecycleStatus,
+        currentType: v.union(CourseType, v.null()),
+        suggestedType: v.literal("masterclass"),
+        currentCode: v.string(),
+        suggestedCode: v.string(),
+        reason: v.string(),
+      }),
+    ),
+    scanned: v.number(),
+    truncated: v.boolean(),
+  }),
   handler: async (ctx, args) => {
     await requireAdmin(ctx);
 
@@ -629,8 +648,12 @@ export const listMasterclassCodeRepairCandidates = query({
       draft: 1,
       archived: 2,
     } as const;
-    const courses = await ctx.db.query("courses").order("desc").take(2000);
-    const candidates = courses
+    const courses = await ctx.db
+      .query("courses")
+      .order("desc")
+      .take(COURSE_INTEGRITY_SCAN_LIMIT + 1);
+    const scannedCourses = courses.slice(0, COURSE_INTEGRITY_SCAN_LIMIT);
+    const candidates = scannedCourses
       .map((course) => {
         if (!hasText(course.code)) {
           return null;
@@ -651,7 +674,11 @@ export const listMasterclassCodeRepairCandidates = query({
         return lifecycleDelta || a.name.localeCompare(b.name);
       });
 
-    return candidates.slice(0, args.limit ?? 100);
+    return {
+      candidates: candidates.slice(0, args.limit ?? 100),
+      scanned: scannedCourses.length,
+      truncated: courses.length > COURSE_INTEGRITY_SCAN_LIMIT,
+    };
   },
 });
 
@@ -841,10 +868,14 @@ export const repairMasterclassCourseCodes = mutation({
   handler: async (ctx, args) => {
     const admin = await requireAdmin(ctx);
     const uniqueCourseIds = Array.from(new Set(args.courseIds));
+    const courseIdsToProcess = uniqueCourseIds.slice(
+      0,
+      MASTERCLASS_REPAIR_BATCH_LIMIT,
+    );
     let updated = 0;
-    let skipped = 0;
+    let skipped = uniqueCourseIds.length - courseIdsToProcess.length;
 
-    for (const courseId of uniqueCourseIds) {
+    for (const courseId of courseIdsToProcess) {
       const existing = await ctx.db.get(courseId);
       if (!existing || !hasText(existing.code)) {
         skipped += 1;
@@ -858,6 +889,22 @@ export const repairMasterclassCourseCodes = mutation({
       if (!candidate) {
         skipped += 1;
         continue;
+      }
+
+      const currentLifecycleStatus = normalizeCourseLifecycleStatus(
+        existing.lifecycleStatus,
+      );
+      if (currentLifecycleStatus === "published") {
+        try {
+          validatePublishableCourse({
+            ...existing,
+            type: "masterclass",
+            code: candidate.suggestedCode,
+          });
+        } catch {
+          skipped += 1;
+          continue;
+        }
       }
 
       const now = Date.now();
@@ -890,6 +937,7 @@ export const repairMasterclassCourseCodes = mutation({
 
     return {
       requested: args.courseIds.length,
+      processed: courseIdsToProcess.length,
       updated,
       skipped,
     };

--- a/convex/adminCourses.ts
+++ b/convex/adminCourses.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { CourseLifecycleStatus, CourseType } from "./schema";
+import type { Id } from "./_generated/dataModel";
 import { requireAdmin } from "./adminAuth";
 import { normalizeCourseLifecycleStatus } from "./adminUtils";
 import { createAdminAuditLog } from "./adminAudit";
@@ -105,19 +106,145 @@ function hasRequiredSchedule(course: {
   );
 }
 
+type AdminCourseType =
+  | "certificate"
+  | "internship"
+  | "diploma"
+  | "pre-recorded"
+  | "masterclass"
+  | "therapy"
+  | "supervised"
+  | "resume-studio"
+  | "worksheet";
+
+type CourseCodeConventionCandidateInput = {
+  _id?: Id<"courses">;
+  name?: string;
+  code?: string;
+  type?: AdminCourseType;
+  lifecycleStatus?: "draft" | "published" | "archived";
+  description?: string;
+  content?: string;
+  fileUrl?: string;
+  worksheetDescription?: string;
+  targetAudience?: string[];
+};
+
+function getUpperCodePrefix(code?: string) {
+  if (typeof code !== "string") {
+    return null;
+  }
+
+  const normalized = code.trim().toUpperCase();
+  return normalized.length >= 2 ? normalized.slice(0, 2) : null;
+}
+
+function replaceCodePrefix(code: string, nextPrefix: string) {
+  const trimmed = code.trim();
+  return `${nextPrefix.toUpperCase()}${trimmed.slice(2)}`;
+}
+
+function hasWorksheetOnlyFields(course: {
+  fileUrl?: string;
+  worksheetDescription?: string;
+  targetAudience?: string[];
+}) {
+  return (
+    hasText(course.fileUrl) ||
+    hasText(course.worksheetDescription) ||
+    (Array.isArray(course.targetAudience) && course.targetAudience.length > 0)
+  );
+}
+
+function hasMasterclassWorkshopSignal(course: {
+  type?: AdminCourseType;
+  name?: string;
+  description?: string;
+  content?: string;
+}) {
+  if (course.type === "masterclass") {
+    return true;
+  }
+
+  const searchableText = [
+    course.name ?? "",
+    course.description ?? "",
+    course.content ?? "",
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  return /\b(masterclass|master class|workshop)\b/.test(searchableText);
+}
+
+function isMasterclassRepairEligible(
+  course: CourseCodeConventionCandidateInput,
+) {
+  return (
+    hasText(course.code) &&
+    getUpperCodePrefix(course.code) === "WS" &&
+    !hasWorksheetOnlyFields(course) &&
+    hasMasterclassWorkshopSignal(course)
+  );
+}
+
+function getMasterclassRepairCandidate(
+  course: CourseCodeConventionCandidateInput & {
+    _id: Id<"courses">;
+    name: string;
+    code: string;
+  },
+) {
+  if (!isMasterclassRepairEligible(course)) {
+    return null;
+  }
+
+  return {
+    courseId: course._id,
+    name: course.name,
+    lifecycleStatus: normalizeCourseLifecycleStatus(course.lifecycleStatus),
+    currentType: course.type ?? null,
+    suggestedType: "masterclass" as const,
+    currentCode: course.code.trim(),
+    suggestedCode: replaceCodePrefix(course.code, "MC"),
+    reason:
+      "Course uses the legacy workshop `WS` prefix but matches masterclass/workshop signals and has no worksheet-only fields.",
+  };
+}
+
+function validatePublishedCourseCodeConvention(course: {
+  type?: AdminCourseType;
+  code?: string;
+}) {
+  const codePrefix = getUpperCodePrefix(course.code);
+
+  if (course.type === "masterclass" && codePrefix !== "MC") {
+    throw new Error(
+      "Masterclass and workshop course codes must start with MC before publishing.",
+    );
+  }
+
+  if (course.type === "worksheet" && codePrefix !== "WS") {
+    throw new Error(
+      "Worksheet course codes must start with WS before publishing.",
+    );
+  }
+
+  if (codePrefix === "WS" && course.type !== "worksheet") {
+    throw new Error("Only worksheet course codes can start with WS.");
+  }
+
+  if (codePrefix === "MC" && course.type !== "masterclass") {
+    throw new Error(
+      "Only masterclass and workshop course codes can start with MC.",
+    );
+  }
+}
+
 function validatePublishableCourse(course: {
   name?: string;
   code?: string;
-  type?:
-    | "certificate"
-    | "internship"
-    | "diploma"
-    | "pre-recorded"
-    | "masterclass"
-    | "therapy"
-    | "supervised"
-    | "resume-studio"
-    | "worksheet";
+  type?: AdminCourseType;
   content?: string;
   description?: string;
   learningOutcomes?: Array<{ icon: string; title: string }>;
@@ -142,6 +269,7 @@ function validatePublishableCourse(course: {
   if (!course.type) {
     throw new Error("Course type is required before publishing");
   }
+  validatePublishedCourseCodeConvention(course);
   if (!hasText(course.description)) {
     throw new Error("Course description is required before publishing");
   }
@@ -227,29 +355,12 @@ function validatePublishableCourse(course: {
   }
 }
 
-function getUpperCodePrefix(code?: string) {
-  if (typeof code !== "string") {
+function getSuggestedCourseType(course: CourseCodeConventionCandidateInput) {
+  const codePrefix = getUpperCodePrefix(course.code);
+
+  if (isMasterclassRepairEligible(course)) {
     return null;
   }
-
-  const normalized = code.trim().toUpperCase();
-  return normalized.length >= 2 ? normalized.slice(0, 2) : null;
-}
-
-function getSuggestedCourseType(course: {
-  type?:
-    | "certificate"
-    | "internship"
-    | "diploma"
-    | "pre-recorded"
-    | "masterclass"
-    | "therapy"
-    | "supervised"
-    | "resume-studio"
-    | "worksheet";
-  code?: string;
-}) {
-  const codePrefix = getUpperCodePrefix(course.code);
 
   if (codePrefix === "IN" && course.type !== "internship") {
     return {
@@ -262,6 +373,13 @@ function getSuggestedCourseType(course: {
     return {
       suggestedType: "pre-recorded" as const,
       reason: "Course code uses the pre-recorded prefix `PR`.",
+    };
+  }
+
+  if (codePrefix === "MC" && course.type !== "masterclass") {
+    return {
+      suggestedType: "masterclass" as const,
+      reason: "Course code uses the masterclass/workshop prefix `MC`.",
     };
   }
 
@@ -468,7 +586,9 @@ export const listCourseTypeIssues = query({
           courseId: course._id,
           name: course.name,
           code: course.code ?? null,
-          lifecycleStatus: normalizeCourseLifecycleStatus(course.lifecycleStatus),
+          lifecycleStatus: normalizeCourseLifecycleStatus(
+            course.lifecycleStatus,
+          ),
           currentType: course.type ?? null,
           suggestedType: suggestion.suggestedType,
           reason: suggestion.reason,
@@ -482,6 +602,56 @@ export const listCourseTypeIssues = query({
       });
 
     return issues.slice(0, args.limit ?? 100);
+  },
+});
+
+export const listMasterclassCodeRepairCandidates = query({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(
+    v.object({
+      courseId: v.id("courses"),
+      name: v.string(),
+      lifecycleStatus: CourseLifecycleStatus,
+      currentType: v.union(CourseType, v.null()),
+      suggestedType: v.literal("masterclass"),
+      currentCode: v.string(),
+      suggestedCode: v.string(),
+      reason: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const lifecycleOrder = {
+      published: 0,
+      draft: 1,
+      archived: 2,
+    } as const;
+    const courses = await ctx.db.query("courses").order("desc").take(2000);
+    const candidates = courses
+      .map((course) => {
+        if (!hasText(course.code)) {
+          return null;
+        }
+
+        return getMasterclassRepairCandidate({
+          ...course,
+          code: course.code,
+        });
+      })
+      .filter(
+        (candidate): candidate is NonNullable<typeof candidate> =>
+          candidate !== null,
+      )
+      .sort((a, b) => {
+        const lifecycleDelta =
+          lifecycleOrder[a.lifecycleStatus] - lifecycleOrder[b.lifecycleStatus];
+        return lifecycleDelta || a.name.localeCompare(b.name);
+      });
+
+    return candidates.slice(0, args.limit ?? 100);
   },
 });
 
@@ -661,6 +831,68 @@ export const correctCourseType = mutation({
     });
 
     return updated;
+  },
+});
+
+export const repairMasterclassCourseCodes = mutation({
+  args: {
+    courseIds: v.array(v.id("courses")),
+  },
+  handler: async (ctx, args) => {
+    const admin = await requireAdmin(ctx);
+    const uniqueCourseIds = Array.from(new Set(args.courseIds));
+    let updated = 0;
+    let skipped = 0;
+
+    for (const courseId of uniqueCourseIds) {
+      const existing = await ctx.db.get(courseId);
+      if (!existing || !hasText(existing.code)) {
+        skipped += 1;
+        continue;
+      }
+
+      const candidate = getMasterclassRepairCandidate({
+        ...existing,
+        code: existing.code,
+      });
+      if (!candidate) {
+        skipped += 1;
+        continue;
+      }
+
+      const now = Date.now();
+      await ctx.db.patch(courseId, {
+        type: "masterclass",
+        code: candidate.suggestedCode,
+        updatedByAdminId: admin.userId,
+        updatedAt: now,
+      });
+
+      await createAdminAuditLog(ctx, {
+        actorAdminId: admin.userId,
+        actorEmail: admin.email,
+        action: "course.repair_masterclass_code",
+        entityType: "course",
+        entityId: String(courseId),
+        before: {
+          type: existing.type ?? null,
+          code: existing.code,
+        },
+        after: {
+          type: "masterclass",
+          code: candidate.suggestedCode,
+          reason: candidate.reason,
+        },
+      });
+
+      updated += 1;
+    }
+
+    return {
+      requested: args.courseIds.length,
+      updated,
+      skipped,
+    };
   },
 });
 


### PR DESCRIPTION
## Summary
- Add an admin review panel for likely masterclass courses still using the legacy `WS` code prefix, with per-course and bulk repair actions.
- Introduce backend detection and repair logic that rewrites eligible course codes to `MC`, updates the course type to `masterclass`, and records admin audit logs.
- Tighten publish-time validation so course types and code prefixes stay aligned, and surface clearer guidance in the course editor.
- Add a `Worksheets` entry to the course layout navigation.

## Testing
- Not run (not requested).
- Review the admin courses page flow for listing repair candidates and applying single/all repairs.
- Verify publish validation blocks mismatched `MC`/`WS` prefixes for non-matching course types.
- Confirm repaired courses are persisted with updated `type`, `code`, `updatedByAdminId`, and audit log entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Course Code Integrity repair tool in the admin panel with single and bulk fix options for course codes.
  * Added new Worksheets section to the courses navigation menu.
  * Enhanced course code validation with helper text indicating required code prefixes for different course types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a masterclass code repair workflow that detects `WS`-prefixed courses matching masterclass/workshop signals, rewrites their codes to `MC`, updates the type, and records audit logs — along with tightened publish-time validation enforcing code/type prefix alignment and a Worksheets sidebar entry.

The previous thread concerns (missing confirmation dialog, unbounded batch mutation, silent scan cap, re-validation of published courses before repair) are all addressed in this version. Two remaining P2 concerns:

- The `repairMasterclassCourseCodes` mutation's `skipped` count combines batch-limit truncation with validation failures, making the toast result ambiguous when "Apply All" sends more than 50 IDs (the query returns up to 100 candidates but the batch limit is 50).
- The new `validatePublishedCourseCodeConvention` check inside `updateCourse` will block _any_ save to a published course with a mismatched code until that course is repaired, creating a short but potentially surprising locked-edit window between deployment and running the repair tool.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness of the post-deploy repair window; no data loss or security issues.

All P0/P1 concerns from previous rounds are addressed. Two remaining P2 findings: ambiguous skipped toast count and a migration-ordering advisory about updateCourse validation blocking edits to affected published courses.

convex/adminCourses.ts (updateCourse validation + skipped count semantics) and apps/web/app/admin/courses/page.tsx (query limit vs. batch limit mismatch)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| convex/adminCourses.ts | Core backend for the repair workflow — adds detection/repair logic, a bounded scan with truncation flag, publish-time code convention validation, and per-course/bulk repair mutations with audit logs. Previous thread concerns addressed; two new P2 concerns around the skipped count and the updateCourse validation gate. |
| apps/web/app/admin/courses/page.tsx | Admin courses page surfaces repair candidates with per-row and bulk actions, truncation notice, and confirmation dialog. Query limit (100) exceeds mutation batch limit (50), producing an ambiguous skipped count on bulk apply. |
| apps/web/components/admin/CourseEditor.tsx | Adds helper-text hints for MC/WS code prefixes and mirrors code-convention checks in client-side validateForPublish. Minimal, low-risk change. |
| apps/web/app/courses/layout.tsx | Adds a Worksheets sidebar nav entry. Purely additive, no logic changes. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fmasterclass-code-repair%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmasterclass-code-repair%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fapp%2Fadmin%2Fcourses%2Fpage.tsx%3A243-251%0A**%60skipped%60%20count%20conflates%20batch-truncation%20with%20validation%20failures**%0A%0A%60applyAllMasterclassCodeRepairs%60%20passes%20all%20visible%20candidates%20%28up%20to%20100%20from%20the%20query%29%20to%20%60repairMasterclassCourseCodes%60%2C%20but%20the%20backend%20silently%20truncates%20to%20%60MASTERCLASS_REPAIR_BATCH_LIMIT%20%3D%2050%60.%20The%20excess%20IDs%20are%20counted%20as%20%60skipped%60%20alongside%20any%20courses%20that%20actually%20failed%20publish%20validation.%20The%20resulting%20toast%20%E2%80%94%20%22Updated%20X%3B%20skipped%20Y%22%20%E2%80%94%20gives%20no%20way%20for%20the%20admin%20to%20distinguish%20%22deferred%20to%20next%20batch%22%20from%20%22cannot%20be%20repaired%22.%0A%0AFor%20example%2C%20with%2060%20candidates%3A%2050%20are%20updated%2C%2010%20are%20batch-truncated%2C%20and%20the%20toast%20reads%20%22Updated%2050%3B%20skipped%2010%22.%20The%20admin%20may%20assume%20those%2010%20have%20validation%20issues%20and%20investigate%2C%20when%20they%20just%20need%20another%20click.%0A%0AConsider%20matching%20the%20query%20limit%20to%20the%20batch%20limit%20%28%60limit%3A%2050%60%20in%20the%20%60useQuery%60%20call%29%2C%20or%20splitting%20the%20%60skipped%60%20count%20into%20%60deferred%60%20vs%20%60failed%60%20in%20the%20return%20value%20and%20displaying%20them%20separately%20in%20the%20toast.%0A%0A%23%23%23%20Issue%202%20of%202%0Aconvex%2FadminCourses.ts%3A796-805%0A**%60updateCourse%60%20blocks%20edits%20to%20published%20courses%20with%20mismatched%20codes%20until%20repaired**%0A%0A%60validatePublishedCourseCodeConvention%60%20is%20called%20inside%20%60updateCourse%60%20whenever%20%60nextLifecycle%20%3D%3D%3D%20%22published%22%60%20%E2%80%94%20which%20is%20always%20true%20for%20an%20already-published%20course%20that%20isn't%20being%20demoted.%20This%20means%20any%20edit%20%28even%20a%20description%20typo%20fix%29%20to%20a%20published%20masterclass%20course%20still%20using%20a%20%60WS%60%20code%20will%20throw%20%60%22Masterclass%20and%20workshop%20course%20codes%20must%20start%20with%20MC%20before%20publishing.%22%60%20until%20the%20repair%20tool%20is%20run.%0A%0AThe%20repair%20tool%20mitigates%20this%20and%20is%20prominently%20shown%20in%20the%20UI%2C%20but%20there%20is%20a%20deployment%20window%20where%20affected%20courses%20are%20silently%20uneditable.%20Consider%20noting%20in%20the%20confirmation%20dialog%20or%20repair%20panel%20that%20edits%20to%20affected%20published%20courses%20will%20fail%20until%20their%20code%20is%20repaired.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fapp%2Fadmin%2Fcourses%2Fpage.tsx%3A243-251%0A**%60skipped%60%20count%20conflates%20batch-truncation%20with%20validation%20failures**%0A%0A%60applyAllMasterclassCodeRepairs%60%20passes%20all%20visible%20candidates%20%28up%20to%20100%20from%20the%20query%29%20to%20%60repairMasterclassCourseCodes%60%2C%20but%20the%20backend%20silently%20truncates%20to%20%60MASTERCLASS_REPAIR_BATCH_LIMIT%20%3D%2050%60.%20The%20excess%20IDs%20are%20counted%20as%20%60skipped%60%20alongside%20any%20courses%20that%20actually%20failed%20publish%20validation.%20The%20resulting%20toast%20%E2%80%94%20%22Updated%20X%3B%20skipped%20Y%22%20%E2%80%94%20gives%20no%20way%20for%20the%20admin%20to%20distinguish%20%22deferred%20to%20next%20batch%22%20from%20%22cannot%20be%20repaired%22.%0A%0AFor%20example%2C%20with%2060%20candidates%3A%2050%20are%20updated%2C%2010%20are%20batch-truncated%2C%20and%20the%20toast%20reads%20%22Updated%2050%3B%20skipped%2010%22.%20The%20admin%20may%20assume%20those%2010%20have%20validation%20issues%20and%20investigate%2C%20when%20they%20just%20need%20another%20click.%0A%0AConsider%20matching%20the%20query%20limit%20to%20the%20batch%20limit%20%28%60limit%3A%2050%60%20in%20the%20%60useQuery%60%20call%29%2C%20or%20splitting%20the%20%60skipped%60%20count%20into%20%60deferred%60%20vs%20%60failed%60%20in%20the%20return%20value%20and%20displaying%20them%20separately%20in%20the%20toast.%0A%0A%23%23%23%20Issue%202%20of%202%0Aconvex%2FadminCourses.ts%3A796-805%0A**%60updateCourse%60%20blocks%20edits%20to%20published%20courses%20with%20mismatched%20codes%20until%20repaired**%0A%0A%60validatePublishedCourseCodeConvention%60%20is%20called%20inside%20%60updateCourse%60%20whenever%20%60nextLifecycle%20%3D%3D%3D%20%22published%22%60%20%E2%80%94%20which%20is%20always%20true%20for%20an%20already-published%20course%20that%20isn't%20being%20demoted.%20This%20means%20any%20edit%20%28even%20a%20description%20typo%20fix%29%20to%20a%20published%20masterclass%20course%20still%20using%20a%20%60WS%60%20code%20will%20throw%20%60%22Masterclass%20and%20workshop%20course%20codes%20must%20start%20with%20MC%20before%20publishing.%22%60%20until%20the%20repair%20tool%20is%20run.%0A%0AThe%20repair%20tool%20mitigates%20this%20and%20is%20prominently%20shown%20in%20the%20UI%2C%20but%20there%20is%20a%20deployment%20window%20where%20affected%20courses%20are%20silently%20uneditable.%20Consider%20noting%20in%20the%20confirmation%20dialog%20or%20repair%20panel%20that%20edits%20to%20affected%20published%20courses%20will%20fail%20until%20their%20code%20is%20repaired.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fapp%2Fadmin%2Fcourses%2Fpage.tsx%3A243-251%0A**%60skipped%60%20count%20conflates%20batch-truncation%20with%20validation%20failures**%0A%0A%60applyAllMasterclassCodeRepairs%60%20passes%20all%20visible%20candidates%20%28up%20to%20100%20from%20the%20query%29%20to%20%60repairMasterclassCourseCodes%60%2C%20but%20the%20backend%20silently%20truncates%20to%20%60MASTERCLASS_REPAIR_BATCH_LIMIT%20%3D%2050%60.%20The%20excess%20IDs%20are%20counted%20as%20%60skipped%60%20alongside%20any%20courses%20that%20actually%20failed%20publish%20validation.%20The%20resulting%20toast%20%E2%80%94%20%22Updated%20X%3B%20skipped%20Y%22%20%E2%80%94%20gives%20no%20way%20for%20the%20admin%20to%20distinguish%20%22deferred%20to%20next%20batch%22%20from%20%22cannot%20be%20repaired%22.%0A%0AFor%20example%2C%20with%2060%20candidates%3A%2050%20are%20updated%2C%2010%20are%20batch-truncated%2C%20and%20the%20toast%20reads%20%22Updated%2050%3B%20skipped%2010%22.%20The%20admin%20may%20assume%20those%2010%20have%20validation%20issues%20and%20investigate%2C%20when%20they%20just%20need%20another%20click.%0A%0AConsider%20matching%20the%20query%20limit%20to%20the%20batch%20limit%20%28%60limit%3A%2050%60%20in%20the%20%60useQuery%60%20call%29%2C%20or%20splitting%20the%20%60skipped%60%20count%20into%20%60deferred%60%20vs%20%60failed%60%20in%20the%20return%20value%20and%20displaying%20them%20separately%20in%20the%20toast.%0A%0A%23%23%23%20Issue%202%20of%202%0Aconvex%2FadminCourses.ts%3A796-805%0A**%60updateCourse%60%20blocks%20edits%20to%20published%20courses%20with%20mismatched%20codes%20until%20repaired**%0A%0A%60validatePublishedCourseCodeConvention%60%20is%20called%20inside%20%60updateCourse%60%20whenever%20%60nextLifecycle%20%3D%3D%3D%20%22published%22%60%20%E2%80%94%20which%20is%20always%20true%20for%20an%20already-published%20course%20that%20isn't%20being%20demoted.%20This%20means%20any%20edit%20%28even%20a%20description%20typo%20fix%29%20to%20a%20published%20masterclass%20course%20still%20using%20a%20%60WS%60%20code%20will%20throw%20%60%22Masterclass%20and%20workshop%20course%20codes%20must%20start%20with%20MC%20before%20publishing.%22%60%20until%20the%20repair%20tool%20is%20run.%0A%0AThe%20repair%20tool%20mitigates%20this%20and%20is%20prominently%20shown%20in%20the%20UI%2C%20but%20there%20is%20a%20deployment%20window%20where%20affected%20courses%20are%20silently%20uneditable.%20Consider%20noting%20in%20the%20confirmation%20dialog%20or%20repair%20panel%20that%20edits%20to%20affected%20published%20courses%20will%20fail%20until%20their%20code%20is%20repaired.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/app/admin/courses/page.tsx
Line: 243-251

Comment:
**`skipped` count conflates batch-truncation with validation failures**

`applyAllMasterclassCodeRepairs` passes all visible candidates (up to 100 from the query) to `repairMasterclassCourseCodes`, but the backend silently truncates to `MASTERCLASS_REPAIR_BATCH_LIMIT = 50`. The excess IDs are counted as `skipped` alongside any courses that actually failed publish validation. The resulting toast — "Updated X; skipped Y" — gives no way for the admin to distinguish "deferred to next batch" from "cannot be repaired".

For example, with 60 candidates: 50 are updated, 10 are batch-truncated, and the toast reads "Updated 50; skipped 10". The admin may assume those 10 have validation issues and investigate, when they just need another click.

Consider matching the query limit to the batch limit (`limit: 50` in the `useQuery` call), or splitting the `skipped` count into `deferred` vs `failed` in the return value and displaying them separately in the toast.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: convex/adminCourses.ts
Line: 796-805

Comment:
**`updateCourse` blocks edits to published courses with mismatched codes until repaired**

`validatePublishedCourseCodeConvention` is called inside `updateCourse` whenever `nextLifecycle === "published"` — which is always true for an already-published course that isn't being demoted. This means any edit (even a description typo fix) to a published masterclass course still using a `WS` code will throw `"Masterclass and workshop course codes must start with MC before publishing."` until the repair tool is run.

The repair tool mitigates this and is prominently shown in the UI, but there is a deployment window where affected courses are silently uneditable. Consider noting in the confirmation dialog or repair panel that edits to affected published courses will fail until their code is repaired.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Bound admin course repair scans and batc..."](https://github.com/ayushj1001/mindpoint/commit/dd8fa85856a8bb5457765a5b5f6aec4ee53770cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28272179)</sub>

<!-- /greptile_comment -->