### PR TITLE
chore: sync package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,14 +101,14 @@
         "expo-document-picker": "^55.0.9",
         "expo-font": "~55.0.4",
         "expo-image": "^55.0.6",
-        "expo-linear-gradient": "^55.0.13",
+        "expo-linear-gradient": "~55.0.13",
         "expo-linking": "~55.0.7",
         "expo-router": "~55.0.5",
         "expo-secure-store": "~55.0.8",
         "expo-splash-screen": "~55.0.10",
         "expo-status-bar": "~55.0.4",
         "expo-symbols": "~55.0.5",
-        "expo-video": "^55.0.15",
+        "expo-video": "~55.0.15",
         "expo-web-browser": "~55.0.9",
         "lucide-react-native": "^0.577.0",
         "nativewind": "^4.2.3",
@@ -4553,9 +4553,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4571,9 +4568,6 @@
       "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4591,9 +4585,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4609,9 +4600,6 @@
       "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Syncs `package-lock.json` after local npm resolution: tilde ranges for two Expo packages and updated optional dependency metadata (libc entries removed from optional packages).

No application code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51fdc820-fa41-4771-9d2b-8bf68cb4b24f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51fdc820-fa41-4771-9d2b-8bf68cb4b24f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

