### PR TITLE
Add repo agent docs for issue tracking and triage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,17 @@ All required secrets (Clerk, Convex, Razorpay, Resend, etc.) are injected as env
 ### Convex backend
 
 Convex functions live in `/convex/` and are deployed to the cloud. `npx convex dev` syncs local changes to a dev deployment but requires a Convex account login (interactive). For cloud agent work, the Convex backend is already deployed; agents can build/lint/run the Next.js frontend without running `convex dev`.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `AyushJ1001/mindpoint`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Triage uses the default canonical label vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repo uses a single-context domain documentation layout. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,38 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** - read ADRs that touch the area you're about to work in
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```text
+/
+|-- CONTEXT.md
+|-- docs/
+|   `-- adr/
+|       |-- 0001-example-decision.md
+|       `-- 0002-example-decision.md
+|-- apps/
+|-- convex/
+`-- packages/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal - either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) - but worth reopening because..._

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -10,7 +10,7 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
 - **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
-- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], commentCount: .comments}]'` with appropriate `--label` and `--state` filters. Use `gh issue view <number> --json comments --jq '[.comments[].body]'` to fetch comment bodies for a specific issue.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
 - **Close**: `gh issue close <number> --comment "..."`

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,26 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Repository
+
+`AyushJ1001/mindpoint`
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` - `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -2,7 +2,7 @@
 
 The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| Canonical skill role       | Label in our tracker | Meaning                                  |
 | -------------------------- | -------------------- | ---------------------------------------- |
 | `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
 | `needs-info`               | `needs-info`         | Waiting on reporter for more information |


### PR DESCRIPTION
## Summary
- Added repo-facing agent documentation for GitHub issue/PRD workflows, including `gh`-based create/read/list/comment/label/close conventions.
- Added a domain docs guide describing how agents should read `CONTEXT.md` and relevant ADRs before exploring or proposing changes.
- Added a triage label mapping file to translate canonical skill roles into this repo's issue label vocabulary.
- Updated `AGENTS.md` to point agents at the new documentation set.

## Testing
- Not run (documentation-only change).
- Verified the diff only adds/updates markdown guidance files and `AGENTS.md`.
- Confirmed no application code, backend functions, or tests were modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Added comprehensive documentation covering GitHub issue tracker workflows with CLI conventions, standardized triage label definitions, and domain documentation consultation standards.
- Updated AGENTS.md with structured references to these new documentation resources for consistent repository management and development practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three agent-facing documentation files (`issue-tracker.md`, `triage-labels.md`, `domain.md`) under `docs/agents/` and updates `AGENTS.md` to point agents at them. No application code is changed.

- **`issue-tracker.md`** codifies `gh` CLI conventions for creating, reading, listing, commenting on, labelling, and closing GitHub issues; the "List issues" command correctly uses `commentCount` to handle the integer returned by `gh issue list --json comments`, but the "Read an issue" convention incorrectly pairs `--comments` (text output) with `jq` filtering — an agent following this literally will get a JSON parse error.
- **`triage-labels.md`** maps five canonical skill roles to their repo label strings; contains a leftover template line that could mislead agents into treating the file as editable configuration.
- **`domain.md`** instructs agents to read `CONTEXT.md` and relevant ADRs before exploring, with sensible silent-proceed behaviour for missing files.

<h3>Confidence Score: 4/5</h3>

Documentation-only PR; the only defect is a misleading gh CLI convention that will cause jq parse failures for agents following the Read an issue guidance literally.

All changes are markdown docs with no impact on running code. The one concrete defect is in docs/agents/issue-tracker.md: the Read an issue bullet instructs agents to filter with jq against --comments output, which is human-readable text and will cause an immediate JSON parse error at runtime. The fix is a one-line change and the correct --json pattern is already shown in the adjacent List issues bullet.

docs/agents/issue-tracker.md — the Read an issue convention needs the --json flag to make jq filtering work.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/agents/issue-tracker.md | New agent doc for GitHub issue workflows; the "Read an issue" convention claims jq filtering works with --comments (text output), which will cause parse errors for agents that follow it literally. |
| docs/agents/triage-labels.md | New triage label mapping file; contains a stale template instruction ("Edit the right-hand column...") that could confuse agents reading it for operational guidance. |
| docs/agents/domain.md | New domain docs guide; cleanly instructs agents to read CONTEXT.md and ADRs before exploring, with correct silent-proceed behavior for missing files. |
| AGENTS.md | Adds an "Agent skills" section with pointers to the three new docs; no logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent receives task] --> B[Read AGENTS.md]
    B --> C{Task type?}
    C -->|Issue / PRD work| D[Read docs/agents/issue-tracker.md]
    C -->|Codebase exploration| E[Read docs/agents/domain.md]
    C -->|Apply triage label| F[Read docs/agents/triage-labels.md]

    D --> G{Operation?}
    G -->|Create| H["gh issue create --title ... --body ..."]
    G -->|Read| I["gh issue view n --json ... --jq ..."]
    G -->|List| J["gh issue list --json ... --jq ..."]
    G -->|Comment| K["gh issue comment n --body ..."]
    G -->|Label| L["gh issue edit n --add-label ..."]
    G -->|Close| M["gh issue close n --comment ..."]

    E --> N{Docs exist?}
    N -->|Yes| O[Read CONTEXT.md and relevant ADRs]
    N -->|No| P[Proceed silently]
    O --> Q{Output contradicts ADR?}
    Q -->|Yes| R[Surface conflict explicitly]
    Q -->|No| S[Use glossary vocabulary in output]

    F --> T[Map canonical role to repo label string]
    T --> U["gh issue edit n --add-label mapped-label"]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fagent-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fagent-docs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2Fagents%2Fissue-tracker.md%3A12%0AThe%20%22Read%20an%20issue%22%20convention%20instructs%20agents%20to%20filter%20with%20%60jq%60%20but%20the%20%60--comments%60%20flag%20outputs%20human-readable%20text%2C%20not%20JSON.%20Piping%20that%20output%20through%20%60jq%60%20will%20immediately%20produce%20a%20parse%20error.%20To%20use%20%60jq%60%20for%20extracting%20labels%20and%20comment%20bodies%20programmatically%2C%20the%20command%20needs%20%60--json%60%20mode%20with%20the%20relevant%20fields.%0A%0A%60%60%60suggestion%0A-%20**Read%20an%20issue**%3A%20%60gh%20issue%20view%20%3Cnumber%3E%20--json%20number%2Ctitle%2Cbody%2Clabels%2Ccomments%20--jq%20'%7Bnumber%2C%20title%2C%20body%2C%20labels%3A%20%5B.labels%5B%5D.name%5D%2C%20comments%3A%20%5B.comments%5B%5D.body%5D%7D'%60.%20Use%20%60gh%20issue%20view%20%3Cnumber%3E%20--comments%60%20for%20a%20human-readable%20view.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2Fagents%2Ftriage-labels.md%3A15%0AThis%20line%20reads%20as%20a%20template%20instruction%20left%20over%20from%20an%20upstream%20scaffold.%20An%20agent%20reading%20this%20file%20for%20operational%20guidance%20could%20interpret%20it%20as%20a%20directive%20to%20modify%20the%20file%20itself.%20Since%20the%20labels%20in%20both%20columns%20already%20match%20the%20intended%20vocabulary%2C%20the%20instruction%20is%20vestigial%20and%20should%20be%20removed.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2Fagents%2Fissue-tracker.md%3A12%0AThe%20%22Read%20an%20issue%22%20convention%20instructs%20agents%20to%20filter%20with%20%60jq%60%20but%20the%20%60--comments%60%20flag%20outputs%20human-readable%20text%2C%20not%20JSON.%20Piping%20that%20output%20through%20%60jq%60%20will%20immediately%20produce%20a%20parse%20error.%20To%20use%20%60jq%60%20for%20extracting%20labels%20and%20comment%20bodies%20programmatically%2C%20the%20command%20needs%20%60--json%60%20mode%20with%20the%20relevant%20fields.%0A%0A%60%60%60suggestion%0A-%20**Read%20an%20issue**%3A%20%60gh%20issue%20view%20%3Cnumber%3E%20--json%20number%2Ctitle%2Cbody%2Clabels%2Ccomments%20--jq%20'%7Bnumber%2C%20title%2C%20body%2C%20labels%3A%20%5B.labels%5B%5D.name%5D%2C%20comments%3A%20%5B.comments%5B%5D.body%5D%7D'%60.%20Use%20%60gh%20issue%20view%20%3Cnumber%3E%20--comments%60%20for%20a%20human-readable%20view.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2Fagents%2Ftriage-labels.md%3A15%0AThis%20line%20reads%20as%20a%20template%20instruction%20left%20over%20from%20an%20upstream%20scaffold.%20An%20agent%20reading%20this%20file%20for%20operational%20guidance%20could%20interpret%20it%20as%20a%20directive%20to%20modify%20the%20file%20itself.%20Since%20the%20labels%20in%20both%20columns%20already%20match%20the%20intended%20vocabulary%2C%20the%20instruction%20is%20vestigial%20and%20should%20be%20removed.%0A%0A&repo=ayushj1001%2Fmindpoint&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2Fagents%2Fissue-tracker.md%3A12%0AThe%20%22Read%20an%20issue%22%20convention%20instructs%20agents%20to%20filter%20with%20%60jq%60%20but%20the%20%60--comments%60%20flag%20outputs%20human-readable%20text%2C%20not%20JSON.%20Piping%20that%20output%20through%20%60jq%60%20will%20immediately%20produce%20a%20parse%20error.%20To%20use%20%60jq%60%20for%20extracting%20labels%20and%20comment%20bodies%20programmatically%2C%20the%20command%20needs%20%60--json%60%20mode%20with%20the%20relevant%20fields.%0A%0A%60%60%60suggestion%0A-%20**Read%20an%20issue**%3A%20%60gh%20issue%20view%20%3Cnumber%3E%20--json%20number%2Ctitle%2Cbody%2Clabels%2Ccomments%20--jq%20'%7Bnumber%2C%20title%2C%20body%2C%20labels%3A%20%5B.labels%5B%5D.name%5D%2C%20comments%3A%20%5B.comments%5B%5D.body%5D%7D'%60.%20Use%20%60gh%20issue%20view%20%3Cnumber%3E%20--comments%60%20for%20a%20human-readable%20view.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2Fagents%2Ftriage-labels.md%3A15%0AThis%20line%20reads%20as%20a%20template%20instruction%20left%20over%20from%20an%20upstream%20scaffold.%20An%20agent%20reading%20this%20file%20for%20operational%20guidance%20could%20interpret%20it%20as%20a%20directive%20to%20modify%20the%20file%20itself.%20Since%20the%20labels%20in%20both%20columns%20already%20match%20the%20intended%20vocabulary%2C%20the%20instruction%20is%20vestigial%20and%20should%20be%20removed.%0A%0A&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
docs/agents/issue-tracker.md:12
The "Read an issue" convention instructs agents to filter with `jq` but the `--comments` flag outputs human-readable text, not JSON. Piping that output through `jq` will immediately produce a parse error. To use `jq` for extracting labels and comment bodies programmatically, the command needs `--json` mode with the relevant fields.

```suggestion
- **Read an issue**: `gh issue view <number> --json number,title,body,labels,comments --jq '{number, title, body, labels: [.labels[].name], comments: [.comments[].body]}'`. Use `gh issue view <number> --comments` for a human-readable view.
```

### Issue 2 of 2
docs/agents/triage-labels.md:15
This line reads as a template instruction left over from an upstream scaffold. An agent reading this file for operational guidance could interpret it as a directive to modify the file itself. Since the labels in both columns already match the intended vocabulary, the instruction is vestigial and should be removed.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Clarify GitHub issue listing and triage ..."](https://github.com/ayushj1001/mindpoint/commit/ee9b6bf7261d1a3e5b6522dd826b23a99eaa732b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31179064)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->