### PR TITLE
Extract reusable course image carousel

### DIFF
--- a/apps/web/components/CourseTypePage.tsx
+++ b/apps/web/components/CourseTypePage.tsx
@@ -12,13 +12,6 @@ import {
   CardTitle,
 } from "../components/ui/card";
 import { Badge } from "../components/ui/badge";
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
-} from "../components/ui/carousel";
 import { Plus, BookOpen, Layers } from "lucide-react";
 import { showRupees, getOfferDetails, getCoursePrice } from "@/lib/utils";
 import { useBundleEligibility } from "@/hooks/use-bundle-eligibility";
@@ -42,7 +35,6 @@ type TherapyCourse = CourseLike & {
 type InternshipCourse = CourseLike & {
   duration?: string;
 };
-import Image from "next/image";
 import {
   Select,
   SelectContent,
@@ -52,58 +44,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "./ui/select";
-
-export const CourseImageCarousel = ({ imageUrls }: { imageUrls: string[] }) => {
-  if (!imageUrls || imageUrls.length === 0) {
-    return (
-      <div className="bg-muted relative flex h-56 items-center justify-center rounded-t-2xl sm:h-72">
-        <BookOpen className="text-muted-foreground h-12 w-12" />
-      </div>
-    );
-  }
-
-  if (imageUrls.length === 1) {
-    return (
-      <div className="bg-muted relative flex h-56 items-center justify-center overflow-hidden rounded-t-2xl sm:h-72">
-        <Image
-          src={
-            imageUrls[0] ??
-            "https://blocks.astratic.com/img/general-img-landscape.png"
-          }
-          alt="Course image"
-          className="max-h-full max-w-full object-contain"
-          width={400}
-          height={600}
-        />
-      </div>
-    );
-  }
-
-  return (
-    <div className="bg-muted relative h-56 overflow-hidden rounded-t-2xl sm:h-72">
-      <Carousel className="h-full w-full">
-        <CarouselContent>
-          {imageUrls.map((imageUrl, index) => (
-            <CarouselItem
-              key={index}
-              className="flex h-56 items-center justify-center sm:h-72"
-            >
-              <Image
-                src={imageUrl || ""}
-                alt={`Course image ${index + 1}`}
-                className="max-h-full max-w-full object-contain"
-                width={400}
-                height={600}
-              />
-            </CarouselItem>
-          ))}
-        </CarouselContent>
-        <CarouselPrevious className="absolute top-1/2 left-2 h-8 w-8 -translate-y-1/2 transform rounded-full bg-black/50 text-white hover:bg-black/70" />
-        <CarouselNext className="absolute top-1/2 right-2 h-8 w-8 -translate-y-1/2 transform rounded-full bg-black/50 text-white hover:bg-black/70" />
-      </Carousel>
-    </div>
-  );
-};
+import { CourseImageCarousel } from "@/components/course-image-carousel";
 
 // Prefer explicit fields: `sessions` (number) or fallback to `duration` (string)
 const extractVariantLabel = (course: CourseLike): string | null => {
@@ -309,7 +250,7 @@ const CourseGroupCard = ({
 
   return (
     <Card
-      className="@container group relative h-full cursor-pointer overflow-hidden rounded-[1.35rem] border border-lavender-200 bg-secondary/50 shadow-[0_14px_35px_-24px_rgba(124,111,155,0.85)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_22px_45px_-22px_rgba(124,111,155,0.95)]"
+      className="group border-lavender-200 bg-secondary/50 @container relative h-full cursor-pointer overflow-hidden rounded-[1.35rem] border shadow-[0_14px_35px_-24px_rgba(124,111,155,0.85)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_22px_45px_-22px_rgba(124,111,155,0.95)]"
       onClick={handleCardClick}
     >
       <CourseImageCarousel imageUrls={selectedCourse.imageUrls || []} />
@@ -323,7 +264,9 @@ const CourseGroupCard = ({
                 className="max-w-full truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
               >
                 <span className="sm:hidden">Special Offer</span>
-                <span className="hidden sm:inline">{offerDetails.offerName}</span>
+                <span className="hidden sm:inline">
+                  {offerDetails.offerName}
+                </span>
               </Badge>
             )}
             {bundleInfo && (
@@ -510,11 +453,10 @@ const CourseGroupCard = ({
             )}
           </div>
           {(() => {
-              const seatsLeft = Math.max(
-                0,
-                (selectedCourse.capacity ?? 0) -
-                  getEnrolledCount(selectedCourse),
-              );
+            const seatsLeft = Math.max(
+              0,
+              (selectedCourse.capacity ?? 0) - getEnrolledCount(selectedCourse),
+            );
             const isOutOfStock =
               (selectedCourse.capacity ?? 0) === 0 || seatsLeft === 0;
 
@@ -704,7 +646,7 @@ const CourseCard = ({
 
   return (
     <Card
-      className="@container group relative h-full cursor-pointer overflow-hidden rounded-[1.35rem] border border-lavender-200 bg-secondary/50 shadow-[0_14px_35px_-24px_rgba(124,111,155,0.85)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_22px_45px_-22px_rgba(124,111,155,0.95)]"
+      className="group border-lavender-200 bg-secondary/50 @container relative h-full cursor-pointer overflow-hidden rounded-[1.35rem] border shadow-[0_14px_35px_-24px_rgba(124,111,155,0.85)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_22px_45px_-22px_rgba(124,111,155,0.95)]"
       onClick={handleCardClick}
     >
       <CourseImageCarousel imageUrls={course.imageUrls || []} />
@@ -718,7 +660,9 @@ const CourseCard = ({
                 className="max-w-full truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
               >
                 <span className="sm:hidden">Special Offer</span>
-                <span className="hidden sm:inline">{offerDetails.offerName}</span>
+                <span className="hidden sm:inline">
+                  {offerDetails.offerName}
+                </span>
               </Badge>
             )}
             {bundleInfo && (
@@ -876,9 +820,7 @@ export default function CourseTypePage({
             <p className="text-primary text-sm font-semibold tracking-wide uppercase">
               {content.tagline}
             </p>
-            <h1 className="calm-catalog-hero-title mt-2">
-              {content.title}
-            </h1>
+            <h1 className="calm-catalog-hero-title mt-2">{content.title}</h1>
             <p className="calm-catalog-hero-lead mt-4 max-w-2xl">
               {content.description}
             </p>
@@ -925,8 +867,8 @@ export default function CourseTypePage({
                   No courses available yet
                 </h3>
                 <p className="text-muted-foreground">
-                  We&apos;re working on adding new{" "}
-                  {content.title.toLowerCase()} courses. Check back soon!
+                  We&apos;re working on adding new {content.title.toLowerCase()}{" "}
+                  courses. Check back soon!
                 </p>
               </div>
             )}

--- a/apps/web/components/course-card.tsx
+++ b/apps/web/components/course-card.tsx
@@ -567,9 +567,7 @@ export function UpcomingCourseCard({
       </div>
 
       {/* Course Image */}
-      <div className="pointer-events-none">
-        <CourseImageCarousel imageUrls={course.imageUrls || []} />
-      </div>
+      <CourseImageCarousel imageUrls={course.imageUrls || []} />
 
       <CardHeader className="pb-3">
         <CardTitle className="group-hover:text-primary line-clamp-2 text-base font-semibold transition-colors group-hover:underline">

--- a/apps/web/components/course-card.tsx
+++ b/apps/web/components/course-card.tsx
@@ -6,7 +6,7 @@ import { Plus, Calendar, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CourseImageCarousel } from "@/components/CourseTypePage";
+import { CourseImageCarousel } from "@/components/course-image-carousel";
 import {
   getCourseScheduleLines,
   shouldShowCourseTiming,
@@ -198,7 +198,7 @@ export function CourseCard({
 
   return (
     <Card
-      className="@container group relative h-full cursor-pointer overflow-hidden rounded-2xl border-none bg-card/50 shadow-[0_8px_24px_-16px_rgba(124,111,155,0.25)] backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_14px_32px_-14px_rgba(124,111,155,0.35)]"
+      className="group bg-card/50 @container relative h-full cursor-pointer overflow-hidden rounded-2xl border-none shadow-[0_8px_24px_-16px_rgba(124,111,155,0.25)] backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_14px_32px_-14px_rgba(124,111,155,0.35)]"
       onClick={handleCardClick}
     >
       {/* Course Image */}
@@ -213,7 +213,9 @@ export function CourseCard({
                 className="max-w-full truncate bg-white/95 text-[11px] font-semibold whitespace-nowrap text-neutral-900 shadow-sm"
               >
                 <span className="sm:hidden">Special Offer</span>
-                <span className="hidden sm:inline">{offerDetails.offerName}</span>
+                <span className="hidden sm:inline">
+                  {offerDetails.offerName}
+                </span>
               </Badge>
             )}
             {bundleInfo && (
@@ -507,7 +509,7 @@ export function UpcomingCourseCard({
 
   return (
     <Card
-      className="@container group relative h-full cursor-pointer overflow-hidden rounded-2xl border-none bg-card/50 shadow-[0_8px_24px_-16px_rgba(124,111,155,0.25)] backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_14px_32px_-14px_rgba(124,111,155,0.35)]"
+      className="group bg-card/50 @container relative h-full cursor-pointer overflow-hidden rounded-2xl border-none shadow-[0_8px_24px_-16px_rgba(124,111,155,0.25)] backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_14px_32px_-14px_rgba(124,111,155,0.35)]"
       onClick={handleCardClick}
     >
       <div className="pointer-events-none absolute inset-x-3 top-3 z-20 flex items-start justify-between gap-2">

--- a/apps/web/components/course-image-carousel.tsx
+++ b/apps/web/components/course-image-carousel.tsx
@@ -62,7 +62,10 @@ export function CourseImageCarousel({
         className={cn(styles.frame, styles.placeholder, className)}
         onClick={stopEvent}
       >
-        <BookOpen className="text-muted-foreground h-12 w-12" />
+        <BookOpen
+          className="text-muted-foreground h-12 w-12"
+          aria-hidden="true"
+        />
       </div>
     );
   }

--- a/apps/web/components/course-image-carousel.tsx
+++ b/apps/web/components/course-image-carousel.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import Image from "next/image";
+import { BookOpen } from "lucide-react";
+
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
+import { cn } from "@/lib/utils";
+
+type CourseImageCarouselProps = {
+  imageUrls?: string[];
+  variant?: "card" | "hero";
+  className?: string;
+};
+
+const variantStyles = {
+  card: {
+    frame: "bg-muted relative overflow-hidden rounded-t-2xl",
+    placeholder: "h-56 sm:h-72",
+    viewport: "h-56 sm:h-72",
+    slide: "h-56 sm:h-72",
+    image: "max-h-full max-w-full object-contain",
+    previous:
+      "absolute top-1/2 left-2 h-8 w-8 -translate-y-1/2 rounded-full bg-black/50 text-white hover:bg-black/70",
+    next: "absolute top-1/2 right-2 h-8 w-8 -translate-y-1/2 rounded-full bg-black/50 text-white hover:bg-black/70",
+  },
+  hero: {
+    frame: "relative overflow-hidden rounded-[inherit]",
+    placeholder:
+      "flex aspect-[4/3] items-center justify-center sm:aspect-[5/4]",
+    viewport: "aspect-[4/3] sm:aspect-[5/4]",
+    slide: "aspect-[4/3] sm:aspect-[5/4]",
+    image: "h-full w-full object-contain p-4 sm:p-6",
+    previous:
+      "absolute top-1/2 left-3 h-10 w-10 -translate-y-1/2 rounded-full border-white/40 bg-white/85 text-foreground shadow-lg hover:bg-white",
+    next: "absolute top-1/2 right-3 h-10 w-10 -translate-y-1/2 rounded-full border-white/40 bg-white/85 text-foreground shadow-lg hover:bg-white",
+  },
+} as const;
+
+export function CourseImageCarousel({
+  imageUrls = [],
+  variant = "card",
+  className,
+}: CourseImageCarouselProps) {
+  const styles = variantStyles[variant];
+  const resolvedImageUrls = imageUrls.filter(Boolean);
+
+  const stopEvent = (event: React.SyntheticEvent) => {
+    if (variant === "card") {
+      event.stopPropagation();
+    }
+  };
+
+  if (resolvedImageUrls.length === 0) {
+    return (
+      <div
+        className={cn(styles.frame, styles.placeholder, className)}
+        onClick={stopEvent}
+      >
+        <BookOpen className="text-muted-foreground h-12 w-12" />
+      </div>
+    );
+  }
+
+  if (resolvedImageUrls.length === 1) {
+    return (
+      <div className={cn(styles.frame, className)} onClick={stopEvent}>
+        <div
+          className={cn(
+            "relative flex items-center justify-center",
+            styles.placeholder,
+          )}
+        >
+          <Image
+            src={resolvedImageUrls[0] ?? "/placeholder.svg"}
+            alt="Course image"
+            fill={variant === "hero"}
+            width={variant === "card" ? 400 : undefined}
+            height={variant === "card" ? 600 : undefined}
+            priority
+            sizes={
+              variant === "hero"
+                ? "(max-width: 768px) 100vw, 72vw"
+                : "(max-width: 768px) 100vw, 400px"
+            }
+            className={styles.image}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn(styles.frame, className)} onClick={stopEvent}>
+      <Carousel className="h-full w-full">
+        <CarouselContent className={cn("ml-0", styles.viewport)}>
+          {resolvedImageUrls.map((imageUrl, index) => (
+            <CarouselItem
+              key={`${imageUrl}-${index}`}
+              className={cn("pl-0", styles.slide)}
+            >
+              <div className="relative flex h-full w-full items-center justify-center">
+                <Image
+                  src={imageUrl}
+                  alt={`Course image ${index + 1}`}
+                  fill={variant === "hero"}
+                  width={variant === "card" ? 400 : undefined}
+                  height={variant === "card" ? 600 : undefined}
+                  priority={index === 0}
+                  sizes={
+                    variant === "hero"
+                      ? "(max-width: 768px) 100vw, 72vw"
+                      : "(max-width: 768px) 100vw, 400px"
+                  }
+                  className={styles.image}
+                />
+              </div>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <CarouselPrevious className={styles.previous} />
+        <CarouselNext className={styles.next} />
+      </Carousel>
+    </div>
+  );
+}

--- a/apps/web/components/course-image-carousel.tsx
+++ b/apps/web/components/course-image-carousel.tsx
@@ -85,7 +85,7 @@ export function CourseImageCarousel({
             fill={variant === "hero"}
             width={variant === "card" ? 400 : undefined}
             height={variant === "card" ? 600 : undefined}
-            priority
+            priority={variant === "hero"}
             sizes={
               variant === "hero"
                 ? "(max-width: 768px) 100vw, 72vw"

--- a/apps/web/components/course/course-hero.tsx
+++ b/apps/web/components/course/course-hero.tsx
@@ -1,6 +1,4 @@
 "use client";
-
-import Image from "next/image";
 import Link from "next/link";
 import { useQuery } from "convex/react";
 import { Calendar, Clock, Award, Users, Star, BookOpen } from "lucide-react";
@@ -9,6 +7,7 @@ import type { PublicCourse } from "@mindpoint/backend";
 
 import { Button } from "@/components/ui/button";
 import { ScrollReveal } from "@/components/ScrollReveal";
+import { CourseImageCarousel } from "@/components/course-image-carousel";
 import { defaultEmotionalHooks } from "@/lib/course-content-data";
 import { formatCourseTimeRange } from "@/lib/course-schedule";
 import { getEnrolledCount } from "@/lib/course-enrollment";
@@ -224,7 +223,6 @@ export default function CourseHero({
   );
   const isSoldOut = (course.capacity ?? 0) === 0 || seatsLeft === 0;
 
-  const poster = course.imageUrls?.[0] ?? null;
   const tintClass = tintClassFor(course.type);
 
   const metaChips: { icon: React.ReactNode; label: string }[] = [];
@@ -254,7 +252,10 @@ export default function CourseHero({
   }
 
   if (!isWorksheet) {
-    metaChips.push({ icon: <Award />, label: "Live Classes + On-Demand Recordings + Official Certificate" });
+    metaChips.push({
+      icon: <Award />,
+      label: "Live Classes + On-Demand Recordings + Official Certificate",
+    });
   }
 
   if (seatsLeft > 0 && seatsLeft <= 8 && !isPreRecorded && !isWorksheet) {
@@ -274,7 +275,7 @@ export default function CourseHero({
           >
             <Link
               href="/courses"
-              className="transition-colors hover:text-primary"
+              className="hover:text-primary transition-colors"
             >
               Courses
             </Link>
@@ -286,15 +287,10 @@ export default function CourseHero({
 
           <div className="calm-hero-stage">
             <div className={`calm-hero-art ${tintClass}`}>
-              {poster ? (
-                <Image
-                  src={poster}
-                  alt={`${course.name} poster`}
-                  width={800}
-                  height={600}
-                  priority
-                  sizes="(min-width: 768px) 72vw, 100vw"
-                  className="h-auto w-full"
+              {course.imageUrls?.length ? (
+                <CourseImageCarousel
+                  imageUrls={course.imageUrls}
+                  variant="hero"
                 />
               ) : (
                 <BookOpen
@@ -311,7 +307,7 @@ export default function CourseHero({
                 {prettyCourseType(course.type)}
               </p>
 
-              <h1 className="calm-hero-title mt-4 text-foreground">
+              <h1 className="calm-hero-title text-foreground mt-4">
                 {course.name}
               </h1>
 
@@ -343,8 +339,8 @@ export default function CourseHero({
               )}
 
               {batches.length > 0 && onBatchSelect && (
-                <div className="mt-8 border-t border-foreground/10 pt-6">
-                  <p className="mb-4 text-[0.95rem] font-medium text-foreground/70">
+                <div className="border-foreground/10 mt-8 border-t pt-6">
+                  <p className="text-foreground/70 mb-4 text-[0.95rem] font-medium">
                     Choose a batch
                   </p>
                   <div
@@ -387,9 +383,7 @@ export default function CourseHero({
                           disabled={disabled}
                           data-selected={selected ? "true" : "false"}
                           data-disabled={disabled ? "true" : "false"}
-                          onClick={() =>
-                            !disabled && onBatchSelect(batch._id)
-                          }
+                          onClick={() => !disabled && onBatchSelect(batch._id)}
                           className="calm-batch-chip"
                         >
                           <span className="min-w-0">
@@ -409,7 +403,7 @@ export default function CourseHero({
                             {batch.isSelectable &&
                               seatsRemaining > 0 &&
                               seatsRemaining <= 8 && (
-                                <span className="calm-batch-sub mt-0.5 block text-primary/70">
+                                <span className="calm-batch-sub text-primary/70 mt-0.5 block">
                                   {seatsRemaining} seat
                                   {seatsRemaining === 1 ? "" : "s"} left
                                 </span>
@@ -427,29 +421,31 @@ export default function CourseHero({
                 </div>
               )}
 
-              {!isWorksheet && course.type !== "therapy" && course.type !== "supervised" && (
-                <div className="mt-8 space-y-4 border-t border-foreground/10 pt-6">
-                  <div className="calm-hero-price-row">
-                    <span className="calm-price-big">{formatINR(price)}</span>
-                    {offerDetails?.hasDiscount && (
-                      <span className="calm-price-strike">
-                        {formatINR(offerDetails.originalPrice)}
-                      </span>
-                    )}
+              {!isWorksheet &&
+                course.type !== "therapy" &&
+                course.type !== "supervised" && (
+                  <div className="border-foreground/10 mt-8 space-y-4 border-t pt-6">
+                    <div className="calm-hero-price-row">
+                      <span className="calm-price-big">{formatINR(price)}</span>
+                      {offerDetails?.hasDiscount && (
+                        <span className="calm-price-strike">
+                          {formatINR(offerDetails.originalPrice)}
+                        </span>
+                      )}
+                    </div>
+                    <Button
+                      size="lg"
+                      disabled={isSoldOut}
+                      onClick={onAddToCart}
+                      className="h-11 w-full text-base font-medium"
+                    >
+                      {isSoldOut ? "Currently full" : "Add to cart"}
+                    </Button>
                   </div>
-                  <Button
-                    size="lg"
-                    disabled={isSoldOut}
-                    onClick={onAddToCart}
-                    className="h-11 w-full text-base font-medium"
-                  >
-                    {isSoldOut ? "Currently full" : "Add to cart"}
-                  </Button>
-                </div>
-              )}
+                )}
 
               {(course.type === "therapy" || course.type === "supervised") && (
-                <div className="mt-8 border-t border-foreground/10 pt-6">
+                <div className="border-foreground/10 mt-8 border-t pt-6">
                   <Button
                     asChild
                     size="lg"

--- a/apps/web/components/course/course-hero.tsx
+++ b/apps/web/components/course/course-hero.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useQuery } from "convex/react";
-import { Calendar, Clock, Award, Users, Star, BookOpen } from "lucide-react";
+import { Calendar, Clock, Award, Users, Star } from "lucide-react";
 import { api } from "@mindpoint/backend/api";
 import type { PublicCourse } from "@mindpoint/backend";
 
@@ -287,19 +287,10 @@ export default function CourseHero({
 
           <div className="calm-hero-stage">
             <div className={`calm-hero-art ${tintClass}`}>
-              {course.imageUrls?.length ? (
-                <CourseImageCarousel
-                  imageUrls={course.imageUrls}
-                  variant="hero"
-                />
-              ) : (
-                <BookOpen
-                  className="text-foreground/40"
-                  strokeWidth={1}
-                  aria-hidden="true"
-                  style={{ width: "4rem", height: "4rem" }}
-                />
-              )}
+              <CourseImageCarousel
+                imageUrls={course.imageUrls ?? []}
+                variant="hero"
+              />
             </div>
 
             <div className="calm-hero-copy">


### PR DESCRIPTION
## Summary
- Extracted the course image carousel into a shared `CourseImageCarousel` component for reuse across course cards and the course hero.
- Added support for `card` and `hero` variants so the same carousel can render appropriately in different layouts.
- Updated course card and hero components to use the shared carousel and cleaned up a few related className/order formatting changes.

## Testing
- Not run (not requested).
- Verified the refactor by reviewing the component split and updated imports/usages in the diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced course image carousel with improved handling for single and multiple images.
  * Added placeholder display when course images are unavailable.

* **Style**
  * Updated card styling for improved visual consistency.
  * Adjusted course hero layout and spacing for better presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `CourseImageCarousel` component with `card` and `hero` variants, replacing duplicated inline image rendering across course cards and the course hero. The refactor correctly centralises the empty-state fallback, `stopPropagation` logic for card clicks, and variant-specific sizing/styling. All remaining findings are P2.

<h3>Confidence Score: 5/5</h3>

Safe to merge; refactor is clean with no logic regressions and only minor style issues remaining.

All findings are P2 (dead fallback code, misleading intrinsic dimensions on card multi-image images). No broken behavior, incorrect data flow, or render errors were identified.

apps/web/components/course-image-carousel.tsx — minor dead code and dimension inconsistency worth cleaning up in a follow-up.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/components/course-image-carousel.tsx | New shared component with card/hero variants; stopEvent propagation logic is correct; minor dead-code fallback and portrait-vs-landscape dimension mismatch in card multi-image case. |
| apps/web/components/course-card.tsx | Replaced inline image blocks with CourseImageCarousel; badge overlay z-ordering and pointer-events handling are correct in both CourseCard and UpcomingCourseCard. |
| apps/web/components/course/course-hero.tsx | Replaced inline BookOpen guard with direct CourseImageCarousel call (variant="hero"); empty-state now handled consistently inside the shared component. |
| apps/web/components/CourseTypePage.tsx | Both local card components (CourseCard, CourseGroupCard) now use CourseImageCarousel; BookOpen retained only for the "no courses" empty state which is unrelated to the carousel. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CIC["CourseImageCarousel\n(imageUrls, variant, className)"]
    CIC --> FILTER["filter(Boolean) → resolvedImageUrls"]
    FILTER --> EMPTY{length === 0}
    EMPTY -- yes --> PLACEHOLDER["BookOpen placeholder\n(stopEvent on click for card)"]
    EMPTY -- no --> SINGLE{length === 1}
    SINGLE -- yes --> IMG1["Single Image\nfill=true (hero)\nwidth/height (card)"]
    SINGLE -- no --> CAROUSEL["Carousel\nCarouselContent + CarouselItems\nCarouselPrevious + CarouselNext"]
    CAROUSEL --> STOP["stopEvent wraps outer div\n(stopPropagation for card only)"]
    IMG1 --> STOP2["stopEvent wraps outer div\n(stopPropagation for card only)"]
    CARD["CourseCard / UpcomingCourseCard\n(course-card.tsx)"] --> CIC
    COURSETYPE["CourseCard / CourseGroupCard\n(CourseTypePage.tsx)"] --> CIC
    HERO["CourseHero\n(course-hero.tsx)"] --> CIC
    CIC -- "variant=card (default)" --> VS_CARD["variantStyles.card\nfixed h-56/h-72 slides\nblack nav buttons"]
    CIC -- "variant=hero" --> VS_HERO["variantStyles.hero\naspect-4/3 slides\nwhite nav buttons"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/components/course-card.tsx`, line 569-572 ([link](https://github.com/ayushj1001/mindpoint/blob/c8fed0045c51c5a20c1f4dacc1e51bfc445a068f/apps/web/components/course-card.tsx#L569-L572)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Carousel navigation disabled by `pointer-events-none` wrapper**

   The `pointer-events-none` div suppresses all mouse and touch events on the entire carousel, including the `CarouselPrevious` and `CarouselNext` buttons. For any upcoming course with more than one image, users will see the navigation arrows but be unable to click them — every click passes straight through to the card's `handleCardClick`.

   The regular `CourseCard` (and both cards in `CourseTypePage.tsx`) omit this wrapper and instead rely on the `stopPropagation` that `CourseImageCarousel` already handles internally when `variant="card"`. The same approach works here without needing the outer wrapper:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/components/course-card.tsx
   Line: 569-572

   Comment:
   **Carousel navigation disabled by `pointer-events-none` wrapper**

   The `pointer-events-none` div suppresses all mouse and touch events on the entire carousel, including the `CarouselPrevious` and `CarouselNext` buttons. For any upcoming course with more than one image, users will see the navigation arrows but be unable to click them — every click passes straight through to the card's `handleCardClick`.

   The regular `CourseCard` (and both cards in `CourseTypePage.tsx`) omit this wrapper and instead rely on the `stopPropagation` that `CourseImageCarousel` already handles internally when `variant="card"`. The same approach works here without needing the outer wrapper:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fcourse-image-carousel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fcourse-image-carousel%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fcomponents%2Fcourse-card.tsx%0ALine%3A%20569-572%0A%0AComment%3A%0A**Carousel%20navigation%20disabled%20by%20%60pointer-events-none%60%20wrapper**%0A%0AThe%20%60pointer-events-none%60%20div%20suppresses%20all%20mouse%20and%20touch%20events%20on%20the%20entire%20carousel%2C%20including%20the%20%60CarouselPrevious%60%20and%20%60CarouselNext%60%20buttons.%20For%20any%20upcoming%20course%20with%20more%20than%20one%20image%2C%20users%20will%20see%20the%20navigation%20arrows%20but%20be%20unable%20to%20click%20them%20%E2%80%94%20every%20click%20passes%20straight%20through%20to%20the%20card's%20%60handleCardClick%60.%0A%0AThe%20regular%20%60CourseCard%60%20%28and%20both%20cards%20in%20%60CourseTypePage.tsx%60%29%20omit%20this%20wrapper%20and%20instead%20rely%20on%20the%20%60stopPropagation%60%20that%20%60CourseImageCarousel%60%20already%20handles%20internally%20when%20%60variant%3D%22card%22%60.%20The%20same%20approach%20works%20here%20without%20needing%20the%20outer%20wrapper%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%7B%2F*%20Course%20Image%20*%2F%7D%0A%20%20%20%20%20%20%3CCourseImageCarousel%20imageUrls%3D%7Bcourse.imageUrls%20%7C%7C%20%5B%5D%7D%20%2F%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fcomponents%2Fcourse-card.tsx%0ALine%3A%20569-572%0A%0AComment%3A%0A**Carousel%20navigation%20disabled%20by%20%60pointer-events-none%60%20wrapper**%0A%0AThe%20%60pointer-events-none%60%20div%20suppresses%20all%20mouse%20and%20touch%20events%20on%20the%20entire%20carousel%2C%20including%20the%20%60CarouselPrevious%60%20and%20%60CarouselNext%60%20buttons.%20For%20any%20upcoming%20course%20with%20more%20than%20one%20image%2C%20users%20will%20see%20the%20navigation%20arrows%20but%20be%20unable%20to%20click%20them%20%E2%80%94%20every%20click%20passes%20straight%20through%20to%20the%20card's%20%60handleCardClick%60.%0A%0AThe%20regular%20%60CourseCard%60%20%28and%20both%20cards%20in%20%60CourseTypePage.tsx%60%29%20omit%20this%20wrapper%20and%20instead%20rely%20on%20the%20%60stopPropagation%60%20that%20%60CourseImageCarousel%60%20already%20handles%20internally%20when%20%60variant%3D%22card%22%60.%20The%20same%20approach%20works%20here%20without%20needing%20the%20outer%20wrapper%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%7B%2F*%20Course%20Image%20*%2F%7D%0A%20%20%20%20%20%20%3CCourseImageCarousel%20imageUrls%3D%7Bcourse.imageUrls%20%7C%7C%20%5B%5D%7D%20%2F%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint&pr=75&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fcomponents%2Fcourse-card.tsx%0ALine%3A%20569-572%0A%0AComment%3A%0A**Carousel%20navigation%20disabled%20by%20%60pointer-events-none%60%20wrapper**%0A%0AThe%20%60pointer-events-none%60%20div%20suppresses%20all%20mouse%20and%20touch%20events%20on%20the%20entire%20carousel%2C%20including%20the%20%60CarouselPrevious%60%20and%20%60CarouselNext%60%20buttons.%20For%20any%20upcoming%20course%20with%20more%20than%20one%20image%2C%20users%20will%20see%20the%20navigation%20arrows%20but%20be%20unable%20to%20click%20them%20%E2%80%94%20every%20click%20passes%20straight%20through%20to%20the%20card's%20%60handleCardClick%60.%0A%0AThe%20regular%20%60CourseCard%60%20%28and%20both%20cards%20in%20%60CourseTypePage.tsx%60%29%20omit%20this%20wrapper%20and%20instead%20rely%20on%20the%20%60stopPropagation%60%20that%20%60CourseImageCarousel%60%20already%20handles%20internally%20when%20%60variant%3D%22card%22%60.%20The%20same%20approach%20works%20here%20without%20needing%20the%20outer%20wrapper%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%7B%2F*%20Course%20Image%20*%2F%7D%0A%20%20%20%20%20%20%3CCourseImageCarousel%20imageUrls%3D%7Bcourse.imageUrls%20%7C%7C%20%5B%5D%7D%20%2F%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=75&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

2. `apps/web/components/course/course-hero.tsx`, line 290-302 ([link](https://github.com/ayushj1001/mindpoint/blob/c8fed0045c51c5a20c1f4dacc1e51bfc445a068f/apps/web/components/course/course-hero.tsx#L290-L302)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Duplicate empty-state guard produces inconsistent BookOpen styling**

   `CourseImageCarousel` already renders its own `BookOpen` placeholder when `imageUrls` is empty (line 59–68 of the new component). The guard here means the hero shows a different icon — `style={{ width: "4rem", height: "4rem" }}` with `strokeWidth={1}` — while the carousel's internal fallback would render `h-12 w-12` (3 rem) at default stroke width. Removing the guard and passing the (possibly empty) array directly to the carousel would keep the two render paths in sync:

   ```tsx
   <CourseImageCarousel
     imageUrls={course.imageUrls ?? []}
     variant="hero"
   />
   ```

   If you need the hero's larger/lighter icon specifically, consider adding those as part of a per-variant placeholder style inside `CourseImageCarousel` instead of branching outside it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/components/course/course-hero.tsx
   Line: 290-302

   Comment:
   **Duplicate empty-state guard produces inconsistent BookOpen styling**

   `CourseImageCarousel` already renders its own `BookOpen` placeholder when `imageUrls` is empty (line 59–68 of the new component). The guard here means the hero shows a different icon — `style={{ width: "4rem", height: "4rem" }}` with `strokeWidth={1}` — while the carousel's internal fallback would render `h-12 w-12` (3 rem) at default stroke width. Removing the guard and passing the (possibly empty) array directly to the carousel would keep the two render paths in sync:

   ```tsx
   <CourseImageCarousel
     imageUrls={course.imageUrls ?? []}
     variant="hero"
   />
   ```

   If you need the hero's larger/lighter icon specifically, consider adding those as part of a per-variant placeholder style inside `CourseImageCarousel` instead of branching outside it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fcourse-image-carousel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fcourse-image-carousel%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fcomponents%2Fcourse%2Fcourse-hero.tsx%0ALine%3A%20290-302%0A%0AComment%3A%0A**Duplicate%20empty-state%20guard%20produces%20inconsistent%20BookOpen%20styling**%0A%0A%60CourseImageCarousel%60%20already%20renders%20its%20own%20%60BookOpen%60%20placeholder%20when%20%60imageUrls%60%20is%20empty%20%28line%2059%E2%80%9368%20of%20the%20new%20component%29.%20The%20guard%20here%20means%20the%20hero%20shows%20a%20different%20icon%20%E2%80%94%20%60style%3D%7B%7B%20width%3A%20%224rem%22%2C%20height%3A%20%224rem%22%20%7D%7D%60%20with%20%60strokeWidth%3D%7B1%7D%60%20%E2%80%94%20while%20the%20carousel's%20internal%20fallback%20would%20render%20%60h-12%20w-12%60%20%283%20rem%29%20at%20default%20stroke%20width.%20Removing%20the%20guard%20and%20passing%20the%20%28possibly%20empty%29%20array%20directly%20to%20the%20carousel%20would%20keep%20the%20two%20render%20paths%20in%20sync%3A%0A%0A%60%60%60tsx%0A%3CCourseImageCarousel%0A%20%20imageUrls%3D%7Bcourse.imageUrls%20%3F%3F%20%5B%5D%7D%0A%20%20variant%3D%22hero%22%0A%2F%3E%0A%60%60%60%0A%0AIf%20you%20need%20the%20hero's%20larger%2Flighter%20icon%20specifically%2C%20consider%20adding%20those%20as%20part%20of%20a%20per-variant%20placeholder%20style%20inside%20%60CourseImageCarousel%60%20instead%20of%20branching%20outside%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fcomponents%2Fcourse%2Fcourse-hero.tsx%0ALine%3A%20290-302%0A%0AComment%3A%0A**Duplicate%20empty-state%20guard%20produces%20inconsistent%20BookOpen%20styling**%0A%0A%60CourseImageCarousel%60%20already%20renders%20its%20own%20%60BookOpen%60%20placeholder%20when%20%60imageUrls%60%20is%20empty%20%28line%2059%E2%80%9368%20of%20the%20new%20component%29.%20The%20guard%20here%20means%20the%20hero%20shows%20a%20different%20icon%20%E2%80%94%20%60style%3D%7B%7B%20width%3A%20%224rem%22%2C%20height%3A%20%224rem%22%20%7D%7D%60%20with%20%60strokeWidth%3D%7B1%7D%60%20%E2%80%94%20while%20the%20carousel's%20internal%20fallback%20would%20render%20%60h-12%20w-12%60%20%283%20rem%29%20at%20default%20stroke%20width.%20Removing%20the%20guard%20and%20passing%20the%20%28possibly%20empty%29%20array%20directly%20to%20the%20carousel%20would%20keep%20the%20two%20render%20paths%20in%20sync%3A%0A%0A%60%60%60tsx%0A%3CCourseImageCarousel%0A%20%20imageUrls%3D%7Bcourse.imageUrls%20%3F%3F%20%5B%5D%7D%0A%20%20variant%3D%22hero%22%0A%2F%3E%0A%60%60%60%0A%0AIf%20you%20need%20the%20hero's%20larger%2Flighter%20icon%20specifically%2C%20consider%20adding%20those%20as%20part%20of%20a%20per-variant%20placeholder%20style%20inside%20%60CourseImageCarousel%60%20instead%20of%20branching%20outside%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint&pr=75&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fcomponents%2Fcourse%2Fcourse-hero.tsx%0ALine%3A%20290-302%0A%0AComment%3A%0A**Duplicate%20empty-state%20guard%20produces%20inconsistent%20BookOpen%20styling**%0A%0A%60CourseImageCarousel%60%20already%20renders%20its%20own%20%60BookOpen%60%20placeholder%20when%20%60imageUrls%60%20is%20empty%20%28line%2059%E2%80%9368%20of%20the%20new%20component%29.%20The%20guard%20here%20means%20the%20hero%20shows%20a%20different%20icon%20%E2%80%94%20%60style%3D%7B%7B%20width%3A%20%224rem%22%2C%20height%3A%20%224rem%22%20%7D%7D%60%20with%20%60strokeWidth%3D%7B1%7D%60%20%E2%80%94%20while%20the%20carousel's%20internal%20fallback%20would%20render%20%60h-12%20w-12%60%20%283%20rem%29%20at%20default%20stroke%20width.%20Removing%20the%20guard%20and%20passing%20the%20%28possibly%20empty%29%20array%20directly%20to%20the%20carousel%20would%20keep%20the%20two%20render%20paths%20in%20sync%3A%0A%0A%60%60%60tsx%0A%3CCourseImageCarousel%0A%20%20imageUrls%3D%7Bcourse.imageUrls%20%3F%3F%20%5B%5D%7D%0A%20%20variant%3D%22hero%22%0A%2F%3E%0A%60%60%60%0A%0AIf%20you%20need%20the%20hero's%20larger%2Flighter%20icon%20specifically%2C%20consider%20adding%20those%20as%20part%20of%20a%20per-variant%20placeholder%20style%20inside%20%60CourseImageCarousel%60%20instead%20of%20branching%20outside%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=75&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fcourse-image-carousel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fcourse-image-carousel%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fcomponents%2Fcourse-image-carousel.tsx%3A83%0A**Unreachable%20fallback%20%60%22%2Fplaceholder.svg%22%60**%0A%0A%60resolvedImageUrls%60%20is%20already%20filtered%20to%20only%20truthy%20strings%20%28line%2051%29%2C%20and%20this%20branch%20is%20entered%20only%20when%20%60resolvedImageUrls.length%20%3D%3D%3D%201%60%2C%20so%20%60resolvedImageUrls%5B0%5D%60%20is%20always%20a%20non-nullish%20string.%20The%20%60%3F%3F%20%22%2Fplaceholder.svg%22%60%20tail%20will%20never%20execute.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20src%3D%7BresolvedImageUrls%5B0%5D!%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fcomponents%2Fcourse-image-carousel.tsx%3A113-116%0A**%60width%60%2F%60height%60%20ignored%20when%20%60fill%60%20is%20true**%0A%0AFor%20the%20hero%20variant%20%28%60fill%3D%7Btrue%7D%60%29%2C%20Next.js%20ignores%20the%20%60width%60%20and%20%60height%60%20props%20and%20they%20are%20passed%20as%20%60undefined%60%2C%20which%20is%20fine.%20For%20the%20card%20variant%20%28%60fill%3D%7Bfalse%7D%60%29%2C%20%60width%3D%7B400%7D%60%20and%20%60height%3D%7B600%7D%60%20set%20a%20portrait%20intrinsic%20ratio%20%284%3A6%29%20inside%20a%20landscape-ish%20fixed-height%20slide%20%28%60h-56%60%2F%60h-72%60%29.%20%60max-h-full%20max-w-full%20object-contain%60%20handles%20the%20visual%20clipping%20correctly%2C%20but%20the%20explicit%20dimensions%20are%20misleading%20%E2%80%94%20a%20portrait%20%60width%3D400%20height%3D600%60%20signals%20one%20layout%20while%20a%20landscape%20container%20enforces%20another.%20Consider%20unifying%20to%20the%20actual%20expected%20intrinsic%20ratio%20or%20using%20%60fill%60%20with%20a%20positioned%20parent%20for%20the%20card%20multi-image%20case%20as%20well%2C%20to%20keep%20both%20branches%20consistent.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fcomponents%2Fcourse-image-carousel.tsx%3A83%0A**Unreachable%20fallback%20%60%22%2Fplaceholder.svg%22%60**%0A%0A%60resolvedImageUrls%60%20is%20already%20filtered%20to%20only%20truthy%20strings%20%28line%2051%29%2C%20and%20this%20branch%20is%20entered%20only%20when%20%60resolvedImageUrls.length%20%3D%3D%3D%201%60%2C%20so%20%60resolvedImageUrls%5B0%5D%60%20is%20always%20a%20non-nullish%20string.%20The%20%60%3F%3F%20%22%2Fplaceholder.svg%22%60%20tail%20will%20never%20execute.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20src%3D%7BresolvedImageUrls%5B0%5D!%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fcomponents%2Fcourse-image-carousel.tsx%3A113-116%0A**%60width%60%2F%60height%60%20ignored%20when%20%60fill%60%20is%20true**%0A%0AFor%20the%20hero%20variant%20%28%60fill%3D%7Btrue%7D%60%29%2C%20Next.js%20ignores%20the%20%60width%60%20and%20%60height%60%20props%20and%20they%20are%20passed%20as%20%60undefined%60%2C%20which%20is%20fine.%20For%20the%20card%20variant%20%28%60fill%3D%7Bfalse%7D%60%29%2C%20%60width%3D%7B400%7D%60%20and%20%60height%3D%7B600%7D%60%20set%20a%20portrait%20intrinsic%20ratio%20%284%3A6%29%20inside%20a%20landscape-ish%20fixed-height%20slide%20%28%60h-56%60%2F%60h-72%60%29.%20%60max-h-full%20max-w-full%20object-contain%60%20handles%20the%20visual%20clipping%20correctly%2C%20but%20the%20explicit%20dimensions%20are%20misleading%20%E2%80%94%20a%20portrait%20%60width%3D400%20height%3D600%60%20signals%20one%20layout%20while%20a%20landscape%20container%20enforces%20another.%20Consider%20unifying%20to%20the%20actual%20expected%20intrinsic%20ratio%20or%20using%20%60fill%60%20with%20a%20positioned%20parent%20for%20the%20card%20multi-image%20case%20as%20well%2C%20to%20keep%20both%20branches%20consistent.%0A%0A&repo=ayushj1001%2Fmindpoint&pr=75&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fcomponents%2Fcourse-image-carousel.tsx%3A83%0A**Unreachable%20fallback%20%60%22%2Fplaceholder.svg%22%60**%0A%0A%60resolvedImageUrls%60%20is%20already%20filtered%20to%20only%20truthy%20strings%20%28line%2051%29%2C%20and%20this%20branch%20is%20entered%20only%20when%20%60resolvedImageUrls.length%20%3D%3D%3D%201%60%2C%20so%20%60resolvedImageUrls%5B0%5D%60%20is%20always%20a%20non-nullish%20string.%20The%20%60%3F%3F%20%22%2Fplaceholder.svg%22%60%20tail%20will%20never%20execute.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20src%3D%7BresolvedImageUrls%5B0%5D!%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fcomponents%2Fcourse-image-carousel.tsx%3A113-116%0A**%60width%60%2F%60height%60%20ignored%20when%20%60fill%60%20is%20true**%0A%0AFor%20the%20hero%20variant%20%28%60fill%3D%7Btrue%7D%60%29%2C%20Next.js%20ignores%20the%20%60width%60%20and%20%60height%60%20props%20and%20they%20are%20passed%20as%20%60undefined%60%2C%20which%20is%20fine.%20For%20the%20card%20variant%20%28%60fill%3D%7Bfalse%7D%60%29%2C%20%60width%3D%7B400%7D%60%20and%20%60height%3D%7B600%7D%60%20set%20a%20portrait%20intrinsic%20ratio%20%284%3A6%29%20inside%20a%20landscape-ish%20fixed-height%20slide%20%28%60h-56%60%2F%60h-72%60%29.%20%60max-h-full%20max-w-full%20object-contain%60%20handles%20the%20visual%20clipping%20correctly%2C%20but%20the%20explicit%20dimensions%20are%20misleading%20%E2%80%94%20a%20portrait%20%60width%3D400%20height%3D600%60%20signals%20one%20layout%20while%20a%20landscape%20container%20enforces%20another.%20Consider%20unifying%20to%20the%20actual%20expected%20intrinsic%20ratio%20or%20using%20%60fill%60%20with%20a%20positioned%20parent%20for%20the%20card%20multi-image%20case%20as%20well%2C%20to%20keep%20both%20branches%20consistent.%0A%0A&pr=75&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/components/course-image-carousel.tsx
Line: 83

Comment:
**Unreachable fallback `"/placeholder.svg"`**

`resolvedImageUrls` is already filtered to only truthy strings (line 51), and this branch is entered only when `resolvedImageUrls.length === 1`, so `resolvedImageUrls[0]` is always a non-nullish string. The `?? "/placeholder.svg"` tail will never execute.

```suggestion
            src={resolvedImageUrls[0]!}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/components/course-image-carousel.tsx
Line: 113-116

Comment:
**`width`/`height` ignored when `fill` is true**

For the hero variant (`fill={true}`), Next.js ignores the `width` and `height` props and they are passed as `undefined`, which is fine. For the card variant (`fill={false}`), `width={400}` and `height={600}` set a portrait intrinsic ratio (4:6) inside a landscape-ish fixed-height slide (`h-56`/`h-72`). `max-h-full max-w-full object-contain` handles the visual clipping correctly, but the explicit dimensions are misleading — a portrait `width=400 height=600` signals one layout while a landscape container enforces another. Consider unifying to the actual expected intrinsic ratio or using `fill` with a positioned parent for the card multi-image case as well, to keep both branches consistent.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Prioritize hero carousel images only"](https://github.com/ayushj1001/mindpoint/commit/918e9f77ffe73f213880cf1adc26bb9ebd8256f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28818106)</sub>

<!-- /greptile_comment -->