### PR TITLE
Add admin pricing controls and free checkout flow

### DIFF
--- a/app/admin/courses/[courseId]/page.tsx
+++ b/app/admin/courses/[courseId]/page.tsx
@@ -223,6 +223,7 @@ export default function AdminEditCoursePage() {
                 <tr>
                   <th className="px-3 py-2">Learner</th>
                   <th className="px-3 py-2">Enrollment</th>
+                  <th className="px-3 py-2">Batch</th>
                   <th className="px-3 py-2">Paid</th>
                   <th className="px-3 py-2">Registered</th>
                   <th className="px-3 py-2">Actions</th>
@@ -231,13 +232,13 @@ export default function AdminEditCoursePage() {
               <tbody>
                 {!enrollments ? (
                   <tr>
-                    <td className="px-3 py-4 text-slate-600" colSpan={5}>
+                    <td className="px-3 py-4 text-slate-600" colSpan={6}>
                       Loading registrations...
                     </td>
                   </tr>
                 ) : registrationRows.length === 0 ? (
                   <tr>
-                    <td className="px-3 py-4 text-slate-600" colSpan={5}>
+                    <td className="px-3 py-4 text-slate-600" colSpan={6}>
                       No registrations found for this course.
                     </td>
                   </tr>
@@ -257,6 +258,18 @@ export default function AdminEditCoursePage() {
                           {row.enrollmentNumber}
                         </p>
                         <Badge variant="outline">{row.status}</Badge>
+                      </td>
+                      <td className="px-3 py-2 text-xs text-slate-700">
+                        <p className="font-medium">{row.batchLabel || "—"}</p>
+                        {[row.batchStartDate, row.batchEndDate].some(
+                          Boolean,
+                        ) ? (
+                          <p className="text-slate-500">
+                            {[row.batchStartDate, row.batchEndDate]
+                              .filter(Boolean)
+                              .join(" to ")}
+                          </p>
+                        ) : null}
                       </td>
                       <td className="px-3 py-2 text-xs text-slate-700">
                         <p>

--- a/app/admin/enrollments/[enrollmentId]/page.tsx
+++ b/app/admin/enrollments/[enrollmentId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { useMutation, useQuery } from "convex/react";
@@ -41,6 +41,7 @@ export default function AdminEnrollmentDetailPage() {
   const [pricingEditReason, setPricingEditReason] =
     useState("Corrected by admin");
   const [isSavingPricing, setIsSavingPricing] = useState(false);
+  const initializedPricingEnrollmentId = useRef<string | null>(null);
   const { formatTimestamp } = useAdminTimeZone();
 
   const detail = useQuery(api.adminEnrollments.getEnrollmentDetail, {
@@ -70,6 +71,9 @@ export default function AdminEnrollmentDetailPage() {
 
   useEffect(() => {
     if (!detail) return;
+    if (initializedPricingEnrollmentId.current === String(detail._id)) {
+      return;
+    }
 
     const fallbackListedPrice = detail.listedPrice ?? detail.course?.price ?? 0;
     const fallbackCheckoutPrice = detail.checkoutPrice ?? fallbackListedPrice;
@@ -81,6 +85,7 @@ export default function AdminEnrollmentDetailPage() {
       detail.mindPointsRedeemed ? String(detail.mindPointsRedeemed) : "",
     );
     setPricingCouponCode(detail.couponCode ?? "");
+    initializedPricingEnrollmentId.current = String(detail._id);
   }, [detail]);
 
   const parsePricingNumber = (value: string) => {

--- a/app/admin/enrollments/[enrollmentId]/page.tsx
+++ b/app/admin/enrollments/[enrollmentId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { useMutation, useQuery } from "convex/react";
@@ -32,6 +32,15 @@ export default function AdminEnrollmentDetailPage() {
     "change_batch" | "transfer" | "cancel" | null
   >(null);
   const [actionReason, setActionReason] = useState("Cancelled by admin");
+  const [pricingListedPrice, setPricingListedPrice] = useState("");
+  const [pricingCheckoutPrice, setPricingCheckoutPrice] = useState("");
+  const [pricingAmountPaid, setPricingAmountPaid] = useState("");
+  const [pricingMindPointsRedeemed, setPricingMindPointsRedeemed] =
+    useState("");
+  const [pricingCouponCode, setPricingCouponCode] = useState("");
+  const [pricingEditReason, setPricingEditReason] =
+    useState("Corrected by admin");
+  const [isSavingPricing, setIsSavingPricing] = useState(false);
   const { formatTimestamp } = useAdminTimeZone();
 
   const detail = useQuery(api.adminEnrollments.getEnrollmentDetail, {
@@ -50,11 +59,40 @@ export default function AdminEnrollmentDetailPage() {
     api.adminEnrollments.changeEnrollmentBatch,
   );
   const cancelEnrollment = useMutation(api.adminEnrollments.cancelEnrollment);
+  const updateEnrollmentPricing = useMutation(
+    api.adminEnrollments.updateEnrollmentPricing,
+  );
 
   const transferableCourses = useMemo(() => {
     if (!detail || !courses) return [];
     return courses.filter((course) => course._id !== detail.courseId);
   }, [detail, courses]);
+
+  useEffect(() => {
+    if (!detail) return;
+
+    const fallbackListedPrice = detail.listedPrice ?? detail.course?.price ?? 0;
+    const fallbackCheckoutPrice = detail.checkoutPrice ?? fallbackListedPrice;
+
+    setPricingListedPrice(String(fallbackListedPrice));
+    setPricingCheckoutPrice(String(fallbackCheckoutPrice));
+    setPricingAmountPaid(String(detail.amountPaid ?? fallbackCheckoutPrice));
+    setPricingMindPointsRedeemed(
+      detail.mindPointsRedeemed ? String(detail.mindPointsRedeemed) : "",
+    );
+    setPricingCouponCode(detail.couponCode ?? "");
+  }, [detail]);
+
+  const parsePricingNumber = (value: string) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
+  };
+
+  const computedRedemptionDiscount = Math.max(
+    0,
+    parsePricingNumber(pricingCheckoutPrice) -
+      parsePricingNumber(pricingAmountPaid),
+  );
 
   const handleTransfer = () => {
     if (!targetCourseId) {
@@ -110,9 +148,38 @@ export default function AdminEnrollmentDetailPage() {
           : pendingAction === "change_batch"
             ? "Batch update failed"
             : pendingAction === "transfer"
-            ? "Transfer failed"
-            : "Cancellation failed",
+              ? "Transfer failed"
+              : "Cancellation failed",
       );
+    }
+  };
+
+  const handleSavePricing = async () => {
+    if (isSavingPricing) return;
+
+    setIsSavingPricing(true);
+    try {
+      await updateEnrollmentPricing({
+        enrollmentId,
+        listedPrice: parsePricingNumber(pricingListedPrice),
+        checkoutPrice: parsePricingNumber(pricingCheckoutPrice),
+        amountPaid: parsePricingNumber(pricingAmountPaid),
+        redemptionDiscountAmount: computedRedemptionDiscount,
+        mindPointsRedeemed: pricingMindPointsRedeemed
+          ? parsePricingNumber(pricingMindPointsRedeemed)
+          : undefined,
+        couponCode: pricingCouponCode.trim() || undefined,
+        reason: pricingEditReason.trim() || undefined,
+      });
+      toast.success("Enrollment pricing updated");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to update enrollment pricing",
+      );
+    } finally {
+      setIsSavingPricing(false);
     }
   };
 
@@ -132,7 +199,9 @@ export default function AdminEnrollmentDetailPage() {
         actions={
           <>
             <Button variant="outline" asChild>
-              <Link href={`/admin/courses/${detail.courseId}`}>Admin Course</Link>
+              <Link href={`/admin/courses/${detail.courseId}`}>
+                Admin Course
+              </Link>
             </Button>
             <Button variant="outline" asChild>
               <Link href={`/courses/${detail.courseId}`} target="_blank">
@@ -218,6 +287,69 @@ export default function AdminEnrollmentDetailPage() {
             {detail.lastConfirmationSentAt
               ? formatTimestamp(detail.lastConfirmationSentAt)
               : "Not resent yet"}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Edit Purchase Split</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 md:grid-cols-5">
+            <Input
+              type="number"
+              min="0"
+              aria-label="Listed price"
+              placeholder="Listed price"
+              value={pricingListedPrice}
+              onChange={(e) => setPricingListedPrice(e.target.value)}
+            />
+            <Input
+              type="number"
+              min="0"
+              aria-label="Checkout price"
+              placeholder="Checkout price"
+              value={pricingCheckoutPrice}
+              onChange={(e) => setPricingCheckoutPrice(e.target.value)}
+            />
+            <Input
+              type="number"
+              min="0"
+              aria-label="Actual money paid"
+              placeholder="Actual money paid"
+              value={pricingAmountPaid}
+              onChange={(e) => setPricingAmountPaid(e.target.value)}
+            />
+            <Input
+              type="number"
+              min="0"
+              aria-label="Mind Points used"
+              placeholder="Mind Points used"
+              value={pricingMindPointsRedeemed}
+              onChange={(e) => setPricingMindPointsRedeemed(e.target.value)}
+            />
+            <Input
+              placeholder="Coupon code"
+              value={pricingCouponCode}
+              onChange={(e) => setPricingCouponCode(e.target.value)}
+            />
+          </div>
+          <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+            <Input
+              placeholder="Audit reason"
+              value={pricingEditReason}
+              onChange={(e) => setPricingEditReason(e.target.value)}
+            />
+            <Button onClick={handleSavePricing} disabled={isSavingPricing}>
+              {isSavingPricing ? "Saving..." : "Save Purchase Split"}
+            </Button>
+          </div>
+          <p className="text-xs text-slate-600">
+            Redemption discount will be stored as{" "}
+            {showRupees(computedRedemptionDiscount)}. This corrects enrollment
+            reporting only; it does not create or reverse Mind Points ledger
+            transactions.
           </p>
         </CardContent>
       </Card>

--- a/app/admin/enrollments/page.tsx
+++ b/app/admin/enrollments/page.tsx
@@ -40,6 +40,14 @@ export default function AdminEnrollmentsPage() {
   const [manualName, setManualName] = useState("");
   const [manualPhone, setManualPhone] = useState("");
   const [manualCourseId, setManualCourseId] = useState("");
+  const [manualPricingMode, setManualPricingMode] = useState<
+    "cash" | "mind_points" | "mixed" | "complimentary"
+  >("cash");
+  const [manualListedPrice, setManualListedPrice] = useState("");
+  const [manualCheckoutPrice, setManualCheckoutPrice] = useState("");
+  const [manualAmountPaid, setManualAmountPaid] = useState("");
+  const [manualMindPointsRedeemed, setManualMindPointsRedeemed] = useState("");
+  const [manualCouponCode, setManualCouponCode] = useState("");
   const [manualInternshipPlan, setManualInternshipPlan] = useState<
     "" | "120" | "240"
   >("");
@@ -70,6 +78,25 @@ export default function AdminEnrollmentsPage() {
       (courses || []).find((course) => String(course._id) === manualCourseId),
     [courses, manualCourseId],
   );
+  const parseManualMoney = (value: string) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
+  };
+  const resetManualPricingForCourse = (
+    course?: NonNullable<typeof selectedManualCourse>,
+    mode: typeof manualPricingMode = manualPricingMode,
+  ) => {
+    const coursePrice = Math.max(0, Math.round(course?.price ?? 0));
+    setManualListedPrice(String(coursePrice));
+    setManualCheckoutPrice(
+      mode === "complimentary" ? "0" : String(coursePrice),
+    );
+    setManualAmountPaid(
+      mode === "cash" || mode === "mixed" ? String(coursePrice) : "0",
+    );
+    setManualMindPointsRedeemed("");
+    setManualCouponCode("");
+  };
 
   const exportRows = useMemo(
     () =>
@@ -82,6 +109,7 @@ export default function AdminEnrollmentsPage() {
         courseName: row.courseName,
         courseType: row.courseType,
         enrollmentNumber: row.enrollmentNumber,
+        batch: row.batchLabel ?? "",
         status: row.status,
         registrationSource: row.registrationSource ?? "checkout",
         amountPaid: row.amountPaid ?? row.checkoutPrice ?? 0,
@@ -133,6 +161,20 @@ export default function AdminEnrollmentsPage() {
         userPhone: manualPhone || undefined,
         courseId: manualCourseId as Id<"courses">,
         isGuestUser: manualUserIdLooksLikeEmail,
+        pricing: {
+          listedPrice: parseManualMoney(manualListedPrice),
+          checkoutPrice: parseManualMoney(manualCheckoutPrice),
+          amountPaid: parseManualMoney(manualAmountPaid),
+          redemptionDiscountAmount: Math.max(
+            0,
+            parseManualMoney(manualCheckoutPrice) -
+              parseManualMoney(manualAmountPaid),
+          ),
+          mindPointsRedeemed: manualMindPointsRedeemed
+            ? parseManualMoney(manualMindPointsRedeemed)
+            : undefined,
+          couponCode: manualCouponCode.trim() || undefined,
+        },
         internshipPlan:
           selectedManualCourse?.type === "internship"
             ? manualInternshipPlan === "120" || manualInternshipPlan === "240"
@@ -146,6 +188,12 @@ export default function AdminEnrollmentsPage() {
       setManualName("");
       setManualPhone("");
       setManualCourseId("");
+      setManualPricingMode("cash");
+      setManualListedPrice("");
+      setManualCheckoutPrice("");
+      setManualAmountPaid("");
+      setManualMindPointsRedeemed("");
+      setManualCouponCode("");
       setManualInternshipPlan("");
     } catch (error) {
       toast.error(
@@ -255,6 +303,7 @@ export default function AdminEnrollmentsPage() {
               if (nextCourse?.type !== "internship") {
                 setManualInternshipPlan("");
               }
+              resetManualPricingForCourse(nextCourse);
             }}
           >
             <option value="">Select course</option>
@@ -287,6 +336,70 @@ export default function AdminEnrollmentsPage() {
             </select>
           ) : null}
         </div>
+        <div className="mt-3 grid gap-3 md:grid-cols-6">
+          <select
+            className="h-10 rounded-md border bg-white px-3 text-sm"
+            value={manualPricingMode}
+            onChange={(e) => {
+              const mode = e.target.value as typeof manualPricingMode;
+              setManualPricingMode(mode);
+              resetManualPricingForCourse(selectedManualCourse, mode);
+            }}
+          >
+            <option value="cash">Actual money</option>
+            <option value="mind_points">Mind Points</option>
+            <option value="mixed">Money + Mind Points</option>
+            <option value="complimentary">Complimentary/admin</option>
+          </select>
+          <Input
+            type="number"
+            min="0"
+            aria-label="Listed price"
+            placeholder="Listed price"
+            value={manualListedPrice}
+            onChange={(e) => setManualListedPrice(e.target.value)}
+          />
+          <Input
+            type="number"
+            min="0"
+            aria-label="Checkout price"
+            placeholder="Checkout price"
+            value={manualCheckoutPrice}
+            onChange={(e) => setManualCheckoutPrice(e.target.value)}
+          />
+          <Input
+            type="number"
+            min="0"
+            aria-label="Actual money paid"
+            placeholder="Actual money paid"
+            value={manualAmountPaid}
+            onChange={(e) => setManualAmountPaid(e.target.value)}
+          />
+          <Input
+            type="number"
+            min="0"
+            aria-label="Mind Points used"
+            placeholder="Mind Points used"
+            value={manualMindPointsRedeemed}
+            onChange={(e) => setManualMindPointsRedeemed(e.target.value)}
+          />
+          <Input
+            placeholder="Coupon code"
+            value={manualCouponCode}
+            onChange={(e) => setManualCouponCode(e.target.value)}
+          />
+        </div>
+        <p className="mt-2 text-xs text-slate-600">
+          Redemption discount will be recorded as{" "}
+          {showRupees(
+            Math.max(
+              0,
+              parseManualMoney(manualCheckoutPrice) -
+                parseManualMoney(manualAmountPaid),
+            ),
+          )}
+          .
+        </p>
         <div className="mt-3">
           <Button
             onClick={handleManualCreate}

--- a/components/CartClient.tsx
+++ b/components/CartClient.tsx
@@ -29,7 +29,7 @@ import { useUser, useClerk } from "@clerk/nextjs";
 import { handlePaymentSuccess } from "@/app/actions/payment";
 import { toast } from "sonner";
 import { WhatsAppModal } from "@/components/whatsapp-modal";
-import { useConvexAuth, useQuery, useMutation } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "@/lib/backend/api";
 import {
   Dialog,
@@ -216,7 +216,6 @@ const CartContent = () => {
     couponCode && isAuthenticated ? { code: couponCode } : "skip",
   );
 
-  const markCouponUsed = useMutation(api.mindPoints.markCouponUsed);
   const now = useNow();
   const cartCourseIds = useMemo(
     () =>
@@ -695,13 +694,8 @@ const CartContent = () => {
       }
 
       if (appliedCoupon) {
-        try {
-          await markCouponUsed({ couponCode: appliedCoupon.code });
-          setAppliedCoupon(null);
-          setCouponCode("");
-        } catch (error) {
-          console.error("Failed to mark coupon as used:", error);
-        }
+        setAppliedCoupon(null);
+        setCouponCode("");
       }
 
       const pointsEarned = totalPointsEarned;
@@ -733,7 +727,6 @@ const CartContent = () => {
       coveredCourseIdSet,
       discountedTotal,
       items,
-      markCouponUsed,
       showEnrollmentToast,
       totalPointsEarned,
       user,

--- a/components/CartClient.tsx
+++ b/components/CartClient.tsx
@@ -131,10 +131,7 @@ function BundleProgressSection({
           {expanded && (
             <div className="space-y-1 border-t border-amber-200 pt-2">
               {eligibleItems.map((item) => (
-                <div
-                  key={item.id}
-                  className="flex items-center gap-2 text-xs"
-                >
+                <div key={item.id} className="flex items-center gap-2 text-xs">
                   <Check className="h-3 w-3 shrink-0 text-amber-600" />
                   <span className="truncate">{item.name}</span>
                 </div>
@@ -175,7 +172,10 @@ const getCartLineKey = (item: {
   batchId?: Id<"courseBatches">;
 }): string =>
   item.courseId
-    ? buildCartItemId(String(item.courseId), item.batchId ? String(item.batchId) : undefined)
+    ? buildCartItemId(
+        String(item.courseId),
+        item.batchId ? String(item.batchId) : undefined,
+      )
     : String(item.id);
 
 const CartContent = () => {
@@ -219,9 +219,10 @@ const CartContent = () => {
   const markCouponUsed = useMutation(api.mindPoints.markCouponUsed);
   const now = useNow();
   const cartCourseIds = useMemo(
-    () => Array.from(new Set(items.map((item) => String(getCartCourseId(item))))).map(
-      (courseId) => courseId as Id<"courses">,
-    ),
+    () =>
+      Array.from(
+        new Set(items.map((item) => String(getCartCourseId(item)))),
+      ).map((courseId) => courseId as Id<"courses">),
     [items],
   );
   const bundleCampaigns = useQuery(
@@ -555,47 +556,54 @@ const CartContent = () => {
     }, 0);
   }, [checkoutPricing.items, items, user?.id]);
 
-  const showEnrollmentToast = (
-    enrollments:
-      | Array<{
-          enrollmentNumber: string;
-          isBogoFree?: boolean;
-        }>
-      | undefined,
-  ) => {
-    if (!enrollments || enrollments.length === 0) {
-      toast.success(
-        "Payment successful! Check your email for enrollment confirmation.",
-      );
-      return;
-    }
+  const showEnrollmentToast = useCallback(
+    (
+      enrollments:
+        | Array<{
+            enrollmentNumber: string;
+            isBogoFree?: boolean;
+          }>
+        | undefined,
+      options: { paidCheckout?: boolean } = {},
+    ) => {
+      const successLabel =
+        options.paidCheckout === false ? "Checkout" : "Payment";
 
-    const bonusCount = enrollments.filter((e) => e.isBogoFree).length;
-    const paidCount = enrollments.length - bonusCount;
-    const parts: string[] = [];
-    if (paidCount > 0) {
-      parts.push(`${paidCount} course${paidCount === 1 ? "" : "s"}`);
-    }
-    if (bonusCount > 0) {
-      parts.push(`${bonusCount} bonus course${bonusCount === 1 ? "" : "s"}`);
-    }
+      if (!enrollments || enrollments.length === 0) {
+        toast.success(
+          `${successLabel} successful! Check your email for enrollment confirmation.`,
+        );
+        return;
+      }
 
-    const message = parts.length
-      ? `Payment successful! ${parts.join(" + ")} added to your account.`
-      : "Payment successful!";
+      const bonusCount = enrollments.filter((e) => e.isBogoFree).length;
+      const paidCount = enrollments.length - bonusCount;
+      const parts: string[] = [];
+      if (paidCount > 0) {
+        parts.push(`${paidCount} course${paidCount === 1 ? "" : "s"}`);
+      }
+      if (bonusCount > 0) {
+        parts.push(`${bonusCount} bonus course${bonusCount === 1 ? "" : "s"}`);
+      }
 
-    const enrollmentNumbers = enrollments
-      .filter((e) => e.enrollmentNumber && e.enrollmentNumber !== "N/A")
-      .map((e) => e.enrollmentNumber);
+      const message = parts.length
+        ? `${successLabel} successful! ${parts.join(" + ")} added to your account.`
+        : `${successLabel} successful!`;
 
-    const hasValidEnrollments = enrollmentNumbers.length > 0;
+      const enrollmentNumbers = enrollments
+        .filter((e) => e.enrollmentNumber && e.enrollmentNumber !== "N/A")
+        .map((e) => e.enrollmentNumber);
 
-    toast.success(message, {
-      description: hasValidEnrollments
-        ? `Enrollment numbers: ${enrollmentNumbers.join(", ")}`
-        : "Check your email for enrollment confirmation.",
-    });
-  };
+      const hasValidEnrollments = enrollmentNumbers.length > 0;
+
+      toast.success(message, {
+        description: hasValidEnrollments
+          ? `Enrollment numbers: ${enrollmentNumbers.join(", ")}`
+          : "Check your email for enrollment confirmation.",
+      });
+    },
+    [],
+  );
 
   const handleClearCart = () => {
     emptyCart();
@@ -628,6 +636,111 @@ const CartContent = () => {
     };
   }, []);
 
+  const completeCheckoutEnrollment = useCallback(
+    async (whatsappNumber?: string) => {
+      if (!user?.id) {
+        return false;
+      }
+
+      const lineItems = items.map((item) => ({
+        batchId: item.batchId as Id<"courseBatches"> | undefined,
+        courseId: getCartCourseId(item),
+      }));
+
+      const bogoSelections = items
+        .filter(
+          (item) =>
+            item.selectedFreeCourse &&
+            !coveredCourseIdSet.has(String(getCartCourseId(item))),
+        )
+        .map((item) => ({
+          selectedFreeBatchId: item.selectedFreeCourse!.batchId,
+          selectedFreeCourseId:
+            item.selectedFreeCourse!.courseId ?? item.selectedFreeCourse!.id,
+          sourceBatchId: item.batchId as Id<"courseBatches"> | undefined,
+          sourceCourseId: getCartCourseId(item),
+        }));
+
+      const userPhone =
+        whatsappNumber || userProfile?.whatsappNumber || undefined;
+
+      const referralCookie = getReferralCookie();
+      const referrerClerkUserId =
+        referralCookie && referralCookie !== user.id
+          ? referralCookie
+          : undefined;
+
+      const result = await handlePaymentSuccess(
+        user.id,
+        lineItems,
+        user.primaryEmailAddress?.emailAddress || "",
+        userPhone,
+        user.fullName || undefined,
+        undefined,
+        bogoSelections.length > 0 ? bogoSelections : undefined,
+        referrerClerkUserId,
+        checkoutPricing,
+      );
+
+      if (!result.success) {
+        toast.error(
+          discountedTotal <= 0
+            ? "Checkout failed. Please try again."
+            : "Payment successful but enrollment failed. Please contact support.",
+          {
+            description: result.error,
+          },
+        );
+        return false;
+      }
+
+      if (appliedCoupon) {
+        try {
+          await markCouponUsed({ couponCode: appliedCoupon.code });
+          setAppliedCoupon(null);
+          setCouponCode("");
+        } catch (error) {
+          console.error("Failed to mark coupon as used:", error);
+        }
+      }
+
+      const pointsEarned = totalPointsEarned;
+
+      if (pointsEarned > 0 && user?.id) {
+        setTimeout(() => {
+          toast.success(`🎉 You earned ${pointsEarned} Mind Points!`, {
+            description:
+              "Points have been added to your account. Visit your account to redeem them.",
+            duration: 6000,
+            action: {
+              label: "View Points",
+              onClick: () => {
+                window.location.href = "/account?tab=points";
+              },
+            },
+          });
+        }, 2000);
+      }
+
+      showEnrollmentToast(result.enrollments, {
+        paidCheckout: discountedTotal > 0,
+      });
+      return true;
+    },
+    [
+      appliedCoupon,
+      checkoutPricing,
+      coveredCourseIdSet,
+      discountedTotal,
+      items,
+      markCouponUsed,
+      showEnrollmentToast,
+      totalPointsEarned,
+      user,
+      userProfile?.whatsappNumber,
+    ],
+  );
+
   const handlePayment = useCallback(
     async (whatsappNumber?: string) => {
       if (isEmpty || !user?.id) return;
@@ -635,6 +748,18 @@ const CartContent = () => {
       setIsProcessing(true);
 
       try {
+        if (discountedTotal <= 0) {
+          const enrollmentCompleted =
+            await completeCheckoutEnrollment(whatsappNumber);
+
+          if (enrollmentCompleted) {
+            emptyCart();
+          }
+
+          setIsProcessing(false);
+          return;
+        }
+
         const data = await requestPaymentOrder({
           amount: discountedTotal,
         });
@@ -649,94 +774,7 @@ const CartContent = () => {
           handler: async () => {
             // Handle signed-in user
             try {
-              const lineItems = items.map((item) => ({
-                batchId: item.batchId as Id<"courseBatches"> | undefined,
-                courseId: getCartCourseId(item),
-              }));
-
-              // Extract BOGO selections from cart items
-              const bogoSelections = items
-                .filter(
-                  (item) =>
-                    item.selectedFreeCourse &&
-                    !coveredCourseIdSet.has(String(getCartCourseId(item))),
-                )
-                .map((item) => ({
-                  selectedFreeBatchId: item.selectedFreeCourse!.batchId,
-                  selectedFreeCourseId:
-                    item.selectedFreeCourse!.courseId ??
-                    item.selectedFreeCourse!.id,
-                  sourceBatchId: item.batchId as
-                    | Id<"courseBatches">
-                    | undefined,
-                  sourceCourseId: getCartCourseId(item),
-                }));
-
-              // Use the WhatsApp number from user profile or the one just collected
-              const userPhone =
-                whatsappNumber || userProfile?.whatsappNumber || undefined;
-
-              const referralCookie = getReferralCookie();
-              const referrerClerkUserId =
-                referralCookie && referralCookie !== user.id
-                  ? referralCookie
-                  : undefined;
-
-              // Call server action to handle enrollment
-              const result = await handlePaymentSuccess(
-                user.id,
-                lineItems,
-                user.primaryEmailAddress?.emailAddress || "",
-                userPhone,
-                user.fullName || undefined, // studentName
-                undefined, // sessionType
-                bogoSelections.length > 0 ? bogoSelections : undefined,
-                referrerClerkUserId,
-                checkoutPricing,
-              );
-
-              if (result.success) {
-                // Mark coupon as used if applied
-                if (appliedCoupon) {
-                  try {
-                    await markCouponUsed({ couponCode: appliedCoupon.code });
-                    setAppliedCoupon(null);
-                    setCouponCode("");
-                  } catch (error) {
-                    console.error("Failed to mark coupon as used:", error);
-                  }
-                }
-
-                const pointsEarned = totalPointsEarned;
-
-                if (pointsEarned > 0 && user?.id) {
-                  setTimeout(() => {
-                    toast.success(
-                      `🎉 You earned ${pointsEarned} Mind Points!`,
-                      {
-                        description:
-                          "Points have been added to your account. Visit your account to redeem them.",
-                        duration: 6000,
-                        action: {
-                          label: "View Points",
-                          onClick: () => {
-                            window.location.href = "/account?tab=points";
-                          },
-                        },
-                      },
-                    );
-                  }, 2000);
-                }
-
-                showEnrollmentToast(result.enrollments);
-              } else {
-                toast.error(
-                  "Payment successful but enrollment failed. Please contact support.",
-                  {
-                    description: result.error,
-                  },
-                );
-              }
+              await completeCheckoutEnrollment(whatsappNumber);
             } catch {
               toast.error(
                 "Payment successful but enrollment failed. Please contact support.",
@@ -966,18 +1004,12 @@ const CartContent = () => {
       user?.fullName,
       user?.primaryEmailAddress?.emailAddress,
       discountedTotal,
-      checkoutPricing,
       items,
-      userProfile,
-      markCouponUsed,
-      appliedCoupon,
-      setAppliedCoupon,
-      setCouponCode,
-      totalPointsEarned,
+      userProfile?.whatsappNumber,
       emptyCart,
       setIsProcessing,
       Razorpay,
-      coveredCourseIdSet,
+      completeCheckoutEnrollment,
     ],
   );
 
@@ -1170,7 +1202,11 @@ const CartContent = () => {
                             </span>
                             {pricingItem.redemptionDiscountAmount > 0 && (
                               <span className="font-medium text-blue-600">
-                                (save {showRupees(pricingItem.redemptionDiscountAmount)})
+                                (save{" "}
+                                {showRupees(
+                                  pricingItem.redemptionDiscountAmount,
+                                )}
+                                )
                               </span>
                             )}
                           </div>
@@ -1561,7 +1597,7 @@ const CartContent = () => {
               </div>
               <Button
                 onClick={handleCheckoutClick}
-                disabled={isProcessing || isLoading}
+                disabled={isProcessing || (discountedTotal > 0 && isLoading)}
                 className="w-full"
               >
                 {isProcessing ? "Processing..." : "Proceed to Checkout"}

--- a/convex/adminEnrollments.ts
+++ b/convex/adminEnrollments.ts
@@ -89,8 +89,59 @@ function normalizeEmail(value: string): string {
   return value.trim().toLowerCase();
 }
 
+function roundCurrency(value: number | undefined): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.round(value!));
+}
+
 function isAuthenticatedUserId(userId: string): boolean {
   return userId.startsWith("user_");
+}
+
+const adminEnrollmentPricingValidator = v.object({
+  listedPrice: v.optional(v.number()),
+  checkoutPrice: v.optional(v.number()),
+  amountPaid: v.optional(v.number()),
+  redemptionDiscountAmount: v.optional(v.number()),
+  couponCode: v.optional(v.string()),
+  mindPointsRedeemed: v.optional(v.number()),
+});
+
+function buildAdminCheckoutPricingItem(
+  course: Doc<"courses">,
+  courseId: Id<"courses">,
+  pricing?: {
+    listedPrice?: number;
+    checkoutPrice?: number;
+    amountPaid?: number;
+    redemptionDiscountAmount?: number;
+    couponCode?: string;
+    mindPointsRedeemed?: number;
+  },
+) {
+  const listedPrice = roundCurrency(pricing?.listedPrice ?? course.price);
+  const checkoutPrice = roundCurrency(pricing?.checkoutPrice ?? listedPrice);
+  const amountPaid = roundCurrency(pricing?.amountPaid ?? checkoutPrice);
+  const redemptionDiscountAmount = roundCurrency(
+    pricing?.redemptionDiscountAmount ??
+      Math.max(0, checkoutPrice - amountPaid),
+  );
+  const couponCode = pricing?.couponCode?.trim() || undefined;
+  const mindPointsRedeemed = roundCurrency(pricing?.mindPointsRedeemed);
+
+  return {
+    courseId,
+    listedPrice,
+    checkoutPrice,
+    amountPaid,
+    redemptionDiscountAmount:
+      redemptionDiscountAmount > 0 ? redemptionDiscountAmount : undefined,
+    couponCode,
+    mindPointsRedeemed: mindPointsRedeemed > 0 ? mindPointsRedeemed : undefined,
+  };
 }
 
 async function removeUserFromCourseIfNoActiveEnrollment(
@@ -428,6 +479,7 @@ export const createManualEnrollment = mutation({
       v.union(v.literal("focus"), v.literal("flow"), v.literal("elevate")),
     ),
     internshipPlan: v.optional(v.union(v.literal("120"), v.literal("240"))),
+    pricing: v.optional(adminEnrollmentPricingValidator),
   },
   handler: async (ctx, args): Promise<Doc<"enrollments"> | null> => {
     const admin = await requireAdmin(ctx);
@@ -457,6 +509,11 @@ export const createManualEnrollment = mutation({
     }
 
     const isGuestUser = args.isGuestUser ?? !isAuthenticatedUserId(args.userId);
+    const pricingItem = buildAdminCheckoutPricingItem(
+      course,
+      args.courseId,
+      args.pricing,
+    );
 
     let enrollmentId: Id<"enrollments"> | null = null;
 
@@ -473,15 +530,8 @@ export const createManualEnrollment = mutation({
           sessionType: args.sessionType,
           internshipPlan: args.internshipPlan,
           checkoutPricing: {
-            totalAmountPaid: 0,
-            items: [
-              {
-                courseId: args.courseId,
-                listedPrice: course.price,
-                checkoutPrice: 0,
-                amountPaid: 0,
-              },
-            ],
+            totalAmountPaid: pricingItem.amountPaid,
+            items: [pricingItem],
           },
         },
       )) as GuestCheckoutResult;
@@ -516,15 +566,8 @@ export const createManualEnrollment = mutation({
             sessionType: args.sessionType,
             internshipPlan: args.internshipPlan,
             checkoutPricing: {
-              totalAmountPaid: 0,
-              items: [
-                {
-                  courseId: args.courseId,
-                  listedPrice: course.price,
-                  checkoutPrice: 0,
-                  amountPaid: 0,
-                },
-              ],
+              totalAmountPaid: pricingItem.amountPaid,
+              items: [pricingItem],
             },
           },
         );
@@ -555,6 +598,7 @@ export const createManualEnrollment = mutation({
         metadata: {
           source: "admin",
           isGuestUser,
+          pricing: pricingItem,
         },
       });
     } catch (error) {
@@ -577,6 +621,64 @@ export const createManualEnrollment = mutation({
     });
 
     return await ctx.db.get(enrollmentId);
+  },
+});
+
+export const updateEnrollmentPricing = mutation({
+  args: {
+    enrollmentId: v.id("enrollments"),
+    listedPrice: v.number(),
+    checkoutPrice: v.number(),
+    amountPaid: v.number(),
+    redemptionDiscountAmount: v.optional(v.number()),
+    couponCode: v.optional(v.string()),
+    mindPointsRedeemed: v.optional(v.number()),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const admin = await requireAdmin(ctx);
+
+    const enrollment = await ctx.db.get(args.enrollmentId);
+    if (!enrollment) {
+      throw new Error("Enrollment not found");
+    }
+
+    const listedPrice = roundCurrency(args.listedPrice);
+    const checkoutPrice = roundCurrency(args.checkoutPrice);
+    const amountPaid = roundCurrency(args.amountPaid);
+    const redemptionDiscountAmount = roundCurrency(
+      args.redemptionDiscountAmount ?? Math.max(0, checkoutPrice - amountPaid),
+    );
+    const mindPointsRedeemed = roundCurrency(args.mindPointsRedeemed);
+    const couponCode = args.couponCode?.trim() || undefined;
+
+    await ctx.db.patch(args.enrollmentId, {
+      listedPrice,
+      checkoutPrice,
+      amountPaid,
+      redemptionDiscountAmount:
+        redemptionDiscountAmount > 0 ? redemptionDiscountAmount : undefined,
+      couponCode,
+      mindPointsRedeemed:
+        mindPointsRedeemed > 0 ? mindPointsRedeemed : undefined,
+    });
+
+    const updated = await ctx.db.get(args.enrollmentId);
+
+    await createAdminAuditLog(ctx, {
+      actorAdminId: admin.userId,
+      actorEmail: admin.email,
+      action: "enrollment.update_pricing",
+      entityType: "enrollment",
+      entityId: String(args.enrollmentId),
+      before: enrollment,
+      after: updated,
+      metadata: {
+        reason: args.reason?.trim() || undefined,
+      },
+    });
+
+    return updated;
   },
 });
 
@@ -680,8 +782,7 @@ export const resendEnrollmentConfirmationEmail = mutation({
       course.startDate ??
       new Date().toISOString().split("T")[0];
     const endDate = enrollment.batchEndDate ?? course.endDate ?? startDate;
-    const startTime =
-      enrollment.batchStartTime ?? course.startTime ?? "00:00";
+    const startTime = enrollment.batchStartTime ?? course.startTime ?? "00:00";
     const endTime = enrollment.batchEndTime ?? course.endTime ?? "23:59";
 
     let emailAction = "generic";

--- a/convex/adminEnrollments.ts
+++ b/convex/adminEnrollments.ts
@@ -125,9 +125,12 @@ function buildAdminCheckoutPricingItem(
   const listedPrice = roundCurrency(pricing?.listedPrice ?? course.price);
   const checkoutPrice = roundCurrency(pricing?.checkoutPrice ?? listedPrice);
   const amountPaid = roundCurrency(pricing?.amountPaid ?? checkoutPrice);
+  if (amountPaid > checkoutPrice) {
+    throw new Error("Amount paid cannot exceed checkout price.");
+  }
+
   const redemptionDiscountAmount = roundCurrency(
-    pricing?.redemptionDiscountAmount ??
-      Math.max(0, checkoutPrice - amountPaid),
+    Math.max(0, checkoutPrice - amountPaid),
   );
   const couponCode = pricing?.couponCode?.trim() || undefined;
   const mindPointsRedeemed = roundCurrency(pricing?.mindPointsRedeemed);
@@ -646,8 +649,12 @@ export const updateEnrollmentPricing = mutation({
     const listedPrice = roundCurrency(args.listedPrice);
     const checkoutPrice = roundCurrency(args.checkoutPrice);
     const amountPaid = roundCurrency(args.amountPaid);
+    if (amountPaid > checkoutPrice) {
+      throw new Error("Amount paid cannot exceed checkout price.");
+    }
+
     const redemptionDiscountAmount = roundCurrency(
-      args.redemptionDiscountAmount ?? Math.max(0, checkoutPrice - amountPaid),
+      Math.max(0, checkoutPrice - amountPaid),
     );
     const mindPointsRedeemed = roundCurrency(args.mindPointsRedeemed);
     const couponCode = args.couponCode?.trim() || undefined;

--- a/convex/myFunctions.ts
+++ b/convex/myFunctions.ts
@@ -3,15 +3,9 @@ import { query, mutation, action } from "./_generated/server";
 import { api, internal } from "./_generated/api";
 import { MutationCtx } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
-import type {
-  CheckoutPricing,
-  CheckoutPricingItem,
-} from "./_shared/checkout";
+import type { CheckoutPricing, CheckoutPricingItem } from "./_shared/checkout";
 import { calculatePointsEarned } from "./_shared/mind-points";
-import {
-  PublicCourseDocumentValue,
-  PublicEnrollmentFields,
-} from "./schema";
+import { PublicCourseDocumentValue, PublicEnrollmentFields } from "./schema";
 import { pickPublicCourse } from "./_publicCourse";
 
 // Write your Convex functions in any file inside this directory (`convex`).
@@ -297,7 +291,8 @@ function getCheckoutPricingItem(
     ) ??
     checkoutPricing?.items.find(
       (item) =>
-        String(item.courseId) === String(courseId) && item.batchId === undefined,
+        String(item.courseId) === String(courseId) &&
+        item.batchId === undefined,
     )
   );
 }
@@ -332,6 +327,84 @@ function buildEnrollmentPricingFields(
     bundleCampaignId: pricingItem?.bundleCampaignId,
     bundleCampaignName: pricingItem?.bundleCampaignName?.trim() || undefined,
   };
+}
+
+async function validateCheckoutPricingItem(
+  ctx: MutationCtx,
+  args: {
+    userId: string;
+    course: CourseDoc;
+    pricingItem?: CheckoutPricingItem;
+  },
+) {
+  const pricingItem = args.pricingItem;
+  if (!pricingItem) {
+    return;
+  }
+
+  const checkoutPrice = roundCurrency(
+    pricingItem.checkoutPrice ?? args.course.price,
+  );
+  const amountPaid = roundCurrency(pricingItem.amountPaid ?? checkoutPrice);
+  if (amountPaid > checkoutPrice) {
+    throw new Error("Amount paid cannot exceed checkout price.");
+  }
+
+  const couponCode = pricingItem.couponCode?.trim();
+  if (!couponCode && amountPaid === 0 && checkoutPrice > 0) {
+    throw new Error("Free checkout requires a valid coupon.");
+  }
+
+  if (!couponCode) {
+    return;
+  }
+
+  const coupon = await ctx.db
+    .query("coupons")
+    .withIndex("by_code", (q) => q.eq("code", couponCode))
+    .first();
+
+  if (!coupon) {
+    throw new Error("Invalid coupon code.");
+  }
+  if (coupon.isUsed) {
+    throw new Error("This coupon has already been used.");
+  }
+  if (coupon.clerkUserId !== args.userId) {
+    throw new Error("This coupon does not belong to this user.");
+  }
+  if (coupon.courseType !== args.course.type) {
+    throw new Error("This coupon is not valid for this course type.");
+  }
+
+  const expectedDiscountAmount = Math.min(
+    checkoutPrice,
+    Math.round(checkoutPrice * (coupon.discount / 100)),
+  );
+  const expectedAmountPaid = Math.max(
+    0,
+    checkoutPrice - expectedDiscountAmount,
+  );
+  const redemptionDiscountAmount = roundCurrency(
+    pricingItem.redemptionDiscountAmount,
+  );
+  const mindPointsRedeemed = roundCurrency(pricingItem.mindPointsRedeemed);
+
+  if (
+    redemptionDiscountAmount !== expectedDiscountAmount ||
+    amountPaid !== expectedAmountPaid
+  ) {
+    throw new Error("Coupon pricing does not match the coupon discount.");
+  }
+
+  if (mindPointsRedeemed > 0 && mindPointsRedeemed !== coupon.pointsCost) {
+    throw new Error("Mind Points redeemed does not match the coupon cost.");
+  }
+
+  await ctx.db.patch(coupon._id, {
+    isUsed: true,
+    usedAt: Date.now(),
+  });
 }
 
 function isCourseBatchBacked(course: CourseDoc) {
@@ -416,7 +489,10 @@ function buildScheduleSnapshot(
     batchEndTime: undefined,
     batchDaysOfWeek: undefined,
     startDate: course.startDate ?? new Date().toISOString().split("T")[0],
-    endDate: course.endDate ?? course.startDate ?? new Date().toISOString().split("T")[0],
+    endDate:
+      course.endDate ??
+      course.startDate ??
+      new Date().toISOString().split("T")[0],
     startTime: course.startTime ?? "00:00",
     endTime: course.endTime ?? "23:59",
     daysOfWeek: course.daysOfWeek ?? [],
@@ -468,7 +544,11 @@ async function ensureEnrollmentCapacity(
     }
     const enrolledUsers = latestBatch.enrolledUsers ?? [];
     const capacity = latestBatch.capacity ?? 0;
-    if (capacity > 0 && enrolledUsers.length >= capacity && !enrolledUsers.includes(userId)) {
+    if (
+      capacity > 0 &&
+      enrolledUsers.length >= capacity &&
+      !enrolledUsers.includes(userId)
+    ) {
       throw new Error(`Batch "${latestBatch.label}" is full.`);
     }
     return latestBatch;
@@ -480,7 +560,11 @@ async function ensureEnrollmentCapacity(
   }
   const enrolledUsers = latestCourse.enrolledUsers ?? [];
   const capacity = latestCourse.capacity ?? 0;
-  if (capacity > 0 && enrolledUsers.length >= capacity && !enrolledUsers.includes(userId)) {
+  if (
+    capacity > 0 &&
+    enrolledUsers.length >= capacity &&
+    !enrolledUsers.includes(userId)
+  ) {
     throw new Error(`Course "${latestCourse.name}" is full.`);
   }
   return null;
@@ -534,7 +618,8 @@ async function scheduleEnrollmentConfirmationForSummary(
     args.course.startDate ??
     new Date().toISOString().split("T")[0];
   const endDate = args.enrollment.endDate ?? args.course.endDate ?? startDate;
-  const startTime = args.enrollment.startTime ?? args.course.startTime ?? "00:00";
+  const startTime =
+    args.enrollment.startTime ?? args.course.startTime ?? "00:00";
   const endTime = args.enrollment.endTime ?? args.course.endTime ?? "23:59";
 
   if (args.course.type === "supervised" && args.sessionType) {
@@ -593,7 +678,10 @@ async function scheduleEnrollmentConfirmationForSummary(
     return;
   }
 
-  if (args.course.type === "certificate" || args.course.type === "resume-studio") {
+  if (
+    args.course.type === "certificate" ||
+    args.course.type === "resume-studio"
+  ) {
     await ctx.scheduler.runAfter(
       0,
       api.emailActions.sendCertificateEnrollmentConfirmation,
@@ -665,20 +753,16 @@ async function scheduleEnrollmentConfirmationForSummary(
     return;
   }
 
-  await ctx.scheduler.runAfter(
-    0,
-    api.emailActions.sendEnrollmentConfirmation,
-    {
-      userEmail: args.recipientEmail,
-      userPhone: args.userPhone,
-      courseName: args.enrollment.courseName,
-      enrollmentNumber: args.enrollment.enrollmentNumber,
-      startDate,
-      endDate,
-      startTime,
-      endTime,
-    },
-  );
+  await ctx.scheduler.runAfter(0, api.emailActions.sendEnrollmentConfirmation, {
+    userEmail: args.recipientEmail,
+    userPhone: args.userPhone,
+    courseName: args.enrollment.courseName,
+    enrollmentNumber: args.enrollment.enrollmentNumber,
+    startDate,
+    endDate,
+    startTime,
+    endTime,
+  });
 }
 
 function getEnrollmentEmailSchedule(
@@ -826,14 +910,10 @@ async function grantBogoEnrollments(
     }
 
     // Validate the BOGO selection
-    const validation = validateBogoSelection(
-      sourceCourse,
-      freeCourse,
-      {
-        ...bogoSelection,
-        selectedFreeCourseId,
-      },
-    );
+    const validation = validateBogoSelection(sourceCourse, freeCourse, {
+      ...bogoSelection,
+      selectedFreeCourseId,
+    });
 
     if (!validation.isValid) {
       console.warn(
@@ -1107,10 +1187,7 @@ async function createBogoEnrollment(
     freeCourse.type === "internship" &&
     (internshipPlan === "120" || internshipPlan === "240")
   ) {
-    computedEndDate = calculateInternshipEndDate(
-      startDate,
-      internshipPlan,
-    );
+    computedEndDate = calculateInternshipEndDate(startDate, internshipPlan);
   }
 
   return [
@@ -1158,7 +1235,11 @@ export const handleSuccessfulPayment = mutation({
     if (!course) {
       throw new Error("Course not found");
     }
-    const batchResolution = await resolveEnrollmentBatch(ctx, course, args.batchId);
+    const batchResolution = await resolveEnrollmentBatch(
+      ctx,
+      course,
+      args.batchId,
+    );
     const batch = batchResolution.batch;
     await ensureEnrollmentCapacity(ctx, course, args.userId, batch);
 
@@ -1192,6 +1273,11 @@ export const handleSuccessfulPayment = mutation({
       args.courseId,
       args.batchId,
     );
+    await validateCheckoutPricingItem(ctx, {
+      userId: args.userId,
+      course,
+      pricingItem,
+    });
 
     // Create enrollment record
     const enrollmentId = await ctx.db.insert("enrollments", {
@@ -1251,17 +1337,22 @@ export const handleSuccessfulPayment = mutation({
 
     const userName = args.studentName || args.userEmail;
 
-    const bogoEnrollments = await grantBogoEnrollments(ctx, course, {
-      userId: args.userId,
-      userName: userName,
-      userEmail: args.userEmail,
-      userPhone: args.userPhone,
-      sessionType: args.sessionType,
-      isGuestUser: false,
-    }, {
-      sourceCourseId: args.courseId,
-      sourceBatchId: args.batchId,
-    });
+    const bogoEnrollments = await grantBogoEnrollments(
+      ctx,
+      course,
+      {
+        userId: args.userId,
+        userName: userName,
+        userEmail: args.userEmail,
+        userPhone: args.userPhone,
+        sessionType: args.sessionType,
+        isGuestUser: false,
+      },
+      {
+        sourceCourseId: args.courseId,
+        sourceBatchId: args.batchId,
+      },
+    );
 
     // Send appropriate email based on course type
     console.log("Checking email conditions:");
@@ -1579,6 +1670,11 @@ export const handleCartCheckout = mutation({
         lineItem.courseId,
         lineItem.batchId,
       );
+      await validateCheckoutPricingItem(ctx, {
+        userId: args.userId,
+        course,
+        pricingItem,
+      });
 
       const enrollmentId = await ctx.db.insert("enrollments", {
         userId: args.userId,
@@ -1706,14 +1802,19 @@ export const handleCartCheckout = mutation({
             console.warn(
               `Invalid BOGO selection for course ${course.name}: ${validation.error}. Attempting fallback to predefined free course.`,
             );
-            bogoEnrollments = await grantBogoEnrollments(ctx, course, {
-              userId: args.userId,
-              userName: args.studentName || args.userEmail,
-              userEmail: args.userEmail,
-              userPhone: args.userPhone,
-              sessionType: args.sessionType,
-              isGuestUser: false,
-            }, bogoSelection);
+            bogoEnrollments = await grantBogoEnrollments(
+              ctx,
+              course,
+              {
+                userId: args.userId,
+                userName: args.studentName || args.userEmail,
+                userEmail: args.userEmail,
+                userPhone: args.userPhone,
+                sessionType: args.sessionType,
+                isGuestUser: false,
+              },
+              bogoSelection,
+            );
           } else {
             bogoEnrollments = await grantBogoEnrollments(
               ctx,
@@ -1730,17 +1831,22 @@ export const handleCartCheckout = mutation({
             );
           }
         } else {
-          bogoEnrollments = await grantBogoEnrollments(ctx, course, {
-            userId: args.userId,
-            userName: args.studentName || args.userEmail,
-            userEmail: args.userEmail,
-            userPhone: args.userPhone,
-            sessionType: args.sessionType,
-            isGuestUser: false,
-          }, {
-            sourceCourseId: lineItem.courseId,
-            sourceBatchId: lineItem.batchId,
-          });
+          bogoEnrollments = await grantBogoEnrollments(
+            ctx,
+            course,
+            {
+              userId: args.userId,
+              userName: args.studentName || args.userEmail,
+              userEmail: args.userEmail,
+              userPhone: args.userPhone,
+              sessionType: args.sessionType,
+              isGuestUser: false,
+            },
+            {
+              sourceCourseId: lineItem.courseId,
+              sourceBatchId: lineItem.batchId,
+            },
+          );
         }
       }
 
@@ -2486,14 +2592,19 @@ export const handleGuestUserCartCheckoutWithData = mutation({
             console.warn(
               `Invalid BOGO selection for course ${course.name}: ${validation.error}. Attempting fallback to predefined free course.`,
             );
-            bogoEnrollments = await grantBogoEnrollments(ctx, course, {
-              userId: args.userData.email,
-              userName: args.userData.name,
-              userEmail: args.userData.email,
-              userPhone: args.userData.phone,
-              sessionType: args.sessionType,
-              isGuestUser: true,
-            }, bogoSelection);
+            bogoEnrollments = await grantBogoEnrollments(
+              ctx,
+              course,
+              {
+                userId: args.userData.email,
+                userName: args.userData.name,
+                userEmail: args.userData.email,
+                userPhone: args.userData.phone,
+                sessionType: args.sessionType,
+                isGuestUser: true,
+              },
+              bogoSelection,
+            );
           } else {
             bogoEnrollments = await grantBogoEnrollments(
               ctx,
@@ -2510,17 +2621,22 @@ export const handleGuestUserCartCheckoutWithData = mutation({
             );
           }
         } else {
-          bogoEnrollments = await grantBogoEnrollments(ctx, course, {
-            userId: args.userData.email,
-            userName: args.userData.name,
-            userEmail: args.userData.email,
-            userPhone: args.userData.phone,
-            sessionType: args.sessionType,
-            isGuestUser: true,
-          }, {
-            sourceCourseId: lineItem.courseId,
-            sourceBatchId: lineItem.batchId,
-          });
+          bogoEnrollments = await grantBogoEnrollments(
+            ctx,
+            course,
+            {
+              userId: args.userData.email,
+              userName: args.userData.name,
+              userEmail: args.userData.email,
+              userPhone: args.userData.phone,
+              sessionType: args.sessionType,
+              isGuestUser: true,
+            },
+            {
+              sourceCourseId: lineItem.courseId,
+              sourceBatchId: lineItem.batchId,
+            },
+          );
         }
       }
 


### PR DESCRIPTION
## Summary
- Add admin controls to create and edit enrollment purchase splits, including listed price, checkout price, amount paid, Mind Points redeemed, and coupon code.
- Support complimentary checkouts in the cart flow by completing enrollment without Razorpay when the discounted total is zero.
- Show batch information in the admin course enrollment table for easier registration review.
- Persist admin pricing edits through a new Convex mutation and record them in audit logs.

## Testing
- Not run
- Verified the diff for manual enrollment creation, enrollment pricing edits, and zero-cost checkout handling.
- Checked that the admin course and enrollment views now display batch and pricing fields where expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Batch column to the Registered Learners table in course admin view
  * Admins can now edit enrollment purchase split (listed price, checkout price, amount paid, coupon details) with audit trails
  * Manual enrollment creation supports configurable pricing modes and flexible pricing inputs

* **Improvements**
  * Enhanced checkout enrollment confirmation messaging with enrollment numbers and Mind Points earned notifications

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AyushJ1001/mindpoint/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds admin pricing controls for enrollment purchase splits, a zero-cost checkout path in the cart flow, and a Batch column to the admin course enrollment table. Server-side coupon validation (`validateCheckoutPricingItem`) is a meaningful security addition, and the move from client-side `markCouponUsed` to server-side coupon marking inside the mutation is a clear improvement.

- **Admin pricing**: New `updateEnrollmentPricing` mutation lets admins correct `listedPrice`, `checkoutPrice`, `amountPaid`, and related fields with an audit trail; `buildAdminCheckoutPricingItem` re-derives `redemptionDiscountAmount` server-side so clients can't inflate it.
- **Zero-cost checkout**: When `discountedTotal <= 0`, `completeCheckoutEnrollment` is called directly without Razorpay, with the server enforcing that a valid coupon must exist for any item whose checkout price is non-zero.
- **Coupon validation gap**: `validateCheckoutPricingItem` is wired into `handleCartCheckout` and `handleSuccessfulPayment` but is absent from `handleGuestUserCartCheckoutWithData`; guest coupon codes are neither validated nor marked as used, and a direct mutation call with `amountPaid: 0` is not blocked on that path.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: the guest checkout mutation accepts client-provided pricing without server-side coupon validation, allowing coupon reuse and zero-cost enrollment for guest users.

The new server-side coupon validation is applied to the authenticated checkout paths but is missing from the guest checkout mutation, which is a public API endpoint. A guest user — or any caller directly invoking the mutation — can embed a coupon code that is never validated or consumed, or can set amountPaid to zero without any coupon, producing a free enrollment.

convex/myFunctions.ts — the handleGuestUserCartCheckoutWithData mutation needs validateCheckoutPricingItem added to its per-item loop.

<details open><summary><h3>Security Review</h3></summary>

- **Coupon bypass (guest checkout)** — `handleGuestUserCartCheckoutWithData` (`convex/myFunctions.ts`) accepts client-supplied `checkoutPricing` but does not call `validateCheckoutPricingItem`. A guest user can submit a coupon code that will never be marked as used (enabling unlimited reuse), or submit `amountPaid: 0` with a non-zero `checkoutPrice` and no coupon, bypassing the guard that exists on the authenticated path. Because this is a public Convex mutation, it is callable directly without going through Razorpay.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| convex/myFunctions.ts | Adds validateCheckoutPricingItem (coupon server-side validation + coupon marking) and wires it into handleCartCheckout and handleSuccessfulPayment, but omits it from handleGuestUserCartCheckoutWithData, leaving guest coupon codes unvalidated and unspent. |
| convex/adminEnrollments.ts | Adds updateEnrollmentPricing mutation (admin pricing edits with audit log) and buildAdminCheckoutPricingItem helper; server-side validates amountPaid <= checkoutPrice and recomputes redemptionDiscountAmount. |
| components/CartClient.tsx | Extracts completeCheckoutEnrollment into a reusable callback and adds a zero-cost checkout path that bypasses Razorpay; removes client-side markCouponUsed in favour of the new server-side coupon marking. |
| app/admin/enrollments/[enrollmentId]/page.tsx | Adds Edit Purchase Split card with six pricing fields; uses a useRef guard so the Convex reactive update only initialises state once per enrollment ID. |
| app/admin/enrollments/page.tsx | Adds manual enrollment pricing controls (mode selector + five price inputs) and resets them when the selected course changes. |
| app/admin/courses/[courseId]/page.tsx | Adds a Batch column to the registered learners table with correct colSpan adjustments. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Checkout] --> B{discountedTotal <= 0?}
    B -- Yes --> C[completeCheckoutEnrollment]
    B -- No --> D[Razorpay payment flow]
    D --> E[Razorpay handler fires]
    E --> C

    C --> F{user.id present?}
    F -- No --> G[return false]
    F -- Yes --> H[handlePaymentSuccess server action]
    H --> I[handleCartCheckout Convex mutation]
    I --> J[validateCheckoutPricingItem per item]
    J --> K{coupon present?}
    K -- Yes --> L[Validate coupon DB + mark isUsed]
    K -- No --> M{amountPaid==0 and checkoutPrice>0?}
    M -- Yes --> N[throw: requires valid coupon]
    M -- No --> O[Enroll user]
    L --> O

    P[Guest user checkout] --> Q[handleGuestUserCartCheckoutWithData]
    Q --> R[getCheckoutPricingItem]
    R --> S[NO validateCheckoutPricingItem]
    S --> T[Enroll guest - coupon not checked or marked used]

    style S fill:#ff6b6b,color:#fff
    style N fill:#ffd93d
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `app/admin/enrollments/[enrollmentId]/page.tsx`, line 89-102 ([link](https://github.com/ayushj1001/mindpoint/blob/ba07266b5666cbf1918c2fdf339a6e12b075d9ae/app/admin/enrollments/[enrollmentId]/page.tsx#L89-L102)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Reactive `detail` update resets unsaved pricing edits**

   The `useEffect` re-initializes all six pricing state variables every time the Convex `detail` query delivers a new object. Because Convex pushes updates reactively, any concurrent mutation on the same enrollment document (a batch change, status update, or another admin session saving pricing) will silently overwrite whatever the admin has typed but not yet saved. Consider initializing these fields only on first load (e.g., with a `useRef` flag, or by using local form state that is only populated once via a one-time effect).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: app/admin/enrollments/[enrollmentId]/page.tsx
   Line: 89-102

   Comment:
   **Reactive `detail` update resets unsaved pricing edits**

   The `useEffect` re-initializes all six pricing state variables every time the Convex `detail` query delivers a new object. Because Convex pushes updates reactively, any concurrent mutation on the same enrollment document (a batch change, status update, or another admin session saving pricing) will silently overwrite whatever the admin has typed but not yet saved. Consider initializing these fields only on first load (e.g., with a `useRef` flag, or by using local form state that is only populated once via a one-time effect).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fadmin-pricing-enrollments%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fadmin-pricing-enrollments%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fadmin%2Fenrollments%2F%5BenrollmentId%5D%2Fpage.tsx%0ALine%3A%2089-102%0A%0AComment%3A%0A**Reactive%20%60detail%60%20update%20resets%20unsaved%20pricing%20edits**%0A%0AThe%20%60useEffect%60%20re-initializes%20all%20six%20pricing%20state%20variables%20every%20time%20the%20Convex%20%60detail%60%20query%20delivers%20a%20new%20object.%20Because%20Convex%20pushes%20updates%20reactively%2C%20any%20concurrent%20mutation%20on%20the%20same%20enrollment%20document%20%28a%20batch%20change%2C%20status%20update%2C%20or%20another%20admin%20session%20saving%20pricing%29%20will%20silently%20overwrite%20whatever%20the%20admin%20has%20typed%20but%20not%20yet%20saved.%20Consider%20initializing%20these%20fields%20only%20on%20first%20load%20%28e.g.%2C%20with%20a%20%60useRef%60%20flag%2C%20or%20by%20using%20local%20form%20state%20that%20is%20only%20populated%20once%20via%20a%20one-time%20effect%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fadmin%2Fenrollments%2F%5BenrollmentId%5D%2Fpage.tsx%0ALine%3A%2089-102%0A%0AComment%3A%0A**Reactive%20%60detail%60%20update%20resets%20unsaved%20pricing%20edits**%0A%0AThe%20%60useEffect%60%20re-initializes%20all%20six%20pricing%20state%20variables%20every%20time%20the%20Convex%20%60detail%60%20query%20delivers%20a%20new%20object.%20Because%20Convex%20pushes%20updates%20reactively%2C%20any%20concurrent%20mutation%20on%20the%20same%20enrollment%20document%20%28a%20batch%20change%2C%20status%20update%2C%20or%20another%20admin%20session%20saving%20pricing%29%20will%20silently%20overwrite%20whatever%20the%20admin%20has%20typed%20but%20not%20yet%20saved.%20Consider%20initializing%20these%20fields%20only%20on%20first%20load%20%28e.g.%2C%20with%20a%20%60useRef%60%20flag%2C%20or%20by%20using%20local%20form%20state%20that%20is%20only%20populated%20once%20via%20a%20one-time%20effect%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint&pr=82&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fadmin%2Fenrollments%2F%5BenrollmentId%5D%2Fpage.tsx%0ALine%3A%2089-102%0A%0AComment%3A%0A**Reactive%20%60detail%60%20update%20resets%20unsaved%20pricing%20edits**%0A%0AThe%20%60useEffect%60%20re-initializes%20all%20six%20pricing%20state%20variables%20every%20time%20the%20Convex%20%60detail%60%20query%20delivers%20a%20new%20object.%20Because%20Convex%20pushes%20updates%20reactively%2C%20any%20concurrent%20mutation%20on%20the%20same%20enrollment%20document%20%28a%20batch%20change%2C%20status%20update%2C%20or%20another%20admin%20session%20saving%20pricing%29%20will%20silently%20overwrite%20whatever%20the%20admin%20has%20typed%20but%20not%20yet%20saved.%20Consider%20initializing%20these%20fields%20only%20on%20first%20load%20%28e.g.%2C%20with%20a%20%60useRef%60%20flag%2C%20or%20by%20using%20local%20form%20state%20that%20is%20only%20populated%20once%20via%20a%20one-time%20effect%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=82&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

2. `convex/adminEnrollments.ts`, line 946-1002 ([link](https://github.com/ayushj1001/mindpoint/blob/ba07266b5666cbf1918c2fdf339a6e12b075d9ae/convex/adminEnrollments.ts#L946-L1002)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **No consistency check between `amountPaid`, `checkoutPrice`, and `redemptionDiscountAmount`**

   `updateEnrollmentPricing` accepts and patches arbitrary combinations of these three fields. An admin could inadvertently save `amountPaid: 5000, checkoutPrice: 1000` — where the actual money paid exceeds the checkout price — producing records that break downstream reporting. Adding a server-side guard (e.g., `amountPaid > checkoutPrice → throw`) would prevent silently inconsistent data from entering the DB.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: convex/adminEnrollments.ts
   Line: 946-1002

   Comment:
   **No consistency check between `amountPaid`, `checkoutPrice`, and `redemptionDiscountAmount`**

   `updateEnrollmentPricing` accepts and patches arbitrary combinations of these three fields. An admin could inadvertently save `amountPaid: 5000, checkoutPrice: 1000` — where the actual money paid exceeds the checkout price — producing records that break downstream reporting. Adding a server-side guard (e.g., `amountPaid > checkoutPrice → throw`) would prevent silently inconsistent data from entering the DB.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fadmin-pricing-enrollments%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fadmin-pricing-enrollments%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminEnrollments.ts%0ALine%3A%20946-1002%0A%0AComment%3A%0A**No%20consistency%20check%20between%20%60amountPaid%60%2C%20%60checkoutPrice%60%2C%20and%20%60redemptionDiscountAmount%60**%0A%0A%60updateEnrollmentPricing%60%20accepts%20and%20patches%20arbitrary%20combinations%20of%20these%20three%20fields.%20An%20admin%20could%20inadvertently%20save%20%60amountPaid%3A%205000%2C%20checkoutPrice%3A%201000%60%20%E2%80%94%20where%20the%20actual%20money%20paid%20exceeds%20the%20checkout%20price%20%E2%80%94%20producing%20records%20that%20break%20downstream%20reporting.%20Adding%20a%20server-side%20guard%20%28e.g.%2C%20%60amountPaid%20%3E%20checkoutPrice%20%E2%86%92%20throw%60%29%20would%20prevent%20silently%20inconsistent%20data%20from%20entering%20the%20DB.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminEnrollments.ts%0ALine%3A%20946-1002%0A%0AComment%3A%0A**No%20consistency%20check%20between%20%60amountPaid%60%2C%20%60checkoutPrice%60%2C%20and%20%60redemptionDiscountAmount%60**%0A%0A%60updateEnrollmentPricing%60%20accepts%20and%20patches%20arbitrary%20combinations%20of%20these%20three%20fields.%20An%20admin%20could%20inadvertently%20save%20%60amountPaid%3A%205000%2C%20checkoutPrice%3A%201000%60%20%E2%80%94%20where%20the%20actual%20money%20paid%20exceeds%20the%20checkout%20price%20%E2%80%94%20producing%20records%20that%20break%20downstream%20reporting.%20Adding%20a%20server-side%20guard%20%28e.g.%2C%20%60amountPaid%20%3E%20checkoutPrice%20%E2%86%92%20throw%60%29%20would%20prevent%20silently%20inconsistent%20data%20from%20entering%20the%20DB.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint&pr=82&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FadminEnrollments.ts%0ALine%3A%20946-1002%0A%0AComment%3A%0A**No%20consistency%20check%20between%20%60amountPaid%60%2C%20%60checkoutPrice%60%2C%20and%20%60redemptionDiscountAmount%60**%0A%0A%60updateEnrollmentPricing%60%20accepts%20and%20patches%20arbitrary%20combinations%20of%20these%20three%20fields.%20An%20admin%20could%20inadvertently%20save%20%60amountPaid%3A%205000%2C%20checkoutPrice%3A%201000%60%20%E2%80%94%20where%20the%20actual%20money%20paid%20exceeds%20the%20checkout%20price%20%E2%80%94%20producing%20records%20that%20break%20downstream%20reporting.%20Adding%20a%20server-side%20guard%20%28e.g.%2C%20%60amountPaid%20%3E%20checkoutPrice%20%E2%86%92%20throw%60%29%20would%20prevent%20silently%20inconsistent%20data%20from%20entering%20the%20DB.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=82&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

3. `convex/myFunctions.ts`, line 2479-2483 ([link](https://github.com/ayushj1001/mindpoint/blob/813d2245b58de05da33f92ef966d2f71c6282d5a/convex/myFunctions.ts#L2479-L2483)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Guest checkout skips coupon validation entirely**

   `handleGuestUserCartCheckoutWithData` extracts a `pricingItem` from `checkoutPricing` (which comes from the client via `lib/services/checkout.ts`) but never calls `validateCheckoutPricingItem`. As a result, for any guest checkout: (1) a coupon code embedded in `checkoutPricing` is neither verified against the database nor marked as used, so the same coupon can be reused indefinitely; (2) a caller that submits `amountPaid: 0` with a non-zero `checkoutPrice` and no coupon passes the zero-cost guard that was added to the authenticated path — a direct call to this public mutation bypasses Razorpay entirely. The fix is to call `validateCheckoutPricingItem` for each `pricingItem` in this mutation's loop, matching the pattern used in `handleCartCheckout`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: convex/myFunctions.ts
   Line: 2479-2483

   Comment:
   **Guest checkout skips coupon validation entirely**

   `handleGuestUserCartCheckoutWithData` extracts a `pricingItem` from `checkoutPricing` (which comes from the client via `lib/services/checkout.ts`) but never calls `validateCheckoutPricingItem`. As a result, for any guest checkout: (1) a coupon code embedded in `checkoutPricing` is neither verified against the database nor marked as used, so the same coupon can be reused indefinitely; (2) a caller that submits `amountPaid: 0` with a non-zero `checkoutPrice` and no coupon passes the zero-cost guard that was added to the authenticated path — a direct call to this public mutation bypasses Razorpay entirely. The fix is to call `validateCheckoutPricingItem` for each `pricingItem` in this mutation's loop, matching the pattern used in `handleCartCheckout`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fadmin-pricing-enrollments%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fadmin-pricing-enrollments%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FmyFunctions.ts%0ALine%3A%202479-2483%0A%0AComment%3A%0A**Guest%20checkout%20skips%20coupon%20validation%20entirely**%0A%0A%60handleGuestUserCartCheckoutWithData%60%20extracts%20a%20%60pricingItem%60%20from%20%60checkoutPricing%60%20%28which%20comes%20from%20the%20client%20via%20%60lib%2Fservices%2Fcheckout.ts%60%29%20but%20never%20calls%20%60validateCheckoutPricingItem%60.%20As%20a%20result%2C%20for%20any%20guest%20checkout%3A%20%281%29%20a%20coupon%20code%20embedded%20in%20%60checkoutPricing%60%20is%20neither%20verified%20against%20the%20database%20nor%20marked%20as%20used%2C%20so%20the%20same%20coupon%20can%20be%20reused%20indefinitely%3B%20%282%29%20a%20caller%20that%20submits%20%60amountPaid%3A%200%60%20with%20a%20non-zero%20%60checkoutPrice%60%20and%20no%20coupon%20passes%20the%20zero-cost%20guard%20that%20was%20added%20to%20the%20authenticated%20path%20%E2%80%94%20a%20direct%20call%20to%20this%20public%20mutation%20bypasses%20Razorpay%20entirely.%20The%20fix%20is%20to%20call%20%60validateCheckoutPricingItem%60%20for%20each%20%60pricingItem%60%20in%20this%20mutation's%20loop%2C%20matching%20the%20pattern%20used%20in%20%60handleCartCheckout%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FmyFunctions.ts%0ALine%3A%202479-2483%0A%0AComment%3A%0A**Guest%20checkout%20skips%20coupon%20validation%20entirely**%0A%0A%60handleGuestUserCartCheckoutWithData%60%20extracts%20a%20%60pricingItem%60%20from%20%60checkoutPricing%60%20%28which%20comes%20from%20the%20client%20via%20%60lib%2Fservices%2Fcheckout.ts%60%29%20but%20never%20calls%20%60validateCheckoutPricingItem%60.%20As%20a%20result%2C%20for%20any%20guest%20checkout%3A%20%281%29%20a%20coupon%20code%20embedded%20in%20%60checkoutPricing%60%20is%20neither%20verified%20against%20the%20database%20nor%20marked%20as%20used%2C%20so%20the%20same%20coupon%20can%20be%20reused%20indefinitely%3B%20%282%29%20a%20caller%20that%20submits%20%60amountPaid%3A%200%60%20with%20a%20non-zero%20%60checkoutPrice%60%20and%20no%20coupon%20passes%20the%20zero-cost%20guard%20that%20was%20added%20to%20the%20authenticated%20path%20%E2%80%94%20a%20direct%20call%20to%20this%20public%20mutation%20bypasses%20Razorpay%20entirely.%20The%20fix%20is%20to%20call%20%60validateCheckoutPricingItem%60%20for%20each%20%60pricingItem%60%20in%20this%20mutation's%20loop%2C%20matching%20the%20pattern%20used%20in%20%60handleCartCheckout%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ayushj1001%2Fmindpoint&pr=82&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20convex%2FmyFunctions.ts%0ALine%3A%202479-2483%0A%0AComment%3A%0A**Guest%20checkout%20skips%20coupon%20validation%20entirely**%0A%0A%60handleGuestUserCartCheckoutWithData%60%20extracts%20a%20%60pricingItem%60%20from%20%60checkoutPricing%60%20%28which%20comes%20from%20the%20client%20via%20%60lib%2Fservices%2Fcheckout.ts%60%29%20but%20never%20calls%20%60validateCheckoutPricingItem%60.%20As%20a%20result%2C%20for%20any%20guest%20checkout%3A%20%281%29%20a%20coupon%20code%20embedded%20in%20%60checkoutPricing%60%20is%20neither%20verified%20against%20the%20database%20nor%20marked%20as%20used%2C%20so%20the%20same%20coupon%20can%20be%20reused%20indefinitely%3B%20%282%29%20a%20caller%20that%20submits%20%60amountPaid%3A%200%60%20with%20a%20non-zero%20%60checkoutPrice%60%20and%20no%20coupon%20passes%20the%20zero-cost%20guard%20that%20was%20added%20to%20the%20authenticated%20path%20%E2%80%94%20a%20direct%20call%20to%20this%20public%20mutation%20bypasses%20Razorpay%20entirely.%20The%20fix%20is%20to%20call%20%60validateCheckoutPricingItem%60%20for%20each%20%60pricingItem%60%20in%20this%20mutation's%20loop%2C%20matching%20the%20pattern%20used%20in%20%60handleCartCheckout%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=82&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22feature%2Fadmin-pricing-enrollments%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fadmin-pricing-enrollments%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aconvex%2FmyFunctions.ts%3A2479-2483%0A**Guest%20checkout%20skips%20coupon%20validation%20entirely**%0A%0A%60handleGuestUserCartCheckoutWithData%60%20extracts%20a%20%60pricingItem%60%20from%20%60checkoutPricing%60%20%28which%20comes%20from%20the%20client%20via%20%60lib%2Fservices%2Fcheckout.ts%60%29%20but%20never%20calls%20%60validateCheckoutPricingItem%60.%20As%20a%20result%2C%20for%20any%20guest%20checkout%3A%20%281%29%20a%20coupon%20code%20embedded%20in%20%60checkoutPricing%60%20is%20neither%20verified%20against%20the%20database%20nor%20marked%20as%20used%2C%20so%20the%20same%20coupon%20can%20be%20reused%20indefinitely%3B%20%282%29%20a%20caller%20that%20submits%20%60amountPaid%3A%200%60%20with%20a%20non-zero%20%60checkoutPrice%60%20and%20no%20coupon%20passes%20the%20zero-cost%20guard%20that%20was%20added%20to%20the%20authenticated%20path%20%E2%80%94%20a%20direct%20call%20to%20this%20public%20mutation%20bypasses%20Razorpay%20entirely.%20The%20fix%20is%20to%20call%20%60validateCheckoutPricingItem%60%20for%20each%20%60pricingItem%60%20in%20this%20mutation's%20loop%2C%20matching%20the%20pattern%20used%20in%20%60handleCartCheckout%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aconvex%2FmyFunctions.ts%3A2479-2483%0A**Guest%20checkout%20skips%20coupon%20validation%20entirely**%0A%0A%60handleGuestUserCartCheckoutWithData%60%20extracts%20a%20%60pricingItem%60%20from%20%60checkoutPricing%60%20%28which%20comes%20from%20the%20client%20via%20%60lib%2Fservices%2Fcheckout.ts%60%29%20but%20never%20calls%20%60validateCheckoutPricingItem%60.%20As%20a%20result%2C%20for%20any%20guest%20checkout%3A%20%281%29%20a%20coupon%20code%20embedded%20in%20%60checkoutPricing%60%20is%20neither%20verified%20against%20the%20database%20nor%20marked%20as%20used%2C%20so%20the%20same%20coupon%20can%20be%20reused%20indefinitely%3B%20%282%29%20a%20caller%20that%20submits%20%60amountPaid%3A%200%60%20with%20a%20non-zero%20%60checkoutPrice%60%20and%20no%20coupon%20passes%20the%20zero-cost%20guard%20that%20was%20added%20to%20the%20authenticated%20path%20%E2%80%94%20a%20direct%20call%20to%20this%20public%20mutation%20bypasses%20Razorpay%20entirely.%20The%20fix%20is%20to%20call%20%60validateCheckoutPricingItem%60%20for%20each%20%60pricingItem%60%20in%20this%20mutation's%20loop%2C%20matching%20the%20pattern%20used%20in%20%60handleCartCheckout%60.%0A%0A&repo=ayushj1001%2Fmindpoint&pr=82&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aconvex%2FmyFunctions.ts%3A2479-2483%0A**Guest%20checkout%20skips%20coupon%20validation%20entirely**%0A%0A%60handleGuestUserCartCheckoutWithData%60%20extracts%20a%20%60pricingItem%60%20from%20%60checkoutPricing%60%20%28which%20comes%20from%20the%20client%20via%20%60lib%2Fservices%2Fcheckout.ts%60%29%20but%20never%20calls%20%60validateCheckoutPricingItem%60.%20As%20a%20result%2C%20for%20any%20guest%20checkout%3A%20%281%29%20a%20coupon%20code%20embedded%20in%20%60checkoutPricing%60%20is%20neither%20verified%20against%20the%20database%20nor%20marked%20as%20used%2C%20so%20the%20same%20coupon%20can%20be%20reused%20indefinitely%3B%20%282%29%20a%20caller%20that%20submits%20%60amountPaid%3A%200%60%20with%20a%20non-zero%20%60checkoutPrice%60%20and%20no%20coupon%20passes%20the%20zero-cost%20guard%20that%20was%20added%20to%20the%20authenticated%20path%20%E2%80%94%20a%20direct%20call%20to%20this%20public%20mutation%20bypasses%20Razorpay%20entirely.%20The%20fix%20is%20to%20call%20%60validateCheckoutPricingItem%60%20for%20each%20%60pricingItem%60%20in%20this%20mutation's%20loop%2C%20matching%20the%20pattern%20used%20in%20%60handleCartCheckout%60.%0A%0A&pr=82&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
convex/myFunctions.ts:2479-2483
**Guest checkout skips coupon validation entirely**

`handleGuestUserCartCheckoutWithData` extracts a `pricingItem` from `checkoutPricing` (which comes from the client via `lib/services/checkout.ts`) but never calls `validateCheckoutPricingItem`. As a result, for any guest checkout: (1) a coupon code embedded in `checkoutPricing` is neither verified against the database nor marked as used, so the same coupon can be reused indefinitely; (2) a caller that submits `amountPaid: 0` with a non-zero `checkoutPrice` and no coupon passes the zero-cost guard that was added to the authenticated path — a direct call to this public mutation bypasses Razorpay entirely. The fix is to call `validateCheckoutPricingItem` for each `pricingItem` in this mutation's loop, matching the pattern used in `handleCartCheckout`.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Validate checkout pricing and simplify c..."](https://github.com/ayushj1001/mindpoint/commit/813d2245b58de05da33f92ef966d2f71c6282d5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31674019)</sub>

<!-- /greptile_comment -->