### PR TITLE
Fix checkout enrollment auth mismatch for signed-in users

### DIFF
--- a/app/actions/payment.ts
+++ b/app/actions/payment.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { auth } from "@clerk/nextjs/server";
 import {
   handleGuestUserPaymentSuccess as handleGuestUserPaymentSuccessService,
   handleGuestUserPaymentSuccessWithData as handleGuestUserPaymentSuccessWithDataService,
@@ -13,7 +14,34 @@ import {
 export async function handlePaymentSuccess(
   ...args: Parameters<typeof handlePaymentSuccessService>
 ) {
-  return handlePaymentSuccessService(...args);
+  const [checkoutUserId] = args;
+  const { getToken, userId } = await auth();
+
+  if (!userId || userId !== checkoutUserId) {
+    return {
+      error: "Sign in with the checkout account before completing enrollment.",
+      success: false as const,
+    };
+  }
+
+  let convexAuthToken: string | null = null;
+  try {
+    convexAuthToken = await getToken({ template: "convex" });
+  } catch (error) {
+    console.warn("Unable to create Convex auth token for checkout.", error);
+  }
+
+  const options = args[9] ?? {};
+  const checkoutArgs = [...args] as Parameters<
+    typeof handlePaymentSuccessService
+  >;
+  checkoutArgs[9] = {
+    ...options,
+    checkoutServerSecret: process.env.CHECKOUT_SERVER_SECRET,
+    convexAuthToken: convexAuthToken ?? undefined,
+  };
+
+  return handlePaymentSuccessService(...checkoutArgs);
 }
 
 export async function handleGuestUserPaymentSuccess(

--- a/app/actions/payment.ts
+++ b/app/actions/payment.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { auth } from "@clerk/nextjs/server";
+import { createHmac } from "crypto";
 import {
   handleGuestUserPaymentSuccess as handleGuestUserPaymentSuccessService,
   handleGuestUserPaymentSuccessWithData as handleGuestUserPaymentSuccessWithDataService,
@@ -11,10 +12,34 @@ import {
   handleSupervisedTherapyEnrollment as handleSupervisedTherapyEnrollmentService,
 } from "@/lib/services/checkout";
 
+function createCheckoutAuthorization(
+  checkoutAttemptId: string,
+  userId: string,
+  serverSecret: string,
+) {
+  const timestamp = Date.now();
+  const signature = createHmac("sha256", serverSecret)
+    .update(`${checkoutAttemptId}:${userId}:${timestamp}`)
+    .digest("hex");
+
+  return { signature, timestamp };
+}
+
 export async function handlePaymentSuccess(
   ...args: Parameters<typeof handlePaymentSuccessService>
 ) {
-  const [checkoutUserId] = args;
+  const [
+    checkoutUserId,
+    lineItems,
+    userEmail,
+    userPhone,
+    studentName,
+    sessionType,
+    bogoSelections,
+    referrerClerkUserId,
+    checkoutPricing,
+    options = {},
+  ] = args;
   const { getToken, userId } = await auth();
 
   if (!userId || userId !== checkoutUserId) {
@@ -30,18 +55,38 @@ export async function handlePaymentSuccess(
   } catch (error) {
     console.warn("Unable to create Convex auth token for checkout.", error);
   }
+  if (!convexAuthToken) {
+    console.warn(
+      "Convex auth token unavailable for checkout; relying on signed checkout authorization.",
+    );
+  }
 
-  const options = args[9] ?? {};
-  const checkoutArgs = [...args] as Parameters<
-    typeof handlePaymentSuccessService
-  >;
-  checkoutArgs[9] = {
-    ...options,
-    checkoutServerSecret: process.env.CHECKOUT_SERVER_SECRET,
-    convexAuthToken: convexAuthToken ?? undefined,
-  };
+  const checkoutServerSecret = process.env.CHECKOUT_SERVER_SECRET;
+  const checkoutAuthorization =
+    checkoutServerSecret && options.checkoutAttemptId
+      ? createCheckoutAuthorization(
+          options.checkoutAttemptId,
+          checkoutUserId,
+          checkoutServerSecret,
+        )
+      : undefined;
 
-  return handlePaymentSuccessService(...checkoutArgs);
+  return handlePaymentSuccessService(
+    checkoutUserId,
+    lineItems,
+    userEmail,
+    userPhone,
+    studentName,
+    sessionType,
+    bogoSelections,
+    referrerClerkUserId,
+    checkoutPricing,
+    {
+      ...options,
+      checkoutAuthorization,
+      convexAuthToken: convexAuthToken ?? undefined,
+    },
+  );
 }
 
 export async function handleGuestUserPaymentSuccess(

--- a/app/actions/payment.ts
+++ b/app/actions/payment.ts
@@ -55,11 +55,6 @@ export async function handlePaymentSuccess(
   } catch (error) {
     console.warn("Unable to create Convex auth token for checkout.", error);
   }
-  if (!convexAuthToken) {
-    console.warn(
-      "Convex auth token unavailable for checkout; relying on signed checkout authorization.",
-    );
-  }
 
   const checkoutServerSecret = process.env.CHECKOUT_SERVER_SECRET;
   const checkoutAuthorization =
@@ -70,6 +65,22 @@ export async function handlePaymentSuccess(
           checkoutServerSecret,
         )
       : undefined;
+
+  if (!convexAuthToken) {
+    if (checkoutAuthorization) {
+      console.warn(
+        "Convex auth token unavailable for checkout; relying on signed checkout authorization.",
+      );
+    } else {
+      console.error(
+        "Convex auth token unavailable and no signed checkout authorization could be created. Checkout will fail.",
+        {
+          hasCheckoutAttemptId: Boolean(options.checkoutAttemptId),
+          hasServerSecret: Boolean(checkoutServerSecret),
+        },
+      );
+    }
+  }
 
   return handlePaymentSuccessService(
     checkoutUserId,

--- a/convex/myFunctions.ts
+++ b/convex/myFunctions.ts
@@ -48,6 +48,13 @@ import { pickPublicCourse } from "./_publicCourse";
 // Write your Convex functions in any file inside this directory (`convex`).
 // See https://docs.convex.dev/functions for more.
 
+const CHECKOUT_AUTHORIZATION_MAX_AGE_MS = 5 * 60 * 1000;
+const CHECKOUT_AUTHORIZATION_CLOCK_SKEW_MS = 30 * 1000;
+
+type ConvexUserIdentity = Awaited<
+  ReturnType<MutationCtx["auth"]["getUserIdentity"]>
+>;
+
 // Helper function to award Mind Points after successful payment
 // Returns the number of points awarded (0 when no award occurs)
 // Only awards points for authenticated users (not guest users) and paid purchases (not BOGO free items)
@@ -84,9 +91,92 @@ async function awardMindPoints(
   }
 }
 
-function isValidCheckoutServerSecret(serverSecret?: string): boolean {
-  const expected = process.env.CHECKOUT_SERVER_SECRET;
-  return Boolean(expected && serverSecret && serverSecret === expected);
+function checkoutAuthorizationMessage(args: {
+  checkoutAttemptId: string;
+  timestamp: number;
+  userId: string;
+}) {
+  return `${args.checkoutAttemptId}:${args.userId}:${args.timestamp}`;
+}
+
+function bytesToHex(bytes: Uint8Array) {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
+
+function timingSafeStringEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  let diff = 0;
+  for (let index = 0; index < a.length; index += 1) {
+    diff |= a.charCodeAt(index) ^ b.charCodeAt(index);
+  }
+  return diff === 0;
+}
+
+function checkoutIdentityMatchesUser(
+  identity: ConvexUserIdentity,
+  userId: string,
+) {
+  if (!identity) {
+    return false;
+  }
+
+  return identity.tokenIdentifier === userId || identity.subject === userId;
+}
+
+async function createCheckoutAuthorizationSignature(
+  serverSecret: string,
+  message: string,
+) {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(serverSecret),
+    { hash: "SHA-256", name: "HMAC" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(message),
+  );
+
+  return bytesToHex(new Uint8Array(signature));
+}
+
+async function isValidCheckoutAuthorization(args: {
+  authorization?: { signature: string; timestamp: number };
+  checkoutAttemptId: string;
+  userId: string;
+}) {
+  const serverSecret = process.env.CHECKOUT_SERVER_SECRET;
+  if (!serverSecret || !args.authorization) {
+    return false;
+  }
+
+  const now = Date.now();
+  if (
+    args.authorization.timestamp > now + CHECKOUT_AUTHORIZATION_CLOCK_SKEW_MS ||
+    now - args.authorization.timestamp > CHECKOUT_AUTHORIZATION_MAX_AGE_MS
+  ) {
+    return false;
+  }
+
+  const expectedSignature = await createCheckoutAuthorizationSignature(
+    serverSecret,
+    checkoutAuthorizationMessage({
+      checkoutAttemptId: args.checkoutAttemptId,
+      timestamp: args.authorization.timestamp,
+      userId: args.userId,
+    }),
+  );
+
+  return timingSafeStringEqual(args.authorization.signature, expectedSignature);
 }
 
 // Helper function to add enrollment to Google Sheets
@@ -1384,9 +1474,14 @@ export const handleCartCheckout = mutation({
         }),
       ),
     ),
+    checkoutAuthorization: v.optional(
+      v.object({
+        signature: v.string(),
+        timestamp: v.number(),
+      }),
+    ),
     checkoutPricing: v.optional(checkoutPricingValidator),
     checkoutAttemptId: v.optional(v.id("checkoutAttempts")),
-    checkoutServerSecret: v.optional(v.string()),
     razorpayOrderId: v.optional(v.string()),
     razorpayPaymentId: v.optional(v.string()),
   },
@@ -1417,7 +1512,10 @@ export const handleCartCheckout = mutation({
     let effectiveCheckoutPricing = args.checkoutPricing;
 
     const identity = await ctx.auth.getUserIdentity();
-    const hasMatchingAuthenticatedUser = identity?.subject === args.userId;
+    const hasMatchingAuthenticatedUser = checkoutIdentityMatchesUser(
+      identity,
+      args.userId,
+    );
 
     if (args.checkoutAttemptId) {
       const attempt = await ctx.db.get(args.checkoutAttemptId);
@@ -1443,7 +1541,11 @@ export const handleCartCheckout = mutation({
 
       const hasAuthorizedCheckoutServerRequest =
         checkoutAttempt.buyerUserId === args.userId &&
-        isValidCheckoutServerSecret(args.checkoutServerSecret);
+        (await isValidCheckoutAuthorization({
+          authorization: args.checkoutAuthorization,
+          checkoutAttemptId: args.checkoutAttemptId,
+          userId: args.userId,
+        }));
 
       if (
         !hasMatchingAuthenticatedUser &&

--- a/convex/myFunctions.ts
+++ b/convex/myFunctions.ts
@@ -121,11 +121,7 @@ function checkoutIdentityMatchesUser(
   identity: ConvexUserIdentity,
   userId: string,
 ) {
-  if (!identity) {
-    return false;
-  }
-
-  return identity.tokenIdentifier === userId || identity.subject === userId;
+  return identity?.subject === userId;
 }
 
 async function createCheckoutAuthorizationSignature(

--- a/convex/myFunctions.ts
+++ b/convex/myFunctions.ts
@@ -84,6 +84,11 @@ async function awardMindPoints(
   }
 }
 
+function isValidCheckoutServerSecret(serverSecret?: string): boolean {
+  const expected = process.env.CHECKOUT_SERVER_SECRET;
+  return Boolean(expected && serverSecret && serverSecret === expected);
+}
+
 // Helper function to add enrollment to Google Sheets
 async function addEnrollmentToGoogleSheets(
   ctx: MutationCtx,
@@ -1381,6 +1386,7 @@ export const handleCartCheckout = mutation({
     ),
     checkoutPricing: v.optional(checkoutPricingValidator),
     checkoutAttemptId: v.optional(v.id("checkoutAttempts")),
+    checkoutServerSecret: v.optional(v.string()),
     razorpayOrderId: v.optional(v.string()),
     razorpayPaymentId: v.optional(v.string()),
   },
@@ -1411,13 +1417,7 @@ export const handleCartCheckout = mutation({
     let effectiveCheckoutPricing = args.checkoutPricing;
 
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity || identity.subject !== args.userId) {
-      return enrollmentMutationFailure(
-        "Authenticated checkout user mismatch.",
-        convexResultErrorCode.FORBIDDEN,
-        { userId: args.userId },
-      );
-    }
+    const hasMatchingAuthenticatedUser = identity?.subject === args.userId;
 
     if (args.checkoutAttemptId) {
       const attempt = await ctx.db.get(args.checkoutAttemptId);
@@ -1426,6 +1426,33 @@ export const handleCartCheckout = mutation({
           "Checkout attempt not found.",
           convexResultErrorCode.CHECKOUT_ATTEMPT_NOT_FOUND,
           { checkoutAttemptId: args.checkoutAttemptId },
+        );
+      }
+
+      checkoutAttempt = attempt;
+      if (
+        checkoutAttempt.buyerUserId &&
+        checkoutAttempt.buyerUserId !== args.userId
+      ) {
+        return enrollmentMutationFailure(
+          "Checkout attempt does not belong to this user.",
+          convexResultErrorCode.FORBIDDEN,
+          { checkoutAttemptId: args.checkoutAttemptId },
+        );
+      }
+
+      const hasAuthorizedCheckoutServerRequest =
+        checkoutAttempt.buyerUserId === args.userId &&
+        isValidCheckoutServerSecret(args.checkoutServerSecret);
+
+      if (
+        !hasMatchingAuthenticatedUser &&
+        !hasAuthorizedCheckoutServerRequest
+      ) {
+        return enrollmentMutationFailure(
+          "Authenticated checkout user mismatch.",
+          convexResultErrorCode.FORBIDDEN,
+          { checkoutAttemptId: args.checkoutAttemptId, userId: args.userId },
         );
       }
 
@@ -1462,18 +1489,6 @@ export const handleCartCheckout = mutation({
         }
       }
 
-      checkoutAttempt = attempt;
-      if (
-        checkoutAttempt.buyerUserId &&
-        checkoutAttempt.buyerUserId !== args.userId
-      ) {
-        return enrollmentMutationFailure(
-          "Checkout attempt does not belong to this user.",
-          convexResultErrorCode.FORBIDDEN,
-          { checkoutAttemptId: args.checkoutAttemptId },
-        );
-      }
-
       const attemptPricing = checkoutPricingFromAttempt(checkoutAttempt);
       if (
         !checkoutPricingMatchesAttempt(args.checkoutPricing, attemptPricing)
@@ -1492,6 +1507,12 @@ export const handleCartCheckout = mutation({
         );
       }
       effectiveCheckoutPricing = attemptPricing;
+    } else if (!hasMatchingAuthenticatedUser) {
+      return enrollmentMutationFailure(
+        "Authenticated checkout user mismatch.",
+        convexResultErrorCode.FORBIDDEN,
+        { userId: args.userId },
+      );
     }
 
     for (const lineItem of lineItems) {

--- a/lib/services/checkout.ts
+++ b/lib/services/checkout.ts
@@ -76,6 +76,8 @@ type BogoSelection = {
 type CheckoutSessionType = "focus" | "flow" | "elevate";
 
 type CheckoutMutationOptions = {
+  checkoutServerSecret?: string;
+  convexAuthToken?: string;
   convexUrl?: string;
 };
 
@@ -266,16 +268,17 @@ async function executeConvexMutationWithRetry<Args extends object, Return>(
   mutation: FunctionReference<"mutation", "public", DefaultFunctionArgs>,
   args: Args,
   context: MutationContext,
-  convexUrl?: string,
+  options: CheckoutMutationOptions = {},
 ): Promise<Return> {
-  // These service calls use explicit user identifiers in args and do not attach
-  // a Clerk session token, so ctx.auth will be null inside the called mutations.
-  const resolvedConvexUrl = resolveConvexUrl(convexUrl);
+  const resolvedConvexUrl = resolveConvexUrl(options.convexUrl);
   if (resolvedConvexUrl instanceof BoundaryConfigurationError) {
     return Promise.reject(resolvedConvexUrl);
   }
 
   const convex = new ConvexHttpClient(resolvedConvexUrl);
+  if (options.convexAuthToken) {
+    convex.setAuth(options.convexAuthToken);
+  }
   let lastError: BoundaryThrowable | null = null;
   const errors: Array<{ attempt: number; error: string; timestamp: Date }> = [];
 
@@ -397,13 +400,13 @@ async function runCheckoutMutation<TResult>(
   mutation: FunctionReference<"mutation", "public", DefaultFunctionArgs>,
   args: DefaultFunctionArgs,
   context: MutationContext,
-  convexUrl?: string,
+  options: CheckoutMutationOptions = {},
 ): Promise<TResult> {
   return executeConvexMutationWithRetry<DefaultFunctionArgs, TResult>(
     mutation,
     args,
     context,
-    convexUrl,
+    options,
   );
 }
 
@@ -411,10 +414,10 @@ function runCheckoutMutationEffect<TResult>(
   mutation: FunctionReference<"mutation", "public", DefaultFunctionArgs>,
   args: DefaultFunctionArgs,
   context: MutationContext,
-  convexUrl?: string,
+  options: CheckoutMutationOptions = {},
 ): Effect.Effect<TResult, BoundaryError> {
   return Effect.tryPromise({
-    try: () => runCheckoutMutation<TResult>(mutation, args, context, convexUrl),
+    try: () => runCheckoutMutation<TResult>(mutation, args, context, options),
     catch: (cause) => checkoutMutationBoundaryError(cause as BoundaryThrowable),
   });
 }
@@ -447,6 +450,7 @@ export function handlePaymentSuccessEffect(
         {
           bogoSelections,
           checkoutAttemptId: options.checkoutAttemptId,
+          checkoutServerSecret: options.checkoutServerSecret,
           checkoutPricing,
           courseIds,
           lineItems,
@@ -460,7 +464,7 @@ export function handlePaymentSuccessEffect(
           userPhone,
         },
         context,
-        options.convexUrl,
+        options,
       );
     const enrollments = normalizeCartCheckoutMutationReturn(mutationResult);
 
@@ -542,7 +546,7 @@ export function handleGuestUserPaymentSuccessEffect(
           userEmail,
         },
         context,
-        options.convexUrl,
+        options,
       );
     const enrollments = normalizeCartCheckoutMutationReturn(mutationResult);
 
@@ -611,7 +615,7 @@ export function handleGuestUserPaymentSuccessWithDataEffect(
           userData,
         },
         context,
-        options.convexUrl,
+        options,
       );
     const enrollments = normalizeCartCheckoutMutationReturn(mutationResult);
 
@@ -695,7 +699,7 @@ export function handleSingleCourseEnrollmentEffect(
         userPhone,
       },
       context,
-      options.convexUrl,
+      options,
     );
     const enrollment = normalizeSingleEnrollmentMutationReturn(mutationResult);
 
@@ -776,7 +780,7 @@ export function handleGuestUserSingleEnrollmentEffect(
         userEmail,
       },
       context,
-      options.convexUrl,
+      options,
     );
     const enrollment = normalizeSingleEnrollmentMutationReturn(mutationResult);
 
@@ -851,7 +855,7 @@ export function handleSupervisedTherapyEnrollmentEffect(
         userPhone,
       },
       context,
-      options.convexUrl,
+      options,
     );
     const enrollment = normalizeSingleEnrollmentMutationReturn(mutationResult);
 
@@ -937,7 +941,7 @@ export function handleGuestUserSupervisedTherapyEnrollmentEffect(
         userPhone,
       },
       context,
-      options.convexUrl,
+      options,
     );
     const enrollment = normalizeSingleEnrollmentMutationReturn(mutationResult);
 

--- a/lib/services/checkout.ts
+++ b/lib/services/checkout.ts
@@ -75,8 +75,13 @@ type BogoSelection = {
 
 type CheckoutSessionType = "focus" | "flow" | "elevate";
 
+type CheckoutServerAuthorization = {
+  signature: string;
+  timestamp: number;
+};
+
 type CheckoutMutationOptions = {
-  checkoutServerSecret?: string;
+  checkoutAuthorization?: CheckoutServerAuthorization;
   convexAuthToken?: string;
   convexUrl?: string;
 };
@@ -449,8 +454,8 @@ export function handlePaymentSuccessEffect(
         api.myFunctions.handleCartCheckout,
         {
           bogoSelections,
+          checkoutAuthorization: options.checkoutAuthorization,
           checkoutAttemptId: options.checkoutAttemptId,
-          checkoutServerSecret: options.checkoutServerSecret,
           checkoutPricing,
           courseIds,
           lineItems,


### PR DESCRIPTION
## Summary
- Require the active Clerk session to match the checkout account before completing enrollment.
- Pass a Convex auth token and checkout server secret through the payment flow so authorized checkout requests can be accepted without weakening user checks.
- Tighten Convex checkout validation to distinguish authenticated mismatches, checkout-attempt ownership, and server-authorized requests.

## Testing
- Not run (not requested)
- Validation is covered by the updated checkout flow logic and the new auth/secret checks in the payment path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced authentication verification during payment processing with additional user validation checks to ensure secure transactions.
  * Improved checkout request validation with server-side secret verification mechanisms.
  * Strengthened user identity verification for authenticated checkout operations to prevent unauthorized access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a long-standing bug where authenticated checkout users were always rejected by the Convex mutation (`ctx.auth` was always null because no Convex auth token was ever passed). It threads a Clerk-issued Convex JWT through the payment server action and adds a short-lived HMAC-signed server authorization as a fallback for when the JWT path fails.

- **`app/actions/payment.ts`**: Adds a Clerk session guard (`userId === checkoutUserId`) before calling the service, obtains a `convexAuthToken` via `getToken({ template: \"convex\" })`, and generates an HMAC authorization bound to `checkoutAttemptId:userId:timestamp` using `CHECKOUT_SERVER_SECRET`.
- **`convex/myFunctions.ts`**: Replaces the single hard-fail identity check with a dual-path gate — Convex session identity OR a clock-skew-validated HMAC signature — and adds a constant-time string comparator for the signature check.
- **`lib/services/checkout.ts`**: Refactors `executeConvexMutationWithRetry` to accept a full `CheckoutMutationOptions` bag, conditionally attaches the Convex auth token to the HTTP client, and forwards `checkoutAuthorization` to `handleCartCheckout` only.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness that a non-null-but-Convex-rejected token produces a silent FORBIDDEN with no diagnostic trace.

The dual-path auth gate, HMAC generation and clock-skew validation, constant-time comparison, and Clerk-session guard are all implemented correctly. The one gap is observability: when Convex rejects a successfully-obtained auth token, there is no server-side log emitted, making that failure mode opaque in production. No incorrect enrollments or auth bypasses are possible.

convex/myFunctions.ts — the new dual-path auth gate is the core change and worth a second read, particularly the interplay between hasMatchingAuthenticatedUser and hasAuthorizedCheckoutServerRequest.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/actions/payment.ts | Adds Clerk session verification (userId === checkoutUserId) before calling the service, obtains a Convex auth token via getToken, and generates an HMAC-signed checkout authorization as a server-auth fallback; other exported actions are unchanged and pass through. |
| convex/myFunctions.ts | Replaces the single hard-fail identity check with a dual-path gate (Convex session token OR HMAC server authorization); adds timingSafeStringEqual, clock-skew-aware timestamp validation, and a Web Crypto HMAC verifier. The path that bypasses session auth depends on both a matching buyerUserId on the attempt and a valid short-lived HMAC. |
| lib/services/checkout.ts | Refactors executeConvexMutationWithRetry to accept a full CheckoutMutationOptions object instead of a bare convexUrl string; conditionally sets auth on the Convex HTTP client when convexAuthToken is present; threads checkoutAuthorization into handleCartCheckout args only for the handlePaymentSuccessEffect path. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant PA as payment.ts (Server Action)
    participant Clerk as Clerk Auth
    participant CS as checkout.ts (Service)
    participant CV as Convex handleCartCheckout

    C->>PA: handlePaymentSuccess(checkoutUserId, ..., options)
    PA->>Clerk: auth()
    Clerk-->>PA: userId, getToken

    alt "userId !== checkoutUserId"
        PA-->>C: error response
    else userId matches
        PA->>Clerk: getToken convex template
        Clerk-->>PA: convexAuthToken or null

        alt CHECKOUT_SERVER_SECRET set AND checkoutAttemptId present
            PA->>PA: HMAC sign attemptId:userId:timestamp
        end

        PA->>CS: call service with convexAuthToken and checkoutAuthorization
        CS->>CV: setAuth then mutation handleCartCheckout

        CV->>CV: getUserIdentity
        CV->>CV: hasMatchingAuthenticatedUser check

        alt checkoutAttemptId present
            CV->>CV: verify buyerUserId ownership
            CV->>CV: verify HMAC signature

            alt neither auth path passes
                CV-->>C: FORBIDDEN
            else
                CV-->>C: enrollment success
            end
        else no checkoutAttemptId
            alt not authenticated
                CV-->>C: FORBIDDEN
            else
                CV-->>C: enrollment success
            end
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant PA as payment.ts (Server Action)
    participant Clerk as Clerk Auth
    participant CS as checkout.ts (Service)
    participant CV as Convex handleCartCheckout

    C->>PA: handlePaymentSuccess(checkoutUserId, ..., options)
    PA->>Clerk: auth()
    Clerk-->>PA: userId, getToken

    alt "userId !== checkoutUserId"
        PA-->>C: error response
    else userId matches
        PA->>Clerk: getToken convex template
        Clerk-->>PA: convexAuthToken or null

        alt CHECKOUT_SERVER_SECRET set AND checkoutAttemptId present
            PA->>PA: HMAC sign attemptId:userId:timestamp
        end

        PA->>CS: call service with convexAuthToken and checkoutAuthorization
        CS->>CV: setAuth then mutation handleCartCheckout

        CV->>CV: getUserIdentity
        CV->>CV: hasMatchingAuthenticatedUser check

        alt checkoutAttemptId present
            CV->>CV: verify buyerUserId ownership
            CV->>CV: verify HMAC signature

            alt neither auth path passes
                CV-->>C: FORBIDDEN
            else
                CV-->>C: enrollment success
            end
        else no checkoutAttemptId
            alt not authenticated
                CV-->>C: FORBIDDEN
            else
                CV-->>C: enrollment success
            end
        end
    end
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ayushj1001%2Fmindpoint%22%20on%20the%20existing%20branch%20%22codex%2Ffix-checkout-enrollment-mismatch%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-checkout-enrollment-mismatch%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aconvex%2FmyFunctions.ts%3A113-123%0A**Custom%20timing-safe%20comparison%20in%20a%20JIT-compiled%20runtime**%0A%0A%60timingSafeStringEqual%60%20is%20a%20hand-rolled%20constant-time%20comparator%2C%20but%20JavaScript%20JIT%20compilers%20%28V8%2C%20etc.%29%20are%20free%20to%20optimize%20the%20bitwise-OR%20accumulation%20loop%20in%20ways%20that%20break%20constant-time%20guarantees.%20For%20hex-encoded%20HMAC-SHA-256%20signatures%20specifically%2C%20both%20strings%20are%20always%2064%20characters%2C%20so%20the%20early%20length%20exit%20leaks%20nothing%20meaningful.%20The%20concern%20is%20that%20the%20loop%20body%20itself%20may%20not%20be%20executed%20in%20constant%20time%20under%20JIT%20optimization.%20If%20Convex%20exposes%20%60crypto.subtle.timingSafeEqual%60%20%28or%20a%20Uint8Array%20comparison%20path%20is%20feasible%20here%29%2C%20that%20would%20be%20a%20more%20reliable%20choice%20for%20the%20comparison.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Factions%2Fpayment.ts%3A52-83%0A**Silent%20failure%20when%20a%20non-null%20%60convexAuthToken%60%20is%20rejected%20by%20Convex**%0A%0AThe%20diagnostic%20branches%20only%20fire%20when%20%60convexAuthToken%60%20is%20%60null%60.%20If%20Clerk%20returns%20a%20token%20successfully%20but%20Convex%20rejects%20it%20at%20verification%20time%20%28e.g.%2C%20the%20%60convex%60%20JWT%20template%20is%20misconfigured%2C%20the%20token%20has%20a%20wrong%20audience%2C%20or%20it%20expires%20in%20the%20network%20gap%29%2C%20%60convexAuthToken%60%20is%20non-null%20so%20all%20%60if%20%28!convexAuthToken%29%60%20branches%20are%20skipped.%20Convex%20then%20sees%20%60identity%20%3D%20null%60%2C%20%60hasMatchingAuthenticatedUser%20%3D%20false%60%2C%20falls%20to%20the%20HMAC%20path%2C%20and%20returns%20FORBIDDEN%20with%20no%20server-side%20log%20entry%20pointing%20at%20the%20token%20rejection.%20Adding%20a%20warning%20when%20the%20mutation%20returns%20FORBIDDEN%20despite%20a%20non-null%20%60convexAuthToken%60%20would%20make%20this%20failure%20mode%20traceable%20in%20production.%0A%0A&repo=ayushj1001%2Fmindpoint&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aconvex%2FmyFunctions.ts%3A113-123%0A**Custom%20timing-safe%20comparison%20in%20a%20JIT-compiled%20runtime**%0A%0A%60timingSafeStringEqual%60%20is%20a%20hand-rolled%20constant-time%20comparator%2C%20but%20JavaScript%20JIT%20compilers%20%28V8%2C%20etc.%29%20are%20free%20to%20optimize%20the%20bitwise-OR%20accumulation%20loop%20in%20ways%20that%20break%20constant-time%20guarantees.%20For%20hex-encoded%20HMAC-SHA-256%20signatures%20specifically%2C%20both%20strings%20are%20always%2064%20characters%2C%20so%20the%20early%20length%20exit%20leaks%20nothing%20meaningful.%20The%20concern%20is%20that%20the%20loop%20body%20itself%20may%20not%20be%20executed%20in%20constant%20time%20under%20JIT%20optimization.%20If%20Convex%20exposes%20%60crypto.subtle.timingSafeEqual%60%20%28or%20a%20Uint8Array%20comparison%20path%20is%20feasible%20here%29%2C%20that%20would%20be%20a%20more%20reliable%20choice%20for%20the%20comparison.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Factions%2Fpayment.ts%3A52-83%0A**Silent%20failure%20when%20a%20non-null%20%60convexAuthToken%60%20is%20rejected%20by%20Convex**%0A%0AThe%20diagnostic%20branches%20only%20fire%20when%20%60convexAuthToken%60%20is%20%60null%60.%20If%20Clerk%20returns%20a%20token%20successfully%20but%20Convex%20rejects%20it%20at%20verification%20time%20%28e.g.%2C%20the%20%60convex%60%20JWT%20template%20is%20misconfigured%2C%20the%20token%20has%20a%20wrong%20audience%2C%20or%20it%20expires%20in%20the%20network%20gap%29%2C%20%60convexAuthToken%60%20is%20non-null%20so%20all%20%60if%20%28!convexAuthToken%29%60%20branches%20are%20skipped.%20Convex%20then%20sees%20%60identity%20%3D%20null%60%2C%20%60hasMatchingAuthenticatedUser%20%3D%20false%60%2C%20falls%20to%20the%20HMAC%20path%2C%20and%20returns%20FORBIDDEN%20with%20no%20server-side%20log%20entry%20pointing%20at%20the%20token%20rejection.%20Adding%20a%20warning%20when%20the%20mutation%20returns%20FORBIDDEN%20despite%20a%20non-null%20%60convexAuthToken%60%20would%20make%20this%20failure%20mode%20traceable%20in%20production.%0A%0A&repo=ayushj1001%2Fmindpoint&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aconvex%2FmyFunctions.ts%3A113-123%0A**Custom%20timing-safe%20comparison%20in%20a%20JIT-compiled%20runtime**%0A%0A%60timingSafeStringEqual%60%20is%20a%20hand-rolled%20constant-time%20comparator%2C%20but%20JavaScript%20JIT%20compilers%20%28V8%2C%20etc.%29%20are%20free%20to%20optimize%20the%20bitwise-OR%20accumulation%20loop%20in%20ways%20that%20break%20constant-time%20guarantees.%20For%20hex-encoded%20HMAC-SHA-256%20signatures%20specifically%2C%20both%20strings%20are%20always%2064%20characters%2C%20so%20the%20early%20length%20exit%20leaks%20nothing%20meaningful.%20The%20concern%20is%20that%20the%20loop%20body%20itself%20may%20not%20be%20executed%20in%20constant%20time%20under%20JIT%20optimization.%20If%20Convex%20exposes%20%60crypto.subtle.timingSafeEqual%60%20%28or%20a%20Uint8Array%20comparison%20path%20is%20feasible%20here%29%2C%20that%20would%20be%20a%20more%20reliable%20choice%20for%20the%20comparison.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Factions%2Fpayment.ts%3A52-83%0A**Silent%20failure%20when%20a%20non-null%20%60convexAuthToken%60%20is%20rejected%20by%20Convex**%0A%0AThe%20diagnostic%20branches%20only%20fire%20when%20%60convexAuthToken%60%20is%20%60null%60.%20If%20Clerk%20returns%20a%20token%20successfully%20but%20Convex%20rejects%20it%20at%20verification%20time%20%28e.g.%2C%20the%20%60convex%60%20JWT%20template%20is%20misconfigured%2C%20the%20token%20has%20a%20wrong%20audience%2C%20or%20it%20expires%20in%20the%20network%20gap%29%2C%20%60convexAuthToken%60%20is%20non-null%20so%20all%20%60if%20%28!convexAuthToken%29%60%20branches%20are%20skipped.%20Convex%20then%20sees%20%60identity%20%3D%20null%60%2C%20%60hasMatchingAuthenticatedUser%20%3D%20false%60%2C%20falls%20to%20the%20HMAC%20path%2C%20and%20returns%20FORBIDDEN%20with%20no%20server-side%20log%20entry%20pointing%20at%20the%20token%20rejection.%20Adding%20a%20warning%20when%20the%20mutation%20returns%20FORBIDDEN%20despite%20a%20non-null%20%60convexAuthToken%60%20would%20make%20this%20failure%20mode%20traceable%20in%20production.%0A%0A&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
convex/myFunctions.ts:113-123
**Custom timing-safe comparison in a JIT-compiled runtime**

`timingSafeStringEqual` is a hand-rolled constant-time comparator, but JavaScript JIT compilers (V8, etc.) are free to optimize the bitwise-OR accumulation loop in ways that break constant-time guarantees. For hex-encoded HMAC-SHA-256 signatures specifically, both strings are always 64 characters, so the early length exit leaks nothing meaningful. The concern is that the loop body itself may not be executed in constant time under JIT optimization. If Convex exposes `crypto.subtle.timingSafeEqual` (or a Uint8Array comparison path is feasible here), that would be a more reliable choice for the comparison.

### Issue 2 of 2
app/actions/payment.ts:52-83
**Silent failure when a non-null `convexAuthToken` is rejected by Convex**

The diagnostic branches only fire when `convexAuthToken` is `null`. If Clerk returns a token successfully but Convex rejects it at verification time (e.g., the `convex` JWT template is misconfigured, the token has a wrong audience, or it expires in the network gap), `convexAuthToken` is non-null so all `if (!convexAuthToken)` branches are skipped. Convex then sees `identity = null`, `hasMatchingAuthenticatedUser = false`, falls to the HMAC path, and returns FORBIDDEN with no server-side log entry pointing at the token rejection. Adding a warning when the mutation returns FORBIDDEN despite a non-null `convexAuthToken` would make this failure mode traceable in production.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: clarify checkout auth fallback logg..."](https://github.com/ayushj1001/mindpoint/commit/30a8689ea6426b6e08baec9cdec48f7380f4c973) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38671725)</sub>

<!-- /greptile_comment -->