### PR TITLE
Switch cart checkout to Clerk Next.js hooks

### DIFF
--- a/apps/web/components/CartClient.tsx
+++ b/apps/web/components/CartClient.tsx
@@ -854,11 +854,7 @@ const CartContent = () => {
     } else {
       // User is not signed in, show Clerk sign-in modal
       setPendingCheckout(true);
-      const returnUrl = window.location.href;
-      openSignIn({
-        forceRedirectUrl: returnUrl,
-        signUpForceRedirectUrl: returnUrl,
-      });
+      openSignIn();
     }
   };
 

--- a/apps/web/components/CartClient.tsx
+++ b/apps/web/components/CartClient.tsx
@@ -21,7 +21,7 @@ import {
   Gift,
 } from "lucide-react";
 import { showRupees, getOfferDetails, type OfferDetails } from "@/lib/utils";
-import { useUser, useClerk } from "@clerk/clerk-react";
+import { useUser, useClerk } from "@clerk/nextjs";
 import { handlePaymentSuccess } from "@/app/actions/payment";
 import { toast } from "sonner";
 import { WhatsAppModal } from "@/components/whatsapp-modal";
@@ -55,13 +55,8 @@ const getReferralCookie = () => {
 };
 
 const CartContent = () => {
-  const {
-    items,
-    removeItem,
-    updateItemQuantity,
-    isEmpty,
-    emptyCart,
-  } = useCart();
+  const { items, removeItem, updateItemQuantity, isEmpty, emptyCart } =
+    useCart();
 
   const [isMounted, setIsMounted] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
@@ -126,8 +121,9 @@ const CartContent = () => {
     [bundleCampaigns, items],
   );
   const appliedBundle = bundleEvaluation.appliedCampaign;
-  const bundleProgressCampaign =
-    appliedBundle ? null : bundleEvaluation.progressCampaign;
+  const bundleProgressCampaign = appliedBundle
+    ? null
+    : bundleEvaluation.progressCampaign;
   const coveredCourseIdSet = useMemo(
     () => new Set(appliedBundle?.coveredCourseIds ?? []),
     [appliedBundle],
@@ -858,9 +854,10 @@ const CartContent = () => {
     } else {
       // User is not signed in, show Clerk sign-in modal
       setPendingCheckout(true);
+      const returnUrl = window.location.href;
       openSignIn({
-        afterSignInUrl: window.location.href,
-        afterSignUpUrl: window.location.href,
+        forceRedirectUrl: returnUrl,
+        signUpForceRedirectUrl: returnUrl,
       });
     }
   };
@@ -879,7 +876,7 @@ const CartContent = () => {
   // Show loading state during hydration to prevent mismatch
   if (!isMounted) {
     return (
-      <div className="container mx-auto py-16 ">
+      <div className="container mx-auto py-16">
         <div className="text-center">
           <ShoppingCart className="text-muted-foreground mx-auto mb-4 h-16 w-16" />
           <h2 className="mb-2 text-2xl font-semibold">Loading cart...</h2>
@@ -890,7 +887,7 @@ const CartContent = () => {
 
   if (isEmpty) {
     return (
-      <div className="container mx-auto py-16 ">
+      <div className="container mx-auto py-16">
         <div className="text-center">
           <ShoppingCart className="text-muted-foreground mx-auto mb-4 h-16 w-16" />
           <h2 className="mb-2 text-2xl font-semibold">Your cart is empty</h2>
@@ -906,7 +903,7 @@ const CartContent = () => {
   }
 
   return (
-    <div className="container py-6 sm:py-8 ">
+    <div className="container py-6 sm:py-8">
       <div className="mb-6 sm:mb-8">
         <h1 className="mb-2 text-4xl font-bold tracking-tight sm:text-5xl">
           Shopping Cart
@@ -978,13 +975,15 @@ const CartContent = () => {
                 );
                 const originalLinePrice = Math.round(
                   pricingItem?.checkoutPrice ??
-                    (item.originalPrice ?? item.price ?? 0),
+                    item.originalPrice ??
+                    item.price ??
+                    0,
                 );
 
                 return (
                   <div
                     key={item.id}
-                    className="rounded-xl border border-lavender-200 bg-card p-3 shadow-[0_10px_22px_-18px_rgba(124,111,155,0.7)]"
+                    className="border-lavender-200 bg-card rounded-xl border p-3 shadow-[0_10px_22px_-18px_rgba(124,111,155,0.7)]"
                   >
                     <div className="flex items-start gap-3">
                       <div className="h-14 w-14 flex-shrink-0 overflow-hidden rounded-md sm:h-16 sm:w-16">
@@ -1163,12 +1162,14 @@ const CartContent = () => {
                   </div>
                   <p>
                     {appliedBundle.coveredCourseIds.length} course
-                    {appliedBundle.coveredCourseIds.length === 1 ? "" : "s"}{" "}
+                    {appliedBundle.coveredCourseIds.length === 1
+                      ? ""
+                      : "s"}{" "}
                     covered for {showRupees(appliedBundle.flatFee)}.
                   </p>
                   <p className="text-xs text-blue-700">
-                    Existing discounts, BOGO, and coupon reductions do not
-                    apply to the covered courses.
+                    Existing discounts, BOGO, and coupon reductions do not apply
+                    to the covered courses.
                   </p>
                 </div>
               ) : bundleProgressCampaign ? (
@@ -1241,7 +1242,9 @@ const CartContent = () => {
                       checkoutPricing.items.reduce(
                         (total, item) =>
                           total +
-                          (item.couponCode ? item.redemptionDiscountAmount ?? 0 : 0),
+                          (item.couponCode
+                            ? (item.redemptionDiscountAmount ?? 0)
+                            : 0),
                         0,
                       ),
                     )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "@clerk/clerk-react": "^5.61.3",
         "@clerk/nextjs": "^7.0.12",
         "@hookform/resolvers": "^5.2.1",
         "@icons-pack/react-simple-icons": "^13.7.0",
@@ -2009,23 +2008,6 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "license": "MIT"
-    },
-    "node_modules/@clerk/clerk-react": {
-      "version": "5.61.4",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.4.tgz",
-      "integrity": "sha512-xGvQvzfc5pQEuqCW8CNUgnlR+9nt6gSSMGMYx3l972utIJrFKByQJFCRZpwYBvAHiveuK11Wgy3J39p904jb+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@clerk/shared": "^3.47.3",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
-        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
-      }
     },
     "node_modules/@clerk/localizations": {
       "version": "3.37.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "test:admin-route-protection": "node scripts/test-admin-route-protection.js"
   },
   "dependencies": {
-    "@clerk/clerk-react": "^5.61.3",
     "@clerk/nextjs": "^7.0.12",
     "@hookform/resolvers": "^5.2.1",
     "@icons-pack/react-simple-icons": "^13.7.0",


### PR DESCRIPTION
## Summary
- Swapped cart checkout auth hooks from `@clerk/clerk-react` to `@clerk/nextjs`.
- Updated the sign-in flow to use Clerk redirect props that preserve the current cart URL after auth.
- Removed the unused `@clerk/clerk-react` dependency from the package manifest and lockfile.
- Applied a small formatting cleanup in `CartClient.tsx` while touching the checkout logic.

## Testing
- Not run (not requested).
- Verify the cart checkout flow opens Clerk sign-in and returns to the same cart URL after login/sign-up.
- Verify the app builds and the cart page still renders for signed-in and signed-out users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified cart interface and authentication code structure for improved maintainability.
  * Updated authentication library integration for better compatibility.

* **Chores**
  * Removed unused authentication dependency from project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR switches `CartClient.tsx` auth hooks from `@clerk/clerk-react` to `@clerk/nextjs` and, in a follow-up commit, strips the `forceRedirectUrl` / `signUpForceRedirectUrl` arguments that were causing a full-page redirect after modal sign-in (which would destroy the `pendingCheckout` React state and force users to click Checkout a second time). The `@clerk/clerk-react` direct dependency is removed from `package.json`; it remains in `package-lock.json` only as a transitive dependency of `@clerk/clerk-expo` used by the mobile workspace, which is expected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the hook swap is correct, the prior forceRedirectUrl concern has been resolved, and no new issues were found.

All remaining findings from the previous review round have been addressed. No P0/P1 issues remain. The openSignIn() call is now argument-free, keeping the Clerk modal in-place and preserving the pendingCheckout React state. The lockfile change is benign (transitive dep of mobile workspace).

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/components/CartClient.tsx | Hook import updated from @clerk/clerk-react to @clerk/nextjs; openSignIn() now called with no redirect args, preserving in-place modal close and React state. |
| package.json | @clerk/clerk-react removed from direct dependencies; @clerk/nextjs was already present. |
| package-lock.json | @clerk/clerk-react remains as a transitive dep of @clerk/clerk-expo (mobile app); its presence is correct and expected. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CartClient
    participant ClerkModal
    participant Effect as useEffect

    User->>CartClient: Click Checkout (not signed in)
    CartClient->>CartClient: setPendingCheckout(true)
    CartClient->>ClerkModal: openSignIn()
    ClerkModal-->>User: Shows modal overlay
    User->>ClerkModal: Signs in
    ClerkModal-->>CartClient: Modal closes, React state preserved
    CartClient->>Effect: pendingCheckout=true, user.id defined, userProfile loaded
    Effect->>CartClient: setPendingCheckout(false)
    Effect->>CartClient: proceedWithCheckoutAfterAuth()
    CartClient-->>User: Proceeds to payment or WhatsApp modal
```

<sub>Reviews (2): Last reviewed commit: ["Simplify cart sign-in handoff"](https://github.com/ayushj1001/mindpoint/commit/e2d849a7b24306e55de8ce569e6e004378d5bd92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28278731)</sub>

<!-- /greptile_comment -->