### PR TITLE
Expand masterclass code repair eligibility

### DIFF
--- a/apps/web/app/admin/courses/page.tsx
+++ b/apps/web/app/admin/courses/page.tsx
@@ -318,9 +318,9 @@ export default function AdminCoursesPage() {
                 Course Code Integrity
               </h2>
               <p className="mt-0.5 text-xs text-amber-800">
-                Review likely workshops using the legacy WS prefix. Fixes update
-                the stored type to masterclass and rewrite only the code prefix
-                to MC.
+                Review MC-coded courses with the wrong stored type and likely
+                workshops using the legacy WS prefix. Fixes store them as
+                masterclass courses and only rewrite WS prefixes to MC.
               </p>
             </div>
             <Button
@@ -748,7 +748,8 @@ export default function AdminCoursesPage() {
             <AlertDialogDescription>
               This will update up to 50 visible repair candidates in this batch,
               including any published courses that still pass publish
-              validation. Codes will keep their suffix and switch from WS to MC.
+              validation. Existing MC codes keep their code; legacy WS workshop
+              codes keep their suffix and switch to MC.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/convex/adminCourses.ts
+++ b/convex/adminCourses.ts
@@ -183,6 +183,14 @@ function hasMasterclassWorkshopSignal(course: {
 function isMasterclassRepairEligible(
   course: CourseCodeConventionCandidateInput,
 ) {
+  if (
+    hasText(course.code) &&
+    getUpperCodePrefix(course.code) === "MC" &&
+    course.type !== "masterclass"
+  ) {
+    return true;
+  }
+
   return (
     hasText(course.code) &&
     getUpperCodePrefix(course.code) === "WS" &&
@@ -202,6 +210,12 @@ function getMasterclassRepairCandidate(
     return null;
   }
 
+  const codePrefix = getUpperCodePrefix(course.code);
+  const suggestedCode =
+    codePrefix === "MC"
+      ? course.code.trim()
+      : replaceCodePrefix(course.code, "MC");
+
   return {
     courseId: course._id,
     name: course.name,
@@ -209,9 +223,11 @@ function getMasterclassRepairCandidate(
     currentType: course.type ?? null,
     suggestedType: "masterclass" as const,
     currentCode: course.code.trim(),
-    suggestedCode: replaceCodePrefix(course.code, "MC"),
+    suggestedCode,
     reason:
-      "Course uses the legacy workshop `WS` prefix but matches masterclass/workshop signals and has no worksheet-only fields.",
+      codePrefix === "MC"
+        ? "Course uses the masterclass/workshop `MC` prefix but is not stored as masterclass."
+        : "Course uses the legacy workshop `WS` prefix but matches masterclass/workshop signals and has no worksheet-only fields.",
   };
 }
 
@@ -711,12 +727,13 @@ export const createCourse = mutation({
       .replace(/-/g, "")
       .slice(0, 6)
       .toUpperCase()}`;
+    const code = args.data?.code || generatedCode;
 
     const payload = {
       ...args.data,
       name: args.name,
       type: args.type ?? args.data?.type ?? "certificate",
-      code: args.data?.code || generatedCode,
+      code,
       price: args.data?.price ?? 0,
       capacity: args.data?.capacity ?? 1,
       enrolledUsers: [],


### PR DESCRIPTION
## Summary
- Expand the admin code-repair flow to detect MC-coded courses whose stored type is not `masterclass`, in addition to legacy `WS` workshop entries.
- Preserve existing `MC` codes during repair while still normalizing legacy `WS` codes to the `MC` prefix.
- Update the admin UI copy to reflect the broader eligibility and the new code-preservation behavior.
- Ensure `createCourse` consistently reuses a single resolved code value when a custom code is provided.

## Testing
- Not run (changes reviewed from diff only).
- Verify the admin repair list now includes MC-coded courses with non-`masterclass` types.
- Verify applying a repair leaves existing MC codes unchanged and rewrites WS codes to MC with the suffix preserved.
- Verify new course creation still accepts an explicit code and falls back to the generated code when one is not provided.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR broadens masterclass code repair to also detect MC-prefixed courses whose stored type is not `masterclass` (previously only WS-prefix legacy courses were caught), preserves existing MC codes during repair, and consolidates the `code` resolution in `createCourse` to a single variable.

The core logic in `isMasterclassRepairEligible`, `getMasterclassRepairCandidate`, and `repairMasterclassCourseCodes` is correct. Two minor issues were found:
- The MC-branch inside `getSuggestedCourseType` (lines 398-403) is now dead code due to the early `isMasterclassRepairEligible` guard added in this PR.
- The "Apply All" dialog says "up to 50 visible repair candidates" but the query can surface up to 100 candidates while the mutation cap stays at 50, creating a subtle mismatch for large repair lists.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both findings are P2 (dead code and a copy inaccuracy); no data integrity or correctness issues.

All remaining comments are style/copy suggestions (P2). The repair logic is correct: MC-coded non-masterclass courses are properly detected, MC codes are preserved, batch limits are enforced with auditing, and published-course validation gates repairs appropriately.

convex/adminCourses.ts lines 398-403 (dead code); apps/web/app/admin/courses/page.tsx line 749 (dialog copy).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| convex/adminCourses.ts | Adds MC-prefix eligibility to `isMasterclassRepairEligible`, preserves MC codes in `getMasterclassRepairCandidate`, and resolves `code` to a single variable in `createCourse`. Core logic is correct; the MC branch in `getSuggestedCourseType` (lines 398-403) is now dead code. |
| apps/web/app/admin/courses/page.tsx | Updates confirmation dialog copy and table description to reflect broader repair eligibility and MC-preservation behavior. Minor copy inaccuracy: the dialog says "up to 50 visible" but the query returns up to 100 candidates while the mutation cap is 50. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `convex/adminCourses.ts`, line 398-403 ([link](https://github.com/ayushj1001/mindpoint/blob/f7d6dfd79bcca5cbd8e86c9edfc36e612b7c9872/convex/adminCourses.ts#L398-L403)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead code — MC branch in `getSuggestedCourseType` is now unreachable**

   The early-return guard `if (isMasterclassRepairEligible(course)) { return null; }` at the top of `getSuggestedCourseType` (line 380) already handles every case where `codePrefix === "MC" && course.type !== "masterclass"` — that is exactly the first branch of `isMasterclassRepairEligible` added in this PR. As a result, execution can never reach this block.

   Consider removing it (or leaving a comment) to avoid confusing future readers who might assume this path is live.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: convex/adminCourses.ts
   Line: 398-403

   Comment:
   **Dead code — MC branch in `getSuggestedCourseType` is now unreachable**

   The early-return guard `if (isMasterclassRepairEligible(course)) { return null; }` at the top of `getSuggestedCourseType` (line 380) already handles every case where `codePrefix === "MC" && course.type !== "masterclass"` — that is exactly the first branch of `isMasterclassRepairEligible` added in this PR. As a result, execution can never reach this block.

   Consider removing it (or leaving a comment) to avoid confusing future readers who might assume this path is live.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fmasterclass-code-repair-2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmasterclass-code-repair-2%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminCourses.ts%0ALine%3A%20398-403%0A%0AComment%3A%0A**Dead%20code%20%E2%80%94%20MC%20branch%20in%20%60getSuggestedCourseType%60%20is%20now%20unreachable**%0A%0AThe%20early-return%20guard%20%60if%20%28isMasterclassRepairEligible%28course%29%29%20%7B%20return%20null%3B%20%7D%60%20at%20the%20top%20of%20%60getSuggestedCourseType%60%20%28line%20380%29%20already%20handles%20every%20case%20where%20%60codePrefix%20%3D%3D%3D%20%22MC%22%20%26%26%20course.type%20!%3D%3D%20%22masterclass%22%60%20%E2%80%94%20that%20is%20exactly%20the%20first%20branch%20of%20%60isMasterclassRepairEligible%60%20added%20in%20this%20PR.%20As%20a%20result%2C%20execution%20can%20never%20reach%20this%20block.%0A%0AConsider%20removing%20it%20%28or%20leaving%20a%20comment%29%20to%20avoid%20confusing%20future%20readers%20who%20might%20assume%20this%20path%20is%20live.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminCourses.ts%0ALine%3A%20398-403%0A%0AComment%3A%0A**Dead%20code%20%E2%80%94%20MC%20branch%20in%20%60getSuggestedCourseType%60%20is%20now%20unreachable**%0A%0AThe%20early-return%20guard%20%60if%20%28isMasterclassRepairEligible%28course%29%29%20%7B%20return%20null%3B%20%7D%60%20at%20the%20top%20of%20%60getSuggestedCourseType%60%20%28line%20380%29%20already%20handles%20every%20case%20where%20%60codePrefix%20%3D%3D%3D%20%22MC%22%20%26%26%20course.type%20!%3D%3D%20%22masterclass%22%60%20%E2%80%94%20that%20is%20exactly%20the%20first%20branch%20of%20%60isMasterclassRepairEligible%60%20added%20in%20this%20PR.%20As%20a%20result%2C%20execution%20can%20never%20reach%20this%20block.%0A%0AConsider%20removing%20it%20%28or%20leaving%20a%20comment%29%20to%20avoid%20confusing%20future%20readers%20who%20might%20assume%20this%20path%20is%20live.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminCourses.ts%0ALine%3A%20398-403%0A%0AComment%3A%0A**Dead%20code%20%E2%80%94%20MC%20branch%20in%20%60getSuggestedCourseType%60%20is%20now%20unreachable**%0A%0AThe%20early-return%20guard%20%60if%20%28isMasterclassRepairEligible%28course%29%29%20%7B%20return%20null%3B%20%7D%60%20at%20the%20top%20of%20%60getSuggestedCourseType%60%20%28line%20380%29%20already%20handles%20every%20case%20where%20%60codePrefix%20%3D%3D%3D%20%22MC%22%20%26%26%20course.type%20!%3D%3D%20%22masterclass%22%60%20%E2%80%94%20that%20is%20exactly%20the%20first%20branch%20of%20%60isMasterclassRepairEligible%60%20added%20in%20this%20PR.%20As%20a%20result%2C%20execution%20can%20never%20reach%20this%20block.%0A%0AConsider%20removing%20it%20%28or%20leaving%20a%20comment%29%20to%20avoid%20confusing%20future%20readers%20who%20might%20assume%20this%20path%20is%20live.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fmasterclass-code-repair-2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmasterclass-code-repair-2%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aconvex%2FadminCourses.ts%3A398-403%0A**Dead%20code%20%E2%80%94%20MC%20branch%20in%20%60getSuggestedCourseType%60%20is%20now%20unreachable**%0A%0AThe%20early-return%20guard%20%60if%20%28isMasterclassRepairEligible%28course%29%29%20%7B%20return%20null%3B%20%7D%60%20at%20the%20top%20of%20%60getSuggestedCourseType%60%20%28line%20380%29%20already%20handles%20every%20case%20where%20%60codePrefix%20%3D%3D%3D%20%22MC%22%20%26%26%20course.type%20!%3D%3D%20%22masterclass%22%60%20%E2%80%94%20that%20is%20exactly%20the%20first%20branch%20of%20%60isMasterclassRepairEligible%60%20added%20in%20this%20PR.%20As%20a%20result%2C%20execution%20can%20never%20reach%20this%20block.%0A%0AConsider%20removing%20it%20%28or%20leaving%20a%20comment%29%20to%20avoid%20confusing%20future%20readers%20who%20might%20assume%20this%20path%20is%20live.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fapp%2Fadmin%2Fcourses%2Fpage.tsx%3A749-753%0A**Dialog%20copy%20understates%20the%20batch%20limit%20mismatch**%0A%0AThe%20query%20%60listMasterclassCodeRepairCandidates%60%20is%20called%20with%20%60limit%3A%20100%60%20%28line%20122%29%2C%20so%20up%20to%20100%20candidates%20can%20be%20shown%20in%20the%20table.%20But%20%60MASTERCLASS_REPAIR_BATCH_LIMIT%20%3D%2050%60%20means%20the%20mutation%20only%20processes%20the%20first%2050%20submitted%20IDs.%20When%20an%20admin%20sees%2060%2B%20rows%20in%20the%20list%20and%20clicks%20%22Apply%20All%22%2C%20only%2050%20are%20applied%3B%20the%20remaining%20candidates%20stay%20listed%20and%20require%20a%20second%20pass.%20The%20phrase%20%22up%20to%2050%20**visible**%20repair%20candidates%22%20is%20misleading%20when%20the%20visible%20count%20can%20exceed%2050.%0A%0AEither%20align%20the%20two%20limits%20%28set%20%60limit%3A%2050%60%20in%20the%20query%2C%20or%20raise%20%60MASTERCLASS_REPAIR_BATCH_LIMIT%60%20to%20100%29%2C%20or%20update%20the%20copy%20to%20clarify%20the%20partial-batch%20behavior.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aconvex%2FadminCourses.ts%3A398-403%0A**Dead%20code%20%E2%80%94%20MC%20branch%20in%20%60getSuggestedCourseType%60%20is%20now%20unreachable**%0A%0AThe%20early-return%20guard%20%60if%20%28isMasterclassRepairEligible%28course%29%29%20%7B%20return%20null%3B%20%7D%60%20at%20the%20top%20of%20%60getSuggestedCourseType%60%20%28line%20380%29%20already%20handles%20every%20case%20where%20%60codePrefix%20%3D%3D%3D%20%22MC%22%20%26%26%20course.type%20!%3D%3D%20%22masterclass%22%60%20%E2%80%94%20that%20is%20exactly%20the%20first%20branch%20of%20%60isMasterclassRepairEligible%60%20added%20in%20this%20PR.%20As%20a%20result%2C%20execution%20can%20never%20reach%20this%20block.%0A%0AConsider%20removing%20it%20%28or%20leaving%20a%20comment%29%20to%20avoid%20confusing%20future%20readers%20who%20might%20assume%20this%20path%20is%20live.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fapp%2Fadmin%2Fcourses%2Fpage.tsx%3A749-753%0A**Dialog%20copy%20understates%20the%20batch%20limit%20mismatch**%0A%0AThe%20query%20%60listMasterclassCodeRepairCandidates%60%20is%20called%20with%20%60limit%3A%20100%60%20%28line%20122%29%2C%20so%20up%20to%20100%20candidates%20can%20be%20shown%20in%20the%20table.%20But%20%60MASTERCLASS_REPAIR_BATCH_LIMIT%20%3D%2050%60%20means%20the%20mutation%20only%20processes%20the%20first%2050%20submitted%20IDs.%20When%20an%20admin%20sees%2060%2B%20rows%20in%20the%20list%20and%20clicks%20%22Apply%20All%22%2C%20only%2050%20are%20applied%3B%20the%20remaining%20candidates%20stay%20listed%20and%20require%20a%20second%20pass.%20The%20phrase%20%22up%20to%2050%20**visible**%20repair%20candidates%22%20is%20misleading%20when%20the%20visible%20count%20can%20exceed%2050.%0A%0AEither%20align%20the%20two%20limits%20%28set%20%60limit%3A%2050%60%20in%20the%20query%2C%20or%20raise%20%60MASTERCLASS_REPAIR_BATCH_LIMIT%60%20to%20100%29%2C%20or%20update%20the%20copy%20to%20clarify%20the%20partial-batch%20behavior.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aconvex%2FadminCourses.ts%3A398-403%0A**Dead%20code%20%E2%80%94%20MC%20branch%20in%20%60getSuggestedCourseType%60%20is%20now%20unreachable**%0A%0AThe%20early-return%20guard%20%60if%20%28isMasterclassRepairEligible%28course%29%29%20%7B%20return%20null%3B%20%7D%60%20at%20the%20top%20of%20%60getSuggestedCourseType%60%20%28line%20380%29%20already%20handles%20every%20case%20where%20%60codePrefix%20%3D%3D%3D%20%22MC%22%20%26%26%20course.type%20!%3D%3D%20%22masterclass%22%60%20%E2%80%94%20that%20is%20exactly%20the%20first%20branch%20of%20%60isMasterclassRepairEligible%60%20added%20in%20this%20PR.%20As%20a%20result%2C%20execution%20can%20never%20reach%20this%20block.%0A%0AConsider%20removing%20it%20%28or%20leaving%20a%20comment%29%20to%20avoid%20confusing%20future%20readers%20who%20might%20assume%20this%20path%20is%20live.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fapp%2Fadmin%2Fcourses%2Fpage.tsx%3A749-753%0A**Dialog%20copy%20understates%20the%20batch%20limit%20mismatch**%0A%0AThe%20query%20%60listMasterclassCodeRepairCandidates%60%20is%20called%20with%20%60limit%3A%20100%60%20%28line%20122%29%2C%20so%20up%20to%20100%20candidates%20can%20be%20shown%20in%20the%20table.%20But%20%60MASTERCLASS_REPAIR_BATCH_LIMIT%20%3D%2050%60%20means%20the%20mutation%20only%20processes%20the%20first%2050%20submitted%20IDs.%20When%20an%20admin%20sees%2060%2B%20rows%20in%20the%20list%20and%20clicks%20%22Apply%20All%22%2C%20only%2050%20are%20applied%3B%20the%20remaining%20candidates%20stay%20listed%20and%20require%20a%20second%20pass.%20The%20phrase%20%22up%20to%2050%20**visible**%20repair%20candidates%22%20is%20misleading%20when%20the%20visible%20count%20can%20exceed%2050.%0A%0AEither%20align%20the%20two%20limits%20%28set%20%60limit%3A%2050%60%20in%20the%20query%2C%20or%20raise%20%60MASTERCLASS_REPAIR_BATCH_LIMIT%60%20to%20100%29%2C%20or%20update%20the%20copy%20to%20clarify%20the%20partial-batch%20behavior.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: convex/adminCourses.ts
Line: 398-403

Comment:
**Dead code — MC branch in `getSuggestedCourseType` is now unreachable**

The early-return guard `if (isMasterclassRepairEligible(course)) { return null; }` at the top of `getSuggestedCourseType` (line 380) already handles every case where `codePrefix === "MC" && course.type !== "masterclass"` — that is exactly the first branch of `isMasterclassRepairEligible` added in this PR. As a result, execution can never reach this block.

Consider removing it (or leaving a comment) to avoid confusing future readers who might assume this path is live.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/app/admin/courses/page.tsx
Line: 749-753

Comment:
**Dialog copy understates the batch limit mismatch**

The query `listMasterclassCodeRepairCandidates` is called with `limit: 100` (line 122), so up to 100 candidates can be shown in the table. But `MASTERCLASS_REPAIR_BATCH_LIMIT = 50` means the mutation only processes the first 50 submitted IDs. When an admin sees 60+ rows in the list and clicks "Apply All", only 50 are applied; the remaining candidates stay listed and require a second pass. The phrase "up to 50 **visible** repair candidates" is misleading when the visible count can exceed 50.

Either align the two limits (set `limit: 50` in the query, or raise `MASTERCLASS_REPAIR_BATCH_LIMIT` to 100), or update the copy to clarify the partial-batch behavior.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Expand masterclass code repair eligibili..."](https://github.com/ayushj1001/mindpoint/commit/f7d6dfd79bcca5cbd8e86c9edfc36e612b7c9872) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28277025)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->