### PR TITLE
Show bundle eligibility on course and cart surfaces

### DIFF
--- a/apps/web/components/CartClient.tsx
+++ b/apps/web/components/CartClient.tsx
@@ -64,8 +64,10 @@ function BundleProgressSection({
   eligibleCourseIdSet: Set<string>;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const remaining =
-    campaign.progress.minCount - campaign.progress.selectedCount;
+  const remaining = Math.max(
+    0,
+    campaign.progress.minCount - campaign.progress.selectedCount,
+  );
   const progressPct = Math.min(
     100,
     Math.round(

--- a/apps/web/components/CartClient.tsx
+++ b/apps/web/components/CartClient.tsx
@@ -19,6 +19,9 @@ import {
   Minus,
   Sparkles,
   Gift,
+  Layers,
+  ChevronDown,
+  ChevronUp,
 } from "lucide-react";
 import { showRupees, getOfferDetails, type OfferDetails } from "@/lib/utils";
 import { useUser, useClerk } from "@clerk/nextjs";
@@ -43,6 +46,105 @@ import { useNow } from "@/hooks/use-now";
 import { useMemo } from "react";
 
 export const dynamic = "force-dynamic";
+
+import type { EvaluatedBundleCampaign } from "@mindpoint/domain/bundles";
+
+/**
+ * Collapsible progress section shown when a bundle is partially fulfilled.
+ * Lists the eligible items already in the cart, shows a progress bar, and
+ * tells the user how many more courses they need.
+ */
+function BundleProgressSection({
+  campaign,
+  items,
+  eligibleCourseIdSet,
+}: {
+  campaign: EvaluatedBundleCampaign;
+  items: Array<{ id: string; name: string; [key: string]: unknown }>;
+  eligibleCourseIdSet: Set<string>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const remaining =
+    campaign.progress.minCount - campaign.progress.selectedCount;
+  const progressPct = Math.min(
+    100,
+    Math.round(
+      (campaign.progress.selectedCount / campaign.progress.minCount) * 100,
+    ),
+  );
+
+  const eligibleItems = items.filter((item) =>
+    eligibleCourseIdSet.has(String(item.id)),
+  );
+
+  return (
+    <div className="space-y-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
+      <div className="flex items-center gap-2 font-semibold">
+        <Layers className="h-4 w-4" />
+        <span className="flex-1">{campaign.campaignName}</span>
+        <span className="text-xs font-medium text-amber-700">
+          {showRupees(campaign.flatFee)}
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-2 w-full overflow-hidden rounded-full bg-amber-200">
+        <div
+          className="h-full rounded-full bg-amber-500 transition-all duration-300"
+          style={{ width: `${progressPct}%` }}
+        />
+      </div>
+
+      <p className="text-xs">
+        <span className="font-semibold">
+          {campaign.progress.selectedCount} of {campaign.progress.minCount}
+        </span>{" "}
+        eligible courses in cart.{" "}
+        <span className="font-medium">
+          Add {remaining} more to unlock the bundle!
+        </span>
+      </p>
+
+      {/* Expandable eligible item list */}
+      {eligibleItems.length > 0 && (
+        <>
+          <button
+            type="button"
+            onClick={() => setExpanded((prev) => !prev)}
+            className="flex items-center gap-1 text-xs font-medium text-amber-700 hover:text-amber-900"
+          >
+            {expanded ? (
+              <ChevronUp className="h-3 w-3" />
+            ) : (
+              <ChevronDown className="h-3 w-3" />
+            )}
+            {expanded ? "Hide" : "Show"} eligible items in cart
+          </button>
+          {expanded && (
+            <div className="space-y-1 border-t border-amber-200 pt-2">
+              {eligibleItems.map((item) => (
+                <div
+                  key={item.id}
+                  className="flex items-center gap-2 text-xs"
+                >
+                  <Check className="h-3 w-3 shrink-0 text-amber-600" />
+                  <span className="truncate">{item.name}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      <p className="text-xs text-amber-700">
+        <Link href="/courses" className="underline hover:text-amber-900">
+          Browse courses
+        </Link>{" "}
+        to find more eligible courses for this deal.
+      </p>
+    </div>
+  );
+}
 
 const getReferralCookie = () => {
   if (typeof document === "undefined") return null;
@@ -127,6 +229,12 @@ const CartContent = () => {
   const coveredCourseIdSet = useMemo(
     () => new Set(appliedBundle?.coveredCourseIds ?? []),
     [appliedBundle],
+  );
+
+  // Set of course IDs eligible for the in-progress bundle (for per-item tagging)
+  const progressEligibleCourseIdSet = useMemo(
+    () => new Set(bundleProgressCampaign?.coveredCourseIds ?? []),
+    [bundleProgressCampaign],
   );
 
   // Update offer details for cart items using shared time
@@ -1000,11 +1108,27 @@ const CartContent = () => {
                         </p>
                         {itemHasBundle && pricingItem?.bundleCampaignName ? (
                           <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
-                            <span className="rounded bg-blue-100 px-2 py-1 text-[11px] font-semibold text-blue-800">
+                            <span className="inline-flex items-center gap-1 rounded bg-blue-100 px-2 py-1 text-[11px] font-semibold text-blue-800">
+                              <Layers className="h-3 w-3" />
                               Bundle Applied
                             </span>
                             <span className="font-medium text-blue-700">
                               {pricingItem.bundleCampaignName}
+                            </span>
+                            {pricingItem.redemptionDiscountAmount > 0 && (
+                              <span className="font-medium text-blue-600">
+                                (save {showRupees(pricingItem.redemptionDiscountAmount)})
+                              </span>
+                            )}
+                          </div>
+                        ) : !itemHasBundle && progressEligibleCourseIdSet.has(String(item.id)) ? (
+                          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+                            <span className="inline-flex items-center gap-1 rounded bg-amber-100 px-2 py-1 text-[11px] font-semibold text-amber-800">
+                              <Layers className="h-3 w-3" />
+                              Bundle Eligible
+                            </span>
+                            <span className="font-medium text-amber-700">
+                              {bundleProgressCampaign?.campaignName}
                             </span>
                           </div>
                         ) : null}
@@ -1153,7 +1277,7 @@ const CartContent = () => {
               {appliedBundle ? (
                 <div className="space-y-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-3 text-sm text-blue-900">
                   <div className="flex items-center gap-2 font-semibold">
-                    <Sparkles className="h-4 w-4" />
+                    <Layers className="h-4 w-4" />
                     <span>{appliedBundle.campaignName}</span>
                   </div>
                   <p>
@@ -1163,23 +1287,41 @@ const CartContent = () => {
                       : "s"}{" "}
                     covered for {showRupees(appliedBundle.flatFee)}.
                   </p>
+                  {/* List covered courses with per-item savings */}
+                  <div className="space-y-1 border-t border-blue-200 pt-2">
+                    {appliedBundle.allocations.map((alloc) => {
+                      const cartItem = items.find(
+                        (i) => String(i.id) === String(alloc.courseId),
+                      );
+                      return (
+                        <div
+                          key={alloc.courseId}
+                          className="flex items-start gap-2 text-xs"
+                        >
+                          <Check className="mt-0.5 h-3 w-3 shrink-0 text-blue-600" />
+                          <span className="min-w-0 flex-1 truncate">
+                            {cartItem?.name ?? "Course"}
+                          </span>
+                          {alloc.savings > 0 && (
+                            <span className="shrink-0 font-medium text-blue-700">
+                              -{showRupees(alloc.savings)}
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
                   <p className="text-xs text-blue-700">
                     Existing discounts, BOGO, and coupon reductions do not apply
                     to the covered courses.
                   </p>
                 </div>
               ) : bundleProgressCampaign ? (
-                <div className="space-y-1 rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900">
-                  <div className="flex items-center gap-2 font-semibold">
-                    <Sparkles className="h-4 w-4" />
-                    <span>{bundleProgressCampaign.campaignName}</span>
-                  </div>
-                  <p>
-                    {bundleProgressCampaign.progress.selectedCount} of{" "}
-                    {bundleProgressCampaign.progress.minCount} selected for the
-                    flat-fee bundle.
-                  </p>
-                </div>
+                <BundleProgressSection
+                  campaign={bundleProgressCampaign}
+                  items={items}
+                  eligibleCourseIdSet={progressEligibleCourseIdSet}
+                />
               ) : null}
               {hasBogoItems && (
                 <div className="space-y-2">

--- a/apps/web/components/CourseTypePage.tsx
+++ b/apps/web/components/CourseTypePage.tsx
@@ -19,8 +19,9 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "../components/ui/carousel";
-import { Plus, BookOpen } from "lucide-react";
+import { Plus, BookOpen, Layers } from "lucide-react";
 import { showRupees, getOfferDetails, getCoursePrice } from "@/lib/utils";
+import { useBundleEligibility } from "@/hooks/use-bundle-eligibility";
 import type {
   CourseLike,
   PublicCourse,
@@ -171,6 +172,9 @@ const CourseGroupCard = ({
     getOfferDetails(selectedCourse),
   );
 
+  // Bundle eligibility (shared subscription, cached across cards)
+  const bundleInfo = useBundleEligibility(selectedCourse._id);
+
   // Use pre-fetched BOGO courses from props
   const availableCourses = bogoCourses;
 
@@ -298,17 +302,26 @@ const CourseGroupCard = ({
     >
       <CourseImageCarousel imageUrls={selectedCourse.imageUrls || []} />
 
-      {offerDetails && (
+      {(offerDetails || bundleInfo) && (
         <div className="pointer-events-none absolute inset-x-3 top-3 z-20 flex items-start justify-between gap-2">
-          {offerDetails && (
-            <Badge
-              variant="secondary"
-              className="max-w-[52%] truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
-            >
-              <span className="sm:hidden">Special Offer</span>
-              <span className="hidden sm:inline">{offerDetails.offerName}</span>
-            </Badge>
-          )}
+          <div className="flex max-w-[52%] flex-col gap-1">
+            {offerDetails && (
+              <Badge
+                variant="secondary"
+                className="max-w-full truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
+              >
+                <span className="sm:hidden">Special Offer</span>
+                <span className="hidden sm:inline">{offerDetails.offerName}</span>
+              </Badge>
+            )}
+            {bundleInfo && (
+              <Badge className="max-w-full bg-blue-600/90 text-[11px] font-semibold whitespace-nowrap text-white shadow-lg">
+                <Layers className="mr-1 h-3 w-3" />
+                <span className="sm:hidden">Bundle</span>
+                <span className="hidden sm:inline">Bundle Deal</span>
+              </Badge>
+            )}
+          </div>
           {(offerDetails?.hasDiscount || offerDetails?.hasBogo) && (
             <div className="flex max-w-[46%] flex-col items-end gap-1">
               {offerDetails?.hasDiscount && (
@@ -477,6 +490,12 @@ const CourseGroupCard = ({
                 )}
               </div>
             )}
+            {bundleInfo && (
+              <div className="flex items-center gap-1 text-xs font-medium text-blue-700">
+                <Layers className="h-3 w-3 shrink-0" />
+                <span className="truncate">{bundleInfo.dealSummary}</span>
+              </div>
+            )}
           </div>
           {(() => {
               const seatsLeft = Math.max(
@@ -539,6 +558,9 @@ const CourseCard = ({
   const [offerDetails, setOfferDetails] = useState(getOfferDetails(course));
   const [mounted, setMounted] = useState(false);
   const [showBogoModal, setShowBogoModal] = useState(false);
+
+  // Bundle eligibility (shared subscription, cached across cards)
+  const bundleInfo = useBundleEligibility(course._id);
 
   // Use pre-fetched BOGO courses from props
   const availableCourses = bogoCourses;
@@ -663,17 +685,26 @@ const CourseCard = ({
     >
       <CourseImageCarousel imageUrls={course.imageUrls || []} />
 
-      {offerDetails && (
+      {(offerDetails || bundleInfo) && (
         <div className="pointer-events-none absolute inset-x-3 top-3 z-20 flex items-start justify-between gap-2">
-          {offerDetails && (
-            <Badge
-              variant="secondary"
-              className="max-w-[52%] truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
-            >
-              <span className="sm:hidden">Special Offer</span>
-              <span className="hidden sm:inline">{offerDetails.offerName}</span>
-            </Badge>
-          )}
+          <div className="flex max-w-[52%] flex-col gap-1">
+            {offerDetails && (
+              <Badge
+                variant="secondary"
+                className="max-w-full truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
+              >
+                <span className="sm:hidden">Special Offer</span>
+                <span className="hidden sm:inline">{offerDetails.offerName}</span>
+              </Badge>
+            )}
+            {bundleInfo && (
+              <Badge className="max-w-full bg-blue-600/90 text-[11px] font-semibold whitespace-nowrap text-white shadow-lg">
+                <Layers className="mr-1 h-3 w-3" />
+                <span className="sm:hidden">Bundle</span>
+                <span className="hidden sm:inline">Bundle Deal</span>
+              </Badge>
+            )}
+          </div>
           {(offerDetails?.hasDiscount || offerDetails?.hasBogo) && (
             <div className="flex max-w-[46%] flex-col items-end gap-1">
               {offerDetails?.hasDiscount && (
@@ -775,6 +806,12 @@ const CourseCard = ({
                 Includes a free bonus course
               </div>
             )}
+          </div>
+        )}
+        {bundleInfo && (
+          <div className="mt-1 flex items-center gap-1 text-xs font-medium text-blue-700">
+            <Layers className="h-3 w-3 shrink-0" />
+            <span className="truncate">{bundleInfo.dealSummary}</span>
           </div>
         )}
       </CardContent>

--- a/apps/web/components/CoursesClient.tsx
+++ b/apps/web/components/CoursesClient.tsx
@@ -31,8 +31,9 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel";
-import { Plus } from "lucide-react";
+import { Plus, Layers } from "lucide-react";
 import { showRupees, getOfferDetails, getCoursePrice } from "@/lib/utils";
+import { useBundleEligibility } from "@/hooks/use-bundle-eligibility";
 import {
   Select,
   SelectContent,
@@ -172,6 +173,9 @@ const CourseGroupCard = ({
   // now is used to trigger re-renders every minute, getOfferDetails uses Date.now() internally
   const offerDetails = getOfferDetails(selectedCourse);
 
+  // Bundle eligibility (shared subscription, cached across cards)
+  const bundleInfo = useBundleEligibility(selectedCourse._id);
+
   const handleAddToCart = () => {
     // Check if course is out of stock
     const seatsLeft = Math.max(
@@ -272,17 +276,26 @@ const CourseGroupCard = ({
     >
       <CourseImageCarousel imageUrls={selectedCourse.imageUrls || []} />
 
-      {offerDetails && (
+      {(offerDetails || bundleInfo) && (
         <div className="pointer-events-none absolute inset-x-3 top-3 z-20 flex items-start justify-between gap-2">
-          {offerDetails && (
-            <Badge
-              variant="secondary"
-              className="max-w-[52%] truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
-            >
-              <span className="sm:hidden">Special Offer</span>
-              <span className="hidden sm:inline">{offerDetails.offerName}</span>
-            </Badge>
-          )}
+          <div className="flex max-w-[52%] flex-col gap-1">
+            {offerDetails && (
+              <Badge
+                variant="secondary"
+                className="max-w-full truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
+              >
+                <span className="sm:hidden">Special Offer</span>
+                <span className="hidden sm:inline">{offerDetails.offerName}</span>
+              </Badge>
+            )}
+            {bundleInfo && (
+              <Badge className="max-w-full bg-blue-600/90 text-[11px] font-semibold whitespace-nowrap text-white shadow-lg">
+                <Layers className="mr-1 h-3 w-3" />
+                <span className="sm:hidden">Bundle</span>
+                <span className="hidden sm:inline">Bundle Deal</span>
+              </Badge>
+            )}
+          </div>
           {(offerDetails?.hasDiscount || offerDetails?.hasBogo) && (
             <div className="flex max-w-[46%] flex-col items-end gap-1">
               {offerDetails?.hasDiscount && (
@@ -450,6 +463,12 @@ const CourseGroupCard = ({
                 Includes a free bonus course
               </div>
             )}
+            {bundleInfo && (
+              <div className="flex items-center gap-1 text-xs font-medium text-blue-700">
+                <Layers className="h-3 w-3 shrink-0" />
+                <span className="truncate">{bundleInfo.dealSummary}</span>
+              </div>
+            )}
           </div>
           {(() => {
               const seatsLeft = Math.max(
@@ -510,6 +529,9 @@ const CourseCard = ({
   const { addItem, inCart } = useCart();
   const router = useRouter();
   const [showBogoModal, setShowBogoModal] = useState(false);
+
+  // Bundle eligibility (shared subscription, cached across cards)
+  const bundleInfo = useBundleEligibility(course._id);
   const [mounted, setMounted] = useState(false);
 
   // Get available courses for BOGO selection from props
@@ -625,17 +647,26 @@ const CourseCard = ({
     >
       <CourseImageCarousel imageUrls={course.imageUrls || []} />
 
-      {offerDetails && (
+      {(offerDetails || bundleInfo) && (
         <div className="pointer-events-none absolute inset-x-3 top-3 z-20 flex items-start justify-between gap-2">
-          {offerDetails && (
-            <Badge
-              variant="secondary"
-              className="max-w-[52%] truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
-            >
-              <span className="sm:hidden">Special Offer</span>
-              <span className="hidden sm:inline">{offerDetails.offerName}</span>
-            </Badge>
-          )}
+          <div className="flex max-w-[52%] flex-col gap-1">
+            {offerDetails && (
+              <Badge
+                variant="secondary"
+                className="max-w-full truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
+              >
+                <span className="sm:hidden">Special Offer</span>
+                <span className="hidden sm:inline">{offerDetails.offerName}</span>
+              </Badge>
+            )}
+            {bundleInfo && (
+              <Badge className="max-w-full bg-blue-600/90 text-[11px] font-semibold whitespace-nowrap text-white shadow-lg">
+                <Layers className="mr-1 h-3 w-3" />
+                <span className="sm:hidden">Bundle</span>
+                <span className="hidden sm:inline">Bundle Deal</span>
+              </Badge>
+            )}
+          </div>
           {(offerDetails?.hasDiscount || offerDetails?.hasBogo) && (
             <div className="flex max-w-[46%] flex-col items-end gap-1">
               {offerDetails?.hasDiscount && (
@@ -707,6 +738,12 @@ const CourseCard = ({
             {offerDetails?.hasBogo && (
               <div className="text-xs font-semibold text-emerald-600">
                 Includes a free bonus course
+              </div>
+            )}
+            {bundleInfo && (
+              <div className="flex items-center gap-1 text-xs font-medium text-blue-700">
+                <Layers className="h-3 w-3 shrink-0" />
+                <span className="truncate">{bundleInfo.dealSummary}</span>
               </div>
             )}
           </div>

--- a/apps/web/components/course-card.tsx
+++ b/apps/web/components/course-card.tsx
@@ -17,8 +17,9 @@ import { useEffect, useState } from "react";
 import { BogoSelectionModal } from "@/components/bogo-selection-modal";
 import { Id } from "@mindpoint/backend/data-model";
 import { calculatePointsEarned } from "@/lib/mind-points";
-import { Gift } from "lucide-react";
+import { Gift, Layers } from "lucide-react";
 import { getEnrolledCount } from "@/lib/course-enrollment";
+import { useBundleEligibility } from "@/hooks/use-bundle-eligibility";
 
 // Helper function to format date
 const formatDate = (dateString: string) => {
@@ -80,6 +81,9 @@ export function CourseCard({
   // Use shared time for offer details - updates automatically via useNow hook
   // now triggers re-renders every minute, getOfferDetails uses Date.now() internally
   const offerDetails = getOfferDetails(course);
+
+  // Bundle eligibility (shared subscription, cached across cards)
+  const bundleInfo = useBundleEligibility(course._id);
 
   const handleAddToCart = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -188,17 +192,26 @@ export function CourseCard({
       {/* Course Image */}
       <CourseImageCarousel imageUrls={course.imageUrls || []} />
 
-      {offerDetails && (
+      {(offerDetails || bundleInfo) && (
         <div className="pointer-events-none absolute inset-x-3 top-3 z-20 flex items-start justify-between gap-2">
-          {offerDetails && (
-            <Badge
-              variant="secondary"
-              className="max-w-[52%] truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
-            >
-              <span className="sm:hidden">Special Offer</span>
-              <span className="hidden sm:inline">{offerDetails.offerName}</span>
-            </Badge>
-          )}
+          <div className="flex max-w-[52%] flex-col gap-1">
+            {offerDetails && (
+              <Badge
+                variant="secondary"
+                className="max-w-full truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
+              >
+                <span className="sm:hidden">Special Offer</span>
+                <span className="hidden sm:inline">{offerDetails.offerName}</span>
+              </Badge>
+            )}
+            {bundleInfo && (
+              <Badge className="max-w-full bg-blue-600/90 text-[11px] font-semibold whitespace-nowrap text-white shadow-lg">
+                <Layers className="mr-1 h-3 w-3" />
+                <span className="sm:hidden">Bundle</span>
+                <span className="hidden sm:inline">Bundle Deal</span>
+              </Badge>
+            )}
+          </div>
           {(offerDetails?.hasDiscount || offerDetails?.hasBogo) && (
             <div className="flex max-w-[46%] flex-col items-end gap-1">
               {offerDetails?.hasDiscount && (
@@ -281,6 +294,12 @@ export function CourseCard({
               Includes a free bonus course
             </div>
           )}
+          {bundleInfo && (
+            <div className="flex items-center gap-1 text-xs font-medium text-blue-700">
+              <Layers className="h-3 w-3 shrink-0" />
+              <span className="truncate">{bundleInfo.dealSummary}</span>
+            </div>
+          )}
           <div className="text-muted-foreground flex items-center gap-1 text-xs">
             <Gift className="h-3 w-3 shrink-0" />
             <span className="truncate">
@@ -357,6 +376,9 @@ export function UpcomingCourseCard({
   // Use shared time for offer details - updates automatically via useNow hook
   // now triggers re-renders every minute, getOfferDetails uses Date.now() internally
   const offerDetails = getOfferDetails(course);
+
+  // Bundle eligibility (shared subscription, cached across cards)
+  const bundleInfo = useBundleEligibility(course._id);
 
   const handleAddToCart = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -482,6 +504,13 @@ export function UpcomingCourseCard({
             <Clock className="mr-1 h-3 w-3" />
             Upcoming
           </Badge>
+          {bundleInfo && (
+            <Badge className="w-fit max-w-full bg-blue-600/90 text-[11px] font-semibold whitespace-nowrap text-white shadow-lg">
+              <Layers className="mr-1 h-3 w-3" />
+              <span className="sm:hidden">Bundle</span>
+              <span className="hidden sm:inline">Bundle Deal</span>
+            </Badge>
+          )}
         </div>
 
         {(offerDetails?.hasDiscount || offerDetails?.hasBogo) && (
@@ -578,6 +607,12 @@ export function UpcomingCourseCard({
             {offerDetails?.hasBogo && (
               <div className="text-xs font-semibold text-emerald-600">
                 Includes a free bonus course
+              </div>
+            )}
+            {bundleInfo && (
+              <div className="flex items-center gap-1 text-xs font-medium text-blue-700">
+                <Layers className="h-3 w-3 shrink-0" />
+                <span className="truncate">{bundleInfo.dealSummary}</span>
               </div>
             )}
           </div>

--- a/apps/web/hooks/use-bundle-eligibility.ts
+++ b/apps/web/hooks/use-bundle-eligibility.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "@mindpoint/backend/api";
+import { useMemo } from "react";
+import { showRupees } from "@/lib/utils";
+
+export type BundleEligibility = {
+  campaignName: string;
+  flatFee: number;
+  requiredCourseCountMin: number;
+  requiredCourseCountMax: number;
+  /** Human-readable summary, e.g. "3 courses for ₹7,000" */
+  dealSummary: string;
+};
+
+/**
+ * Returns bundle deal information for a given course ID if it belongs to any
+ * active bundle campaign.  Returns the highest-priority matching campaign.
+ *
+ * The underlying Convex query is cached — multiple cards on the same page
+ * share a single subscription.
+ */
+export function useBundleEligibility(
+  courseId: string,
+): BundleEligibility | null {
+  const campaigns = useQuery(
+    api.bundleCampaigns.listAllActiveBundleCampaigns,
+    {},
+  );
+
+  return useMemo(() => {
+    if (!campaigns || campaigns.length === 0) return null;
+
+    // Campaigns are returned sorted by priority desc from the query.
+    // Find the first (highest priority) campaign that includes this course.
+    const match = campaigns.find((c) =>
+      c.eligibleCourseIds.some((id) => String(id) === String(courseId)),
+    );
+
+    if (!match) return null;
+
+    const { requiredCourseCountMin: min, requiredCourseCountMax: max } = match;
+    const countLabel =
+      min === max ? `${min}` : `${min}\u2013${max}`;
+
+    return {
+      campaignName: match.name,
+      flatFee: match.flatFee,
+      requiredCourseCountMin: min,
+      requiredCourseCountMax: max,
+      dealSummary: `${countLabel} courses for ${showRupees(match.flatFee)}`,
+    };
+  }, [campaigns, courseId]);
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -28,6 +28,7 @@ import type * as adminUsers from "../adminUsers.js";
 import type * as adminUtils from "../adminUtils.js";
 import type * as bundleCampaigns from "../bundleCampaigns.js";
 import type * as courses from "../courses.js";
+import type * as crons from "../crons.js";
 import type * as emailActions from "../emailActions.js";
 import type * as emailActionsWithRateLimit from "../emailActionsWithRateLimit.js";
 import type * as googleSheets from "../googleSheets.js";
@@ -63,6 +64,7 @@ declare const fullApi: ApiFromModules<{
   adminUtils: typeof adminUtils;
   bundleCampaigns: typeof bundleCampaigns;
   courses: typeof courses;
+  crons: typeof crons;
   emailActions: typeof emailActions;
   emailActionsWithRateLimit: typeof emailActionsWithRateLimit;
   googleSheets: typeof googleSheets;

--- a/convex/bundleCampaigns.ts
+++ b/convex/bundleCampaigns.ts
@@ -30,6 +30,36 @@ function isBundleCampaignActive(campaign: {
   return true;
 }
 
+/**
+ * Returns all active (enabled, not archived, within date window) bundle campaigns.
+ * Used by course listing pages to show bundle-eligibility badges on cards.
+ */
+export const listAllActiveBundleCampaigns = query({
+  args: {},
+  handler: async (ctx) => {
+    const campaigns = await ctx.db
+      .query("bundleCampaigns")
+      .withIndex("by_enabled_isArchived_priority", (q) =>
+        q.eq("enabled", true).eq("isArchived", false),
+      )
+      .order("desc")
+      .take(500);
+
+    return campaigns
+      .filter((campaign) => isBundleCampaignActive(campaign))
+      .map((campaign) => ({
+        _id: campaign._id,
+        name: campaign.name,
+        description: campaign.description,
+        flatFee: campaign.flatFee,
+        requiredCourseCountMin: campaign.requiredCourseCountMin,
+        requiredCourseCountMax: campaign.requiredCourseCountMax,
+        eligibleCourseIds: campaign.eligibleCourseIds,
+        priority: campaign.priority,
+      }));
+  },
+});
+
 export const listActiveBundleCampaignsForCourses = query({
   args: {
     courseIds: v.array(v.id("courses")),

--- a/convex/bundleCampaigns.ts
+++ b/convex/bundleCampaigns.ts
@@ -1,5 +1,8 @@
 import { v } from "convex/values";
-import { query } from "./_generated/server";
+import { query, internalMutation } from "./_generated/server";
+
+/** Reasonable upper bound for active campaigns. */
+const MAX_ACTIVE_CAMPAIGNS = 50;
 
 function isBundleCampaignActive(campaign: {
   enabled: boolean;
@@ -43,7 +46,13 @@ export const listAllActiveBundleCampaigns = query({
         q.eq("enabled", true).eq("isArchived", false),
       )
       .order("desc")
-      .take(500);
+      .take(MAX_ACTIVE_CAMPAIGNS);
+
+    if (campaigns.length === MAX_ACTIVE_CAMPAIGNS) {
+      console.warn(
+        `[bundleCampaigns] Hit ${MAX_ACTIVE_CAMPAIGNS} campaign cap — some may be missing from badge display`,
+      );
+    }
 
     return campaigns
       .filter((campaign) => isBundleCampaignActive(campaign))
@@ -79,7 +88,13 @@ export const listActiveBundleCampaignsForCourses = query({
         q.eq("enabled", true).eq("isArchived", false),
       )
       .order("desc")
-      .take(500);
+      .take(MAX_ACTIVE_CAMPAIGNS);
+
+    if (campaigns.length === MAX_ACTIVE_CAMPAIGNS) {
+      console.warn(
+        `[bundleCampaigns] Hit ${MAX_ACTIVE_CAMPAIGNS} campaign cap in listActiveBundleCampaignsForCourses`,
+      );
+    }
 
     return campaigns
       .filter((campaign) => isBundleCampaignActive(campaign))
@@ -103,5 +118,44 @@ export const listActiveBundleCampaignsForCourses = query({
         startDate: campaign.startDate,
         endDate: campaign.endDate,
       }));
+  },
+});
+
+/**
+ * Disables bundle campaigns whose endDate has passed.
+ * Called by the cron in convex/crons.ts to ensure Convex subscriptions
+ * re-evaluate when a campaign expires (document change triggers update).
+ */
+export const disableExpiredCampaigns = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const campaigns = await ctx.db
+      .query("bundleCampaigns")
+      .withIndex("by_enabled_isArchived_priority", (q) =>
+        q.eq("enabled", true).eq("isArchived", false),
+      )
+      .collect();
+
+    const now = Date.now();
+    let disabled = 0;
+
+    for (const campaign of campaigns) {
+      if (!campaign.endDate) continue;
+      const end = new Date(campaign.endDate).getTime();
+      if (Number.isNaN(end) || now <= end) continue;
+
+      await ctx.db.patch(campaign._id, {
+        enabled: false,
+        updatedAt: now,
+        updatedByAdminId: "system:cron",
+      });
+      disabled += 1;
+    }
+
+    if (disabled > 0) {
+      console.log(
+        `[bundleCampaigns] Cron disabled ${disabled} expired campaign(s)`,
+      );
+    }
   },
 });

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,17 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+// Disable expired bundle campaigns every 10 minutes.
+// This ensures Convex subscriptions re-evaluate when a campaign's endDate
+// passes, because the document change (enabled → false) triggers updates
+// for all clients subscribed to active-campaign queries.
+crons.interval(
+  "disable expired bundle campaigns",
+  { minutes: 10 },
+  internal.bundleCampaigns.disableExpiredCampaigns,
+  {},
+);
+
+export default crons;


### PR DESCRIPTION
## Summary
- Added bundle eligibility badges and deal summaries across course listing cards, course-type pages, and the cart.
- Added a shared `useBundleEligibility` hook backed by a new Convex query for all active bundle campaigns.
- Expanded cart bundle UI to show covered courses, per-item savings, and a collapsible progress section for partially fulfilled campaigns.
- Updated bundle rendering to distinguish applied bundles from bundle-eligible items more clearly.

## Testing
- Not run (not requested).
- Verified the diff for updated course, cart, and Convex bundle campaign paths.
- Confirmed the new query returns only active, enabled, non-archived campaigns sorted by priority.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds bundle eligibility badges and deal summaries to course cards, course-type pages, and the cart, backed by two new Convex queries (`listAllActiveBundleCampaigns`, `listActiveBundleCampaignsForCourses`) and a shared `useBundleEligibility` hook. A cron job is introduced to disable expired campaigns every 10 minutes, ensuring Convex subscriptions re-evaluate when campaign state changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the only remaining finding is a P2 maintenance note about a duplicated active-campaign check.

Prior concerns (remaining=0 display, 500-campaign truncation) are resolved. The implementation is logically correct: progressCampaign guarantees selectedCount < minCount so remaining is always ≥1, and the 50-cap plus warning log replaces the silent 500 truncation. The one new finding (duplicated isBundleCampaignActive with divergent invalid-date handling) is a P2 maintenance concern that does not affect any current user-visible behavior.

convex/bundleCampaigns.ts — local isBundleCampaignActive should be consolidated with the domain package version.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/components/CartClient.tsx | Adds bundle evaluation with BundleProgressSection, per-item bundle badges, and applied-bundle summary in order sidebar; logic is correct and the Math.max(0,...) guard on remaining is in place. |
| convex/bundleCampaigns.ts | Adds two public queries with MAX_ACTIVE_CAMPAIGNS=50 cap and cap-hit warning; introduces a duplicated local isBundleCampaignActive with subtly different invalid-date handling compared to the domain package. |
| apps/web/hooks/use-bundle-eligibility.ts | Clean shared hook that piggybacks on a single Convex subscription and memos per courseId; no issues found. |
| apps/web/components/course-card.tsx | Adds bundle badge and deal summary to both CourseCard and UpcomingCourseCard using the shared hook; logic and rendering are correct. |
| convex/crons.ts | New cron running disableExpiredCampaigns every 10 minutes to trigger Convex subscription updates; setup is correct. |
| apps/web/components/CoursesClient.tsx | Adds bundle badge to CourseGroupCard via useBundleEligibility; hook is always called unconditionally so no hook-rules violation. |
| apps/web/components/CourseTypePage.tsx | Adds bundle badge display on course-type page cards using useBundleEligibility; no issues found. |
| convex/_generated/api.d.ts | Auto-generated types updated to include new bundleCampaigns and crons modules; no manual changes needed. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser as Browser (React)
    participant Hook as useBundleEligibility
    participant Cart as CartClient
    participant Convex as Convex Backend
    participant Cron as Cron (10 min)

    Browser->>Hook: useBundleEligibility(courseId)
    Hook->>Convex: listAllActiveBundleCampaigns {}
    Convex-->>Hook: campaigns[] (filtered, capped at 50)
    Hook-->>Browser: BundleEligibility | null (per card)

    Browser->>Cart: CartClient renders
    Cart->>Convex: listActiveBundleCampaignsForCourses({courseIds})
    Convex-->>Cart: campaigns[] relevant to cart items
    Cart->>Cart: evaluateBundleCampaigns() → appliedBundle | progressCampaign
    Cart-->>Browser: Bundle Applied / Bundle Eligible badges + BundleProgressSection

    Cron->>Convex: disableExpiredCampaigns (internalMutation)
    Convex->>Convex: patch expired campaigns (enabled=false)
    Convex-->>Hook: subscription update triggered
    Convex-->>Cart: subscription update triggered
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `convex/bundleCampaigns.ts`, line 4-31 ([link](https://github.com/ayushj1001/mindpoint/blob/88ca6c7d25264aa420a5b91107134968e698bc2f/convex/bundleCampaigns.ts#L4-L31)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale date filtering — expired campaigns stay visible**

   `isBundleCampaignActive` uses `Date.now()` for end-date checks, but Convex queries only re-execute when the *documents they read* change — not when time passes. Once a client subscribes, an expired campaign whose document has not been modified will continue to appear active indefinitely, causing "Bundle Deal" badges to outlive the campaign and, more critically, pushing an incorrect discounted total through the cart checkout flow.

   The standard mitigation is a Convex cron job (or an in-mutation check) that sets `isArchived = true` on expired campaigns, which does trigger a document change and forces the subscription to re-evaluate.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: convex/bundleCampaigns.ts
   Line: 4-31

   Comment:
   **Stale date filtering — expired campaigns stay visible**

   `isBundleCampaignActive` uses `Date.now()` for end-date checks, but Convex queries only re-execute when the *documents they read* change — not when time passes. Once a client subscribes, an expired campaign whose document has not been modified will continue to appear active indefinitely, causing "Bundle Deal" badges to outlive the campaign and, more critically, pushing an incorrect discounted total through the cart checkout flow.

   The standard mitigation is a Convex cron job (or an in-mutation check) that sets `isArchived = true` on expired campaigns, which does trigger a document change and forces the subscription to re-evaluate.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fbundle-eligibility-ui%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fbundle-eligibility-ui%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FbundleCampaigns.ts%0ALine%3A%204-31%0A%0AComment%3A%0A**Stale%20date%20filtering%20%E2%80%94%20expired%20campaigns%20stay%20visible**%0A%0A%60isBundleCampaignActive%60%20uses%20%60Date.now%28%29%60%20for%20end-date%20checks%2C%20but%20Convex%20queries%20only%20re-execute%20when%20the%20*documents%20they%20read*%20change%20%E2%80%94%20not%20when%20time%20passes.%20Once%20a%20client%20subscribes%2C%20an%20expired%20campaign%20whose%20document%20has%20not%20been%20modified%20will%20continue%20to%20appear%20active%20indefinitely%2C%20causing%20%22Bundle%20Deal%22%20badges%20to%20outlive%20the%20campaign%20and%2C%20more%20critically%2C%20pushing%20an%20incorrect%20discounted%20total%20through%20the%20cart%20checkout%20flow.%0A%0AThe%20standard%20mitigation%20is%20a%20Convex%20cron%20job%20%28or%20an%20in-mutation%20check%29%20that%20sets%20%60isArchived%20%3D%20true%60%20on%20expired%20campaigns%2C%20which%20does%20trigger%20a%20document%20change%20and%20forces%20the%20subscription%20to%20re-evaluate.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FbundleCampaigns.ts%0ALine%3A%204-31%0A%0AComment%3A%0A**Stale%20date%20filtering%20%E2%80%94%20expired%20campaigns%20stay%20visible**%0A%0A%60isBundleCampaignActive%60%20uses%20%60Date.now%28%29%60%20for%20end-date%20checks%2C%20but%20Convex%20queries%20only%20re-execute%20when%20the%20*documents%20they%20read*%20change%20%E2%80%94%20not%20when%20time%20passes.%20Once%20a%20client%20subscribes%2C%20an%20expired%20campaign%20whose%20document%20has%20not%20been%20modified%20will%20continue%20to%20appear%20active%20indefinitely%2C%20causing%20%22Bundle%20Deal%22%20badges%20to%20outlive%20the%20campaign%20and%2C%20more%20critically%2C%20pushing%20an%20incorrect%20discounted%20total%20through%20the%20cart%20checkout%20flow.%0A%0AThe%20standard%20mitigation%20is%20a%20Convex%20cron%20job%20%28or%20an%20in-mutation%20check%29%20that%20sets%20%60isArchived%20%3D%20true%60%20on%20expired%20campaigns%2C%20which%20does%20trigger%20a%20document%20change%20and%20forces%20the%20subscription%20to%20re-evaluate.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FbundleCampaigns.ts%0ALine%3A%204-31%0A%0AComment%3A%0A**Stale%20date%20filtering%20%E2%80%94%20expired%20campaigns%20stay%20visible**%0A%0A%60isBundleCampaignActive%60%20uses%20%60Date.now%28%29%60%20for%20end-date%20checks%2C%20but%20Convex%20queries%20only%20re-execute%20when%20the%20*documents%20they%20read*%20change%20%E2%80%94%20not%20when%20time%20passes.%20Once%20a%20client%20subscribes%2C%20an%20expired%20campaign%20whose%20document%20has%20not%20been%20modified%20will%20continue%20to%20appear%20active%20indefinitely%2C%20causing%20%22Bundle%20Deal%22%20badges%20to%20outlive%20the%20campaign%20and%2C%20more%20critically%2C%20pushing%20an%20incorrect%20discounted%20total%20through%20the%20cart%20checkout%20flow.%0A%0AThe%20standard%20mitigation%20is%20a%20Convex%20cron%20job%20%28or%20an%20in-mutation%20check%29%20that%20sets%20%60isArchived%20%3D%20true%60%20on%20expired%20campaigns%2C%20which%20does%20trigger%20a%20document%20change%20and%20forces%20the%20subscription%20to%20re-evaluate.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fbundle-eligibility-ui%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fbundle-eligibility-ui%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aconvex%2FbundleCampaigns.ts%3A7-33%0A**Duplicated%20active-campaign%20check%20diverges%20from%20domain%20version**%0A%0A%60convex%2FbundleCampaigns.ts%60%20reimplements%20%60isBundleCampaignActive%60%20locally%20instead%20of%20importing%20the%20identical%20function%20already%20exported%20from%20%60packages%2Fdomain%2Fsrc%2Fbundles.ts%60.%20The%20two%20implementations%20differ%20on%20invalid%20date%20strings%3A%20the%20local%20version%20returns%20%60false%60%20%28campaign%20inactive%29%20when%20%60startDate%60%2F%60endDate%60%20is%20unparseable%2C%20while%20the%20domain%20version's%20%60toTimestamp%60%20helper%20returns%20%60null%60%20and%20silently%20ignores%20the%20constraint%20%28campaign%20may%20still%20be%20active%29.%20If%20campaign%20data%20or%20the%20active-check%20logic%20evolves%2C%20the%20two%20copies%20can%20drift%20further%20and%20produce%20inconsistent%20badge%20vs.%20cart%20behavior.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aconvex%2FbundleCampaigns.ts%3A7-33%0A**Duplicated%20active-campaign%20check%20diverges%20from%20domain%20version**%0A%0A%60convex%2FbundleCampaigns.ts%60%20reimplements%20%60isBundleCampaignActive%60%20locally%20instead%20of%20importing%20the%20identical%20function%20already%20exported%20from%20%60packages%2Fdomain%2Fsrc%2Fbundles.ts%60.%20The%20two%20implementations%20differ%20on%20invalid%20date%20strings%3A%20the%20local%20version%20returns%20%60false%60%20%28campaign%20inactive%29%20when%20%60startDate%60%2F%60endDate%60%20is%20unparseable%2C%20while%20the%20domain%20version's%20%60toTimestamp%60%20helper%20returns%20%60null%60%20and%20silently%20ignores%20the%20constraint%20%28campaign%20may%20still%20be%20active%29.%20If%20campaign%20data%20or%20the%20active-check%20logic%20evolves%2C%20the%20two%20copies%20can%20drift%20further%20and%20produce%20inconsistent%20badge%20vs.%20cart%20behavior.%0A%0A&repo=ayushj1001%2Fmindpoint"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aconvex%2FbundleCampaigns.ts%3A7-33%0A**Duplicated%20active-campaign%20check%20diverges%20from%20domain%20version**%0A%0A%60convex%2FbundleCampaigns.ts%60%20reimplements%20%60isBundleCampaignActive%60%20locally%20instead%20of%20importing%20the%20identical%20function%20already%20exported%20from%20%60packages%2Fdomain%2Fsrc%2Fbundles.ts%60.%20The%20two%20implementations%20differ%20on%20invalid%20date%20strings%3A%20the%20local%20version%20returns%20%60false%60%20%28campaign%20inactive%29%20when%20%60startDate%60%2F%60endDate%60%20is%20unparseable%2C%20while%20the%20domain%20version's%20%60toTimestamp%60%20helper%20returns%20%60null%60%20and%20silently%20ignores%20the%20constraint%20%28campaign%20may%20still%20be%20active%29.%20If%20campaign%20data%20or%20the%20active-check%20logic%20evolves%2C%20the%20two%20copies%20can%20drift%20further%20and%20produce%20inconsistent%20badge%20vs.%20cart%20behavior.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: convex/bundleCampaigns.ts
Line: 7-33

Comment:
**Duplicated active-campaign check diverges from domain version**

`convex/bundleCampaigns.ts` reimplements `isBundleCampaignActive` locally instead of importing the identical function already exported from `packages/domain/src/bundles.ts`. The two implementations differ on invalid date strings: the local version returns `false` (campaign inactive) when `startDate`/`endDate` is unparseable, while the domain version's `toTimestamp` helper returns `null` and silently ignores the constraint (campaign may still be active). If campaign data or the active-check logic evolves, the two copies can drift further and produce inconsistent badge vs. cart behavior.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Cap active bundle campaign fetches and e..."](https://github.com/ayushj1001/mindpoint/commit/232d81b4ae72018fcaa5b293d78100205e5f7e7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28282308)</sub>

<!-- /greptile_comment -->