### PR TITLE
Fix checkout HMAC verification in Convex runtime

### DIFF
--- a/convex/myFunctions.ts
+++ b/convex/myFunctions.ts
@@ -1,4 +1,7 @@
 import { v } from "convex/values";
+import { hmac } from "@noble/hashes/hmac";
+import { sha256 } from "@noble/hashes/sha2";
+import { bytesToHex, utf8ToBytes } from "@noble/hashes/utils";
 import { query, mutation, action } from "./_generated/server";
 import { api, internal } from "./_generated/api";
 import { MutationCtx } from "./_generated/server";
@@ -99,12 +102,6 @@ function checkoutAuthorizationMessage(args: {
   return `${args.checkoutAttemptId}:${args.userId}:${args.timestamp}`;
 }
 
-function bytesToHex(bytes: Uint8Array) {
-  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
-    "",
-  );
-}
-
 function timingSafeStringEqual(a: string, b: string): boolean {
   if (a.length !== b.length) {
     return false;
@@ -124,28 +121,16 @@ function checkoutIdentityMatchesUser(
   return identity?.subject === userId;
 }
 
-async function createCheckoutAuthorizationSignature(
+function createCheckoutAuthorizationSignature(
   serverSecret: string,
   message: string,
 ) {
-  const encoder = new TextEncoder();
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(serverSecret),
-    { hash: "SHA-256", name: "HMAC" },
-    false,
-    ["sign"],
+  return bytesToHex(
+    hmac(sha256, utf8ToBytes(serverSecret), utf8ToBytes(message)),
   );
-  const signature = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    encoder.encode(message),
-  );
-
-  return bytesToHex(new Uint8Array(signature));
 }
 
-async function isValidCheckoutAuthorization(args: {
+function isValidCheckoutAuthorization(args: {
   authorization?: { signature: string; timestamp: number };
   checkoutAttemptId: string;
   userId: string;
@@ -163,7 +148,7 @@ async function isValidCheckoutAuthorization(args: {
     return false;
   }
 
-  const expectedSignature = await createCheckoutAuthorizationSignature(
+  const expectedSignature = createCheckoutAuthorizationSignature(
     serverSecret,
     checkoutAuthorizationMessage({
       checkoutAttemptId: args.checkoutAttemptId,
@@ -1537,11 +1522,11 @@ export const handleCartCheckout = mutation({
 
       const hasAuthorizedCheckoutServerRequest =
         checkoutAttempt.buyerUserId === args.userId &&
-        (await isValidCheckoutAuthorization({
+        isValidCheckoutAuthorization({
           authorization: args.checkoutAuthorization,
           checkoutAttemptId: args.checkoutAttemptId,
           userId: args.userId,
-        }));
+        });
 
       if (
         !hasMatchingAuthenticatedUser &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@clerk/nextjs": "^7.0.12",
         "@hookform/resolvers": "^5.2.1",
         "@icons-pack/react-simple-icons": "^13.7.0",
+        "@noble/hashes": "^1.8.0",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.10",
@@ -1937,6 +1938,18 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@clerk/nextjs": "^7.0.12",
     "@hookform/resolvers": "^5.2.1",
     "@icons-pack/react-simple-icons": "^13.7.0",
+    "@noble/hashes": "^1.8.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.10",


### PR DESCRIPTION
## Summary
- Replace Convex mutation Web Crypto HMAC verification with @noble/hashes pure-JS HMAC-SHA256.
- Keep the existing checkout authorization signature format unchanged.
- Avoid runtime-only Convex Server Error during QR checkout enrollment finalization.

## Testing
- npm run type-check
- npm run type-check:convex
- npm run lint
- npm run test:checkout-reconciliation
- npm run build with CI dummy env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized checkout authorization signature verification with improved cryptographic handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the async `crypto.subtle` Web Crypto HMAC-SHA256 implementation in Convex mutations with the synchronous `@noble/hashes` pure-JS equivalent, fixing a Convex runtime error that prevented QR checkout enrollment finalization.

- **HMAC swap**: `createCheckoutAuthorizationSignature` and `isValidCheckoutAuthorization` are converted from `async`/`await` to synchronous functions, with the `crypto.subtle` key-import and sign steps replaced by `hmac(sha256, key, message)` from `@noble/hashes`.
- **Cleanup**: The local `bytesToHex` helper is removed in favor of the one exported by `@noble/hashes/utils`; `utf8ToBytes` replaces `new TextEncoder().encode()`, yielding identical byte sequences for all valid UTF-8 inputs.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the HMAC computation logic is unchanged and the @noble/hashes API is used correctly throughout.

The swap from async Web Crypto to synchronous @noble/hashes is a well-scoped runtime-compatibility fix. The key/message argument order matches the @noble/hashes API, utf8ToBytes produces byte-identical output to TextEncoder for all valid UTF-8 inputs, and the replaced bytesToHex helper yields the same lowercase hex encoding. No authorization logic, secret handling, or signature format was altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| convex/myFunctions.ts | Core logic change: async Web Crypto HMAC replaced with synchronous @noble/hashes; call sites updated accordingly; bytesToHex local helper removed. Implementation is correct and argument order matches the @noble/hashes API (hash, key, message). |
| package.json | Adds @noble/hashes ^1.8.0 as a production dependency to support the HMAC swap. |
| package-lock.json | Lock file updated to pin @noble/hashes 1.8.0 with integrity hash and MIT license. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Mutation as "Convex Mutation"
    participant Validator as "isValidCheckoutAuthorization"
    participant Signer as "createCheckoutAuthorizationSignature"
    participant Noble as "@noble/hashes"

    Client->>Mutation: "checkoutAuthorization { signature, timestamp }"
    Mutation->>Validator: "authorization, checkoutAttemptId, userId"
    Validator->>Validator: "validate timestamp window"
    Validator->>Signer: "serverSecret, message"
    Signer->>Noble: "hmac(sha256, utf8ToBytes(key), utf8ToBytes(msg))"
    Noble-->>Signer: "Uint8Array"
    Signer-->>Validator: "hex string (expectedSignature)"
    Validator->>Validator: "timingSafeStringEqual(provided, expected)"
    Validator-->>Mutation: "boolean"
    Mutation-->>Client: "enrollment result or FORBIDDEN"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Mutation as "Convex Mutation"
    participant Validator as "isValidCheckoutAuthorization"
    participant Signer as "createCheckoutAuthorizationSignature"
    participant Noble as "@noble/hashes"

    Client->>Mutation: "checkoutAuthorization { signature, timestamp }"
    Mutation->>Validator: "authorization, checkoutAttemptId, userId"
    Validator->>Validator: "validate timestamp window"
    Validator->>Signer: "serverSecret, message"
    Signer->>Noble: "hmac(sha256, utf8ToBytes(key), utf8ToBytes(msg))"
    Noble-->>Signer: "Uint8Array"
    Signer-->>Validator: "hex string (expectedSignature)"
    Validator->>Validator: "timingSafeStringEqual(provided, expected)"
    Validator-->>Mutation: "boolean"
    Mutation-->>Client: "enrollment result or FORBIDDEN"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid web crypto in checkout hmac v..."](https://github.com/ayushj1001/mindpoint/commit/eaab739e59d1f18e9be12fa930cda210e10156c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38706011)</sub>

<!-- /greptile_comment -->