### PR TITLE
fix: authenticate checkout finalization

### DIFF
--- a/app/actions/payment.ts
+++ b/app/actions/payment.ts
@@ -1,5 +1,8 @@
 "use server";
 
+import { auth } from "@clerk/nextjs/server";
+import { resolveAuthEmail } from "@/lib/clerk-email";
+import { isClerkServerConfigured } from "@/lib/clerk-env";
 import {
   handleGuestUserPaymentSuccess as handleGuestUserPaymentSuccessService,
   handleGuestUserPaymentSuccessWithData as handleGuestUserPaymentSuccessWithDataService,
@@ -10,10 +13,123 @@ import {
   handleSupervisedTherapyEnrollment as handleSupervisedTherapyEnrollmentService,
 } from "@/lib/services/checkout";
 
+type CheckoutActionFailure = {
+  error: string;
+  success: false;
+};
+
+type AuthenticatedCheckoutContext = {
+  convexAuthToken: string;
+  userEmail?: string;
+  userId: string;
+};
+
+type HandlePaymentSuccessArgs = Parameters<typeof handlePaymentSuccessService>;
+type HandlePaymentSuccessClientArgs = [
+  lineItems: HandlePaymentSuccessArgs[1],
+  userEmail: HandlePaymentSuccessArgs[2],
+  userPhone?: HandlePaymentSuccessArgs[3],
+  studentName?: HandlePaymentSuccessArgs[4],
+  sessionType?: HandlePaymentSuccessArgs[5],
+  bogoSelections?: HandlePaymentSuccessArgs[6],
+  referrerClerkUserId?: HandlePaymentSuccessArgs[7],
+  checkoutPricing?: HandlePaymentSuccessArgs[8],
+  options?: HandlePaymentSuccessArgs[9],
+];
+
+type HandleSingleCourseEnrollmentArgs = Parameters<
+  typeof handleSingleCourseEnrollmentService
+>;
+type HandleSingleCourseEnrollmentClientArgs = [
+  courseId: HandleSingleCourseEnrollmentArgs[1],
+  batchId: HandleSingleCourseEnrollmentArgs[2],
+  userEmail: HandleSingleCourseEnrollmentArgs[3],
+  userPhone?: HandleSingleCourseEnrollmentArgs[4],
+  studentName?: HandleSingleCourseEnrollmentArgs[5],
+  sessionType?: HandleSingleCourseEnrollmentArgs[6],
+  options?: HandleSingleCourseEnrollmentArgs[7],
+];
+
+type HandleSupervisedTherapyEnrollmentArgs = Parameters<
+  typeof handleSupervisedTherapyEnrollmentService
+>;
+type HandleSupervisedTherapyEnrollmentClientArgs = [
+  courseId: HandleSupervisedTherapyEnrollmentArgs[1],
+  userEmail: HandleSupervisedTherapyEnrollmentArgs[2],
+  userPhone: HandleSupervisedTherapyEnrollmentArgs[3],
+  studentName: HandleSupervisedTherapyEnrollmentArgs[4],
+  sessionType: HandleSupervisedTherapyEnrollmentArgs[5],
+  options?: HandleSupervisedTherapyEnrollmentArgs[6],
+];
+
+function checkoutActionFailure(error: string): CheckoutActionFailure {
+  return { error, success: false };
+}
+
+async function getAuthenticatedCheckoutContext(): Promise<
+  AuthenticatedCheckoutContext | CheckoutActionFailure
+> {
+  if (!isClerkServerConfigured()) {
+    return checkoutActionFailure("Checkout authentication is not configured.");
+  }
+
+  try {
+    const { userId, sessionClaims, getToken } = await auth();
+    if (!userId) {
+      return checkoutActionFailure("Sign in before checkout.");
+    }
+
+    const convexAuthToken = await getToken({ template: "convex" });
+    if (!convexAuthToken) {
+      return checkoutActionFailure(
+        "Checkout authentication token is unavailable.",
+      );
+    }
+
+    return {
+      convexAuthToken,
+      userEmail: await resolveAuthEmail(sessionClaims),
+      userId,
+    };
+  } catch {
+    return checkoutActionFailure(
+      "Checkout authentication service is unavailable.",
+    );
+  }
+}
+
 export async function handlePaymentSuccess(
-  ...args: Parameters<typeof handlePaymentSuccessService>
+  ...args: HandlePaymentSuccessClientArgs
 ) {
-  return handlePaymentSuccessService(...args);
+  const authContext = await getAuthenticatedCheckoutContext();
+  if ("success" in authContext) {
+    return authContext;
+  }
+
+  const [
+    lineItems,
+    userEmail,
+    userPhone,
+    studentName,
+    sessionType,
+    bogoSelections,
+    referrerClerkUserId,
+    checkoutPricing,
+    options = {},
+  ] = args;
+
+  return handlePaymentSuccessService(
+    authContext.userId,
+    lineItems,
+    authContext.userEmail || userEmail,
+    userPhone,
+    studentName,
+    sessionType,
+    bogoSelections,
+    referrerClerkUserId,
+    checkoutPricing,
+    { ...options, convexAuthToken: authContext.convexAuthToken },
+  );
 }
 
 export async function handleGuestUserPaymentSuccess(
@@ -29,9 +145,33 @@ export async function handleGuestUserPaymentSuccessWithData(
 }
 
 export async function handleSingleCourseEnrollment(
-  ...args: Parameters<typeof handleSingleCourseEnrollmentService>
+  ...args: HandleSingleCourseEnrollmentClientArgs
 ) {
-  return handleSingleCourseEnrollmentService(...args);
+  const authContext = await getAuthenticatedCheckoutContext();
+  if ("success" in authContext) {
+    return authContext;
+  }
+
+  const [
+    courseId,
+    batchId,
+    userEmail,
+    userPhone,
+    studentName,
+    sessionType,
+    options = {},
+  ] = args;
+
+  return handleSingleCourseEnrollmentService(
+    authContext.userId,
+    courseId,
+    batchId,
+    authContext.userEmail || userEmail,
+    userPhone,
+    studentName,
+    sessionType,
+    { ...options, convexAuthToken: authContext.convexAuthToken },
+  );
 }
 
 export async function handleGuestUserSingleEnrollment(
@@ -41,9 +181,31 @@ export async function handleGuestUserSingleEnrollment(
 }
 
 export async function handleSupervisedTherapyEnrollment(
-  ...args: Parameters<typeof handleSupervisedTherapyEnrollmentService>
+  ...args: HandleSupervisedTherapyEnrollmentClientArgs
 ) {
-  return handleSupervisedTherapyEnrollmentService(...args);
+  const authContext = await getAuthenticatedCheckoutContext();
+  if ("success" in authContext) {
+    return authContext;
+  }
+
+  const [
+    courseId,
+    userEmail,
+    userPhone,
+    studentName,
+    sessionType,
+    options = {},
+  ] = args;
+
+  return handleSupervisedTherapyEnrollmentService(
+    authContext.userId,
+    courseId,
+    authContext.userEmail || userEmail,
+    userPhone,
+    studentName,
+    sessionType,
+    { ...options, convexAuthToken: authContext.convexAuthToken },
+  );
 }
 
 export async function handleGuestUserSupervisedTherapyEnrollment(

--- a/app/api/create-order/route.ts
+++ b/app/api/create-order/route.ts
@@ -29,7 +29,7 @@ async function handleCreateOrder(req: NextRequest) {
         );
       }
 
-      const { userId, sessionClaims } = yield* Effect.tryPromise({
+      const { userId, sessionClaims, getToken } = yield* Effect.tryPromise({
         try: () => auth(),
         catch: (cause) =>
           new BoundaryExternalServiceError({
@@ -47,10 +47,21 @@ async function handleCreateOrder(req: NextRequest) {
       }
 
       const checkoutServerSecret = process.env.CHECKOUT_SERVER_SECRET;
-      if (!checkoutServerSecret) {
+      const convexAuthToken = checkoutServerSecret
+        ? undefined
+        : yield* Effect.tryPromise({
+            try: () => getToken({ template: "convex" }),
+            catch: (cause) =>
+              new BoundaryExternalServiceError({
+                ...(cause instanceof Error ? { cause } : {}),
+                message: "Checkout authentication token is unavailable.",
+              }),
+          });
+
+      if (!checkoutServerSecret && !convexAuthToken) {
         return yield* Effect.fail(
           new BoundaryConfigurationError({
-            message: "Checkout server authorization is not configured.",
+            message: "Checkout authentication token is unavailable.",
           }),
         );
       }
@@ -71,7 +82,9 @@ async function handleCreateOrder(req: NextRequest) {
           buyerEmail,
           referrerClerkUserId: createOrderBody.referrerClerkUserId,
         },
-        { checkoutServerSecret, buyerUserId: userId },
+        checkoutServerSecret
+          ? { checkoutServerSecret, buyerUserId: userId }
+          : { convexAuthToken: convexAuthToken ?? undefined },
       );
 
       const amount = Number(attempt.reconciliation.totalAmountPaid);

--- a/components/CartClient.tsx
+++ b/components/CartClient.tsx
@@ -886,7 +886,6 @@ const CartContent = () => {
           : undefined;
 
       const result = await handlePaymentSuccess(
-        user.id,
         lineItems,
         user.primaryEmailAddress?.emailAddress || "",
         userPhone,

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -12,6 +12,7 @@ type RateLimiter = {
   limit(identifier: string): Promise<RateLimitResult>;
 };
 
+const DEFAULT_RATE_LIMIT_TIMEOUT_MS = 1_000;
 const upstashUrl =
   process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
 const upstashToken =
@@ -82,10 +83,44 @@ export function getClientIdentifier(req: Request): string {
   return ip;
 }
 
+function getRateLimitTimeoutMs(): number {
+  const timeoutMs = Number(process.env.RATE_LIMIT_TIMEOUT_MS);
+  return Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? timeoutMs
+    : DEFAULT_RATE_LIMIT_TIMEOUT_MS;
+}
+
+async function limitWithTimeout(
+  limiter: RateLimiter,
+  identifier: string,
+  timeoutMs: number,
+): Promise<RateLimitResult> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      limiter.limit(identifier),
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          () =>
+            reject(
+              new Error(`Rate limit check timed out after ${timeoutMs}ms.`),
+            ),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
 // Helper function to check rate limit
 export async function checkRateLimit(
   req: Request,
   limiter: RateLimiter = ratelimit,
+  timeoutMs = getRateLimitTimeoutMs(),
 ): Promise<{
   success: boolean;
   limit: number;
@@ -93,7 +128,7 @@ export async function checkRateLimit(
   reset: number;
 }> {
   const identifier = getClientIdentifier(req);
-  const result = await limiter.limit(identifier);
+  const result = await limitWithTimeout(limiter, identifier, timeoutMs);
 
   return {
     success: result.success,

--- a/lib/services/checkout-attempts.server.ts
+++ b/lib/services/checkout-attempts.server.ts
@@ -263,11 +263,17 @@ function checkoutAttemptBoundaryError(cause: BoundaryThrowable): BoundaryError {
     return error;
   }
 
+  const message = cause instanceof Error ? cause.message : String(cause);
+  if (message.includes("No auth provider found matching the given token")) {
+    return new BoundaryConfigurationError({
+      ...(cause instanceof Error ? { cause } : {}),
+      message:
+        "Checkout authentication is not configured for this Clerk instance.",
+    });
+  }
+
   return new BoundaryExternalServiceError({
     ...(cause instanceof Error ? { cause } : {}),
-    message:
-      cause instanceof Error
-        ? cause.message
-        : "Failed to update checkout attempt.",
+    message,
   });
 }

--- a/lib/services/checkout.ts
+++ b/lib/services/checkout.ts
@@ -76,6 +76,7 @@ type BogoSelection = {
 type CheckoutSessionType = "focus" | "flow" | "elevate";
 
 type CheckoutMutationOptions = {
+  convexAuthToken?: string;
   convexUrl?: string;
 };
 
@@ -266,16 +267,17 @@ async function executeConvexMutationWithRetry<Args extends object, Return>(
   mutation: FunctionReference<"mutation", "public", DefaultFunctionArgs>,
   args: Args,
   context: MutationContext,
-  convexUrl?: string,
+  options: CheckoutMutationOptions = {},
 ): Promise<Return> {
-  // These service calls use explicit user identifiers in args and do not attach
-  // a Clerk session token, so ctx.auth will be null inside the called mutations.
-  const resolvedConvexUrl = resolveConvexUrl(convexUrl);
+  const resolvedConvexUrl = resolveConvexUrl(options.convexUrl);
   if (resolvedConvexUrl instanceof BoundaryConfigurationError) {
     return Promise.reject(resolvedConvexUrl);
   }
 
   const convex = new ConvexHttpClient(resolvedConvexUrl);
+  if (options.convexAuthToken) {
+    convex.setAuth(options.convexAuthToken);
+  }
   let lastError: BoundaryThrowable | null = null;
   const errors: Array<{ attempt: number; error: string; timestamp: Date }> = [];
 
@@ -397,13 +399,13 @@ async function runCheckoutMutation<TResult>(
   mutation: FunctionReference<"mutation", "public", DefaultFunctionArgs>,
   args: DefaultFunctionArgs,
   context: MutationContext,
-  convexUrl?: string,
+  options: CheckoutMutationOptions = {},
 ): Promise<TResult> {
   return executeConvexMutationWithRetry<DefaultFunctionArgs, TResult>(
     mutation,
     args,
     context,
-    convexUrl,
+    options,
   );
 }
 
@@ -411,10 +413,10 @@ function runCheckoutMutationEffect<TResult>(
   mutation: FunctionReference<"mutation", "public", DefaultFunctionArgs>,
   args: DefaultFunctionArgs,
   context: MutationContext,
-  convexUrl?: string,
+  options: CheckoutMutationOptions = {},
 ): Effect.Effect<TResult, BoundaryError> {
   return Effect.tryPromise({
-    try: () => runCheckoutMutation<TResult>(mutation, args, context, convexUrl),
+    try: () => runCheckoutMutation<TResult>(mutation, args, context, options),
     catch: (cause) => checkoutMutationBoundaryError(cause as BoundaryThrowable),
   });
 }
@@ -460,7 +462,7 @@ export function handlePaymentSuccessEffect(
           userPhone,
         },
         context,
-        options.convexUrl,
+        options,
       );
     const enrollments = normalizeCartCheckoutMutationReturn(mutationResult);
 
@@ -542,7 +544,7 @@ export function handleGuestUserPaymentSuccessEffect(
           userEmail,
         },
         context,
-        options.convexUrl,
+        options,
       );
     const enrollments = normalizeCartCheckoutMutationReturn(mutationResult);
 
@@ -611,7 +613,7 @@ export function handleGuestUserPaymentSuccessWithDataEffect(
           userData,
         },
         context,
-        options.convexUrl,
+        options,
       );
     const enrollments = normalizeCartCheckoutMutationReturn(mutationResult);
 
@@ -695,7 +697,7 @@ export function handleSingleCourseEnrollmentEffect(
         userPhone,
       },
       context,
-      options.convexUrl,
+      options,
     );
     const enrollment = normalizeSingleEnrollmentMutationReturn(mutationResult);
 
@@ -776,7 +778,7 @@ export function handleGuestUserSingleEnrollmentEffect(
         userEmail,
       },
       context,
-      options.convexUrl,
+      options,
     );
     const enrollment = normalizeSingleEnrollmentMutationReturn(mutationResult);
 
@@ -851,7 +853,7 @@ export function handleSupervisedTherapyEnrollmentEffect(
         userPhone,
       },
       context,
-      options.convexUrl,
+      options,
     );
     const enrollment = normalizeSingleEnrollmentMutationReturn(mutationResult);
 
@@ -937,7 +939,7 @@ export function handleGuestUserSupervisedTherapyEnrollmentEffect(
         userPhone,
       },
       context,
-      options.convexUrl,
+      options,
     );
     const enrollment = normalizeSingleEnrollmentMutationReturn(mutationResult);
 

--- a/lib/with-rate-limit.ts
+++ b/lib/with-rate-limit.ts
@@ -20,6 +20,7 @@ interface RateLimitOptions {
   };
   errorMessage?: string;
   statusCode?: number;
+  timeoutMs?: number;
 }
 
 export function withRateLimit(
@@ -30,6 +31,7 @@ export function withRateLimit(
     limiter,
     errorMessage = "Too many requests. Please try again later.",
     statusCode = 429,
+    timeoutMs,
   } = options;
 
   return async (req: NextRequest): Promise<NextResponse> => {
@@ -39,7 +41,7 @@ export function withRateLimit(
       }
 
       // Check rate limit
-      const rateLimitResult = await checkRateLimit(req, limiter);
+      const rateLimitResult = await checkRateLimit(req, limiter, timeoutMs);
 
       // Add rate limit headers to response
       const headers = createRateLimitHeaders(
@@ -77,7 +79,9 @@ export function withRateLimit(
 
       return response;
     } catch (error) {
-      console.error("Rate limiting error:", error);
+      console.warn("Rate limiting unavailable; allowing request.", {
+        error: error instanceof Error ? error.message : String(error),
+      });
 
       // If rate limiting fails, still allow the request to proceed
       // but log the error for monitoring

--- a/test-checkout-reconciliation.js
+++ b/test-checkout-reconciliation.js
@@ -1,9 +1,11 @@
 const assert = require("node:assert/strict");
 
 async function main() {
-  const { buildCheckoutAttemptPayload, reconcileCheckoutIntent } = await import(
+  const checkoutReconciliation = await import(
     "./lib/domain/checkout-reconciliation.ts"
   );
+  const { buildCheckoutAttemptPayload, reconcileCheckoutIntent } =
+    checkoutReconciliation.default;
 
   const now = new Date("2026-05-12T12:00:00Z");
 

--- a/test-effect-boundary.ts
+++ b/test-effect-boundary.ts
@@ -67,6 +67,26 @@ test("runApiEffect converts failed effects into NextResponse JSON", async () => 
   });
 });
 
+test("rate limit wrapper fails open quickly when the limiter stalls", async () => {
+  const { NextResponse } = await import("next/server");
+  const { withRateLimit } = await import("./lib/with-rate-limit");
+  const handler = withRateLimit(async () => NextResponse.json({ ok: true }), {
+    limiter: {
+      limit: () => new Promise(() => {}),
+    },
+    timeoutMs: 5,
+  });
+
+  const startedAt = Date.now();
+  const response = await handler(
+    new Request("http://localhost/api/create-order") as never,
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true });
+  assert.ok(Date.now() - startedAt < 500);
+});
+
 test("boundaryErrorToHttp maps external service errors to gateway failures", () => {
   const http = boundaryErrorToHttp(
     new BoundaryExternalServiceError({

--- a/test-effect-boundary.ts
+++ b/test-effect-boundary.ts
@@ -271,3 +271,16 @@ test("checkout attempt boundary normalizes legacy Convex ok tuples", async () =>
     },
   });
 });
+
+test("checkout attempt boundary maps Convex auth provider mismatch to configuration error", () => {
+  const source = readFileSync(
+    "lib/services/checkout-attempts.server.ts",
+    "utf8",
+  );
+
+  assert.match(source, /No auth provider found matching the given token/);
+  assert.match(
+    source,
+    /Checkout authentication is not configured for this Clerk instance\./,
+  );
+});

--- a/test-effect-boundary.ts
+++ b/test-effect-boundary.ts
@@ -154,6 +154,21 @@ test("create order boundary maps missing cart intent through the Effect boundary
   });
 });
 
+test("create order route can authorize checkout attempts with a Convex auth token fallback", () => {
+  const routeSource = readFileSync("app/api/create-order/route.ts", "utf8");
+  const checkoutAttemptSource = readFileSync(
+    "lib/services/checkout-attempts.server.ts",
+    "utf8",
+  );
+
+  assert.match(routeSource, /getToken\(\{\s*template: "convex"\s*\}\)/);
+  assert.match(routeSource, /convexAuthToken/);
+  assert.match(
+    checkoutAttemptSource,
+    /convex\.setAuth\(options\.convexAuthToken\)/,
+  );
+});
+
 test("checkout service exposes an Effect implementation for authenticated cart checkout", () => {
   const source = readFileSync("lib/services/checkout.ts", "utf8");
   const checkoutSlice = source.slice(

--- a/test-effect-boundary.ts
+++ b/test-effect-boundary.ts
@@ -145,6 +145,24 @@ test("checkout service exposes an Effect implementation for authenticated cart c
   assert.doesNotMatch(checkoutSlice, /try\s*\{/);
 });
 
+test("authenticated checkout finalization forwards Clerk auth to Convex", () => {
+  const checkoutSource = readFileSync("lib/services/checkout.ts", "utf8");
+  const paymentActionSource = readFileSync("app/actions/payment.ts", "utf8");
+  const cartSource = readFileSync("components/CartClient.tsx", "utf8");
+  const cartCheckoutCall = cartSource.slice(
+    cartSource.indexOf("const result = await handlePaymentSuccess("),
+    cartSource.indexOf(
+      "if (!result.success)",
+      cartSource.indexOf("const result = await handlePaymentSuccess("),
+    ),
+  );
+
+  assert.match(checkoutSource, /convex\.setAuth\(options\.convexAuthToken\)/);
+  assert.match(paymentActionSource, /await auth\(\)/);
+  assert.match(paymentActionSource, /getToken\(\{\s*template: "convex"\s*\}\)/);
+  assert.doesNotMatch(cartCheckoutCall, /user\.id/);
+});
+
 test("checkout service exposes Effect implementations for all payment action wrappers", () => {
   const source = readFileSync("lib/services/checkout.ts", "utf8");
   const names = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fix QR/cart checkout enrollment finalization so authenticated server actions derive Clerk identity server-side and forward the Convex JWT to authenticated Convex mutations. Also make API rate limiting fail open quickly when Upstash is unavailable, and let create-order use authenticated Convex JWT fallback when `CHECKOUT_SERVER_SECRET` is absent.

## Screenshots / Recordings

- Browser testing reached signed-in `Go to Payment`, but this local/cloud-agent environment cannot complete QR checkout because Convex rejects the current Clerk token issuer (`No auth provider found matching the given token`) and the matching `CHECKOUT_SERVER_SECRET` is not present locally.

## Checklist

- [x] No business logic behavior changed (or documented exceptions)
- [ ] IA updated with rationale
- [ ] Visual tokens defined and applied consistently
- [ ] Components accessible (focus, ARIA, roles, labels, error messaging)
- [ ] Keyboard navigation verified for core flows
- [ ] Motion respects reduced motion preference
- [ ] Core Web Vitals green on key routes; Lighthouse ≥ 95 (attach reports)
- [ ] Images/fonts/CSS optimized
- [ ] Mobile responsiveness verified
- [x] Tests updated/added for critical checkout finalization, create-order auth fallback, and rate-limit fail-open behavior
- [ ] Docs updated (`docs/ux-overhaul-notes.md`, `README`, `CONTRIBUTING` if needed)
- [x] Backend Adjustments: authenticated checkout finalization now forwards Clerk Convex JWT to Convex mutations; create-order can fall back to Clerk Convex JWT; rate-limit failures now allow requests after a bounded timeout.

## Notes for Reviewers

- Root cause of original Vercel finalization failure: finalization used `ConvexHttpClient` without `setAuth()`, while `handleCartCheckout` requires `ctx.auth.getUserIdentity()` to match the buyer.
- Signed-in local checkout test now reaches `/api/create-order`, but this agent environment blocks completion because:
  - `CHECKOUT_SERVER_SECRET` is absent in the Next process.
  - `CLERK_JWT_ISSUER_DOMAIN` is absent / deployed Convex auth does not match the current Clerk token issuer, producing `No auth provider found matching the given token`.
- The create-order code now supports both auth routes: shared server secret when configured, or Clerk Convex JWT fallback when Convex auth is configured.
- Guest checkout paths are unchanged.
- Authenticated cart, single-course, and supervised therapy action wrappers no longer trust client-supplied Clerk user IDs.
- Restored the checkout reconciliation smoke test import so `npm run test:checkout-reconciliation` runs again.

Verified:
- Signed-in browser click: `Go to Payment` reaches `/api/create-order`; QR does not open in this environment due the Convex/Clerk auth configuration blocker above.
- `npm run test:effect-boundary`
- `npm run test:checkout-reconciliation`
- `npm run lint`
- `npm run type-check`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f71a8d5-1896-40ff-882c-ae3e5941ca3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f71a8d5-1896-40ff-882c-ae3e5941ca3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

