### PR TITLE
chore: gitignore local .agents skill installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@
 .DS_Store
 *.pem
 
+# Local agent skills (e.g. agentskill.sh /learn installs)
+.agents/
+
 # debug
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `.agents/` to `.gitignore` so local agentskill.sh `/learn` installs stay out of version control.

**Why:** Skill installs are per-machine tooling, not part of the application. Ignoring this directory prevents accidental commits and keeps `git status` clean after using the CLI.

**Note:** `package-lock.json` had incidental edits from `npx`; those were reverted so this PR stays scoped to the ignore rule only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d156621-462b-4392-acb6-edfb7f3a1af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d156621-462b-4392-acb6-edfb7f3a1af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

