### PR TITLE
feat: replace UPI transaction ID with payment screenshot at checkout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@
 
 - Never commit `.env*`; use environment variables referenced in `setup-env.sh` and Convex dashboard secrets.
 - Rotate API keys after using local scripts and confirm rate-limit thresholds in `convex/rateLimit.ts` before scaling traffic.
+- User-supplied UploadThing URLs (e.g. payment screenshots) are validated server-side in the Convex mutation before persisting — HTTPS, no embedded userinfo, and an UploadThing host allowlist (`sanitizeUploadThingUrl` in `convex/myFunctions.ts`). The non-admin `paymentScreenshotUploader` route is auth-gated and per-user rate-limited (`uploadRatelimit`).
+- Render UploadThing-hosted images (arbitrary remote URLs) with `next/image` using the `unoptimized` prop — not a raw `<img>`. The host allowlist lives in `next.config.ts` `images.remotePatterns`; `unoptimized` skips the optimizer while keeping the component consistent across buyer and admin surfaces.
 
 ## Cursor Cloud specific instructions
 

--- a/app/admin/enrollments/[enrollmentId]/page.tsx
+++ b/app/admin/enrollments/[enrollmentId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
+import Image from "next/image";
 import Link from "next/link";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@/lib/backend/api";
@@ -324,11 +325,13 @@ export default function AdminEnrollmentDetailPage() {
                 rel="noopener noreferrer"
                 className="mt-2 block w-fit"
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
+                <Image
                   src={detail.paymentScreenshotUrl}
                   alt="Payment screenshot"
-                  className="max-h-64 w-auto rounded-md border"
+                  width={400}
+                  height={256}
+                  unoptimized
+                  className="h-auto max-h-64 w-auto rounded-md border"
                 />
                 <span className="text-xs text-blue-600 underline">
                   Open full size

--- a/app/admin/enrollments/[enrollmentId]/page.tsx
+++ b/app/admin/enrollments/[enrollmentId]/page.tsx
@@ -315,6 +315,29 @@ export default function AdminEnrollmentDetailPage() {
               ? formatTimestamp(detail.lastConfirmationSentAt)
               : "Not resent yet"}
           </p>
+          <div>
+            <strong>Payment Screenshot:</strong>{" "}
+            {detail.paymentScreenshotUrl ? (
+              <a
+                href={detail.paymentScreenshotUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 block w-fit"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={detail.paymentScreenshotUrl}
+                  alt="Payment screenshot"
+                  className="max-h-64 w-auto rounded-md border"
+                />
+                <span className="text-xs text-blue-600 underline">
+                  Open full size
+                </span>
+              </a>
+            ) : (
+              "Not provided"
+            )}
+          </div>
         </CardContent>
       </Card>
 

--- a/app/api/uploadthing/core.ts
+++ b/app/api/uploadthing/core.ts
@@ -4,6 +4,7 @@ import { UploadThingError } from "uploadthing/server";
 import { hasAdminAccess } from "@/lib/admin-access";
 import { resolveAuthEmail } from "@/lib/clerk-email";
 import { isClerkServerConfigured } from "@/lib/clerk-env";
+import { uploadRatelimit } from "@/lib/rate-limit";
 
 const f = createUploadthing();
 
@@ -23,6 +24,30 @@ async function adminMiddleware() {
   const uploaderId = userId ?? sessionEmail;
   if (!uploaderId) {
     throw new UploadThingError("Unauthorized");
+  }
+
+  return { userId: uploaderId };
+}
+
+// Buyers upload a payment screenshot during checkout, so this route only
+// requires an authenticated Clerk user (not admin access).
+async function authenticatedUserMiddleware() {
+  if (!isClerkServerConfigured()) {
+    throw new UploadThingError("Unauthorized");
+  }
+
+  const { userId, sessionClaims } = await auth();
+  const sessionEmail = await resolveAuthEmail(sessionClaims);
+  const uploaderId = userId ?? sessionEmail;
+  if (!uploaderId) {
+    throw new UploadThingError("Unauthorized");
+  }
+
+  // Cap per-user upload spam on this non-admin route. No-ops when Redis is
+  // unconfigured; never blocks a legitimate buyer within the limit.
+  const { success } = await uploadRatelimit.limit(uploaderId);
+  if (!success) {
+    throw new UploadThingError("Too many uploads. Please wait and try again.");
   }
 
   return { userId: uploaderId };
@@ -64,6 +89,20 @@ export const ourFileRouter = {
     },
   })
     .middleware(adminMiddleware)
+    .onUploadComplete(async ({ metadata, file }) => {
+      return {
+        uploadedBy: metadata.userId,
+        url: file.ufsUrl,
+      };
+    }),
+
+  paymentScreenshotUploader: f({
+    image: {
+      maxFileSize: "4MB",
+      maxFileCount: 1,
+    },
+  })
+    .middleware(authenticatedUserMiddleware)
     .onUploadComplete(async ({ metadata, file }) => {
       return {
         uploadedBy: metadata.userId,

--- a/components/CartClient.tsx
+++ b/components/CartClient.tsx
@@ -49,6 +49,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { UploadDropzone } from "@/lib/uploadthing";
 import Link from "next/link";
 import { Check, X } from "lucide-react";
 import { useNow } from "@/hooks/use-now";
@@ -217,7 +218,8 @@ const CartContent = () => {
   const [qrImageAvailable, setQrImageAvailable] = useState(true);
   const [qrPaymentSession, setQrPaymentSession] =
     useState<PaymentSession | null>(null);
-  const [upiTransactionReference, setUpiTransactionReference] = useState("");
+  const [paymentScreenshotUrl, setPaymentScreenshotUrl] = useState("");
+  const [isUploadingScreenshot, setIsUploadingScreenshot] = useState(false);
   const [pendingQrWhatsAppNumber, setPendingQrWhatsAppNumber] = useState<
     string | undefined
   >();
@@ -850,6 +852,7 @@ const CartContent = () => {
         checkoutAttemptId?: string;
         razorpayOrderId?: string;
         razorpayPaymentId?: string;
+        paymentScreenshotUrl?: string;
         checkoutPricingOverride?: typeof checkoutPricing;
       } = {},
     ) => {
@@ -996,7 +999,8 @@ const CartContent = () => {
 
       setQrPaymentSession(paymentOrder.data);
       setQrImageAvailable(true);
-      setUpiTransactionReference("");
+      setPaymentScreenshotUrl("");
+      setIsUploadingScreenshot(false);
       setPendingQrWhatsAppNumber(whatsappNumber);
       setShowQrPaymentDialog(true);
       setIsProcessing(false);
@@ -1016,9 +1020,9 @@ const CartContent = () => {
   const handleQrPaymentConfirmed = useCallback(async () => {
     if (!qrPaymentSession) return;
 
-    const paymentReference = upiTransactionReference.trim();
-    if (paymentReference.length < 6) {
-      toast.error("Enter the UPI transaction reference number.");
+    const screenshotUrl = paymentScreenshotUrl.trim();
+    if (!screenshotUrl) {
+      toast.error("Upload a screenshot of your successful payment.");
       return;
     }
 
@@ -1030,7 +1034,7 @@ const CartContent = () => {
         {
           checkoutAttemptId: qrPaymentSession.checkoutAttemptId,
           razorpayOrderId: qrPaymentSession.id,
-          razorpayPaymentId: paymentReference,
+          paymentScreenshotUrl: screenshotUrl,
           checkoutPricingOverride: qrPaymentSession.reconciliation
             ?.checkoutPricing as typeof checkoutPricing | undefined,
         },
@@ -1040,7 +1044,8 @@ const CartContent = () => {
         emptyCart();
         setShowQrPaymentDialog(false);
         setQrPaymentSession(null);
-        setUpiTransactionReference("");
+        setPaymentScreenshotUrl("");
+        setIsUploadingScreenshot(false);
         setPendingQrWhatsAppNumber(undefined);
       }
     } finally {
@@ -1051,7 +1056,7 @@ const CartContent = () => {
     emptyCart,
     pendingQrWhatsAppNumber,
     qrPaymentSession,
-    upiTransactionReference,
+    paymentScreenshotUrl,
   ]);
 
   // Check for WhatsApp number after sign-in and proceed with checkout
@@ -1723,10 +1728,17 @@ const CartContent = () => {
       <Dialog
         open={showQrPaymentDialog}
         onOpenChange={(open) => {
+          // Don't allow the dialog to close (and reset state) while a screenshot
+          // is still uploading — the in-flight URL would be silently discarded.
+          if (!open && (isProcessing || isUploadingScreenshot)) {
+            return;
+          }
           setShowQrPaymentDialog(open);
-          if (!open && !isProcessing) {
+          if (!open) {
             setQrPaymentSession(null);
             setPendingQrWhatsAppNumber(undefined);
+            setPaymentScreenshotUrl("");
+            setIsUploadingScreenshot(false);
           }
         }}
       >
@@ -1764,34 +1776,79 @@ const CartContent = () => {
               </div>
             )}
 
-            <label className="space-y-2 text-sm">
-              <span className="font-medium">UPI transaction ID</span>
-              <Input
-                value={upiTransactionReference}
-                onChange={(event) =>
-                  setUpiTransactionReference(event.target.value)
-                }
-                placeholder="Enter reference number after payment"
-                autoComplete="off"
-              />
-            </label>
+            <div className="space-y-2 text-sm">
+              <span className="font-medium">Payment screenshot</span>
+              <p className="text-muted-foreground text-xs">
+                After paying, upload a screenshot of the successful transaction
+                from your UPI app.
+              </p>
+              {paymentScreenshotUrl ? (
+                <div className="space-y-2">
+                  <div className="mx-auto w-full max-w-[220px] overflow-hidden rounded-md border">
+                    <Image
+                      src={paymentScreenshotUrl}
+                      alt="Uploaded payment screenshot"
+                      width={440}
+                      height={440}
+                      className="h-auto w-full object-contain"
+                      unoptimized
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="w-full"
+                    onClick={() => setPaymentScreenshotUrl("")}
+                    disabled={isProcessing}
+                  >
+                    Replace screenshot
+                  </Button>
+                </div>
+              ) : (
+                <UploadDropzone
+                  endpoint="paymentScreenshotUploader"
+                  onUploadBegin={() => setIsUploadingScreenshot(true)}
+                  onClientUploadComplete={(res) => {
+                    setIsUploadingScreenshot(false);
+                    const url = res?.[0]?.serverData?.url;
+                    if (url) {
+                      setPaymentScreenshotUrl(url);
+                      toast.success("Screenshot uploaded.");
+                    } else {
+                      toast.error("Upload failed. Please try again.");
+                    }
+                  }}
+                  onUploadError={(error) => {
+                    setIsUploadingScreenshot(false);
+                    toast.error(error.message || "Screenshot upload failed.");
+                  }}
+                  config={{ mode: "auto" }}
+                  className="ut-button:bg-primary ut-button:text-primary-foreground ut-label:text-foreground border-muted-foreground/30 mt-0"
+                />
+              )}
+            </div>
           </div>
 
           <DialogFooter className="gap-2 sm:gap-0">
             <Button
               variant="outline"
               onClick={() => setShowQrPaymentDialog(false)}
-              disabled={isProcessing}
+              disabled={isProcessing || isUploadingScreenshot}
             >
               Cancel
             </Button>
             <Button
               onClick={handleQrPaymentConfirmed}
               disabled={
-                isProcessing || upiTransactionReference.trim().length < 6
+                isProcessing || isUploadingScreenshot || !paymentScreenshotUrl
               }
             >
-              {isProcessing ? "Finishing..." : "Confirm payment"}
+              {isProcessing
+                ? "Finishing..."
+                : isUploadingScreenshot
+                  ? "Uploading..."
+                  : "Confirm payment"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/convex/myFunctions.ts
+++ b/convex/myFunctions.ts
@@ -366,8 +366,18 @@ function sanitizeUploadThingUrl(value: string | undefined): string | undefined {
   }
   try {
     const parsed = new URL(trimmed);
-    if (parsed.protocol === "https:" && isUploadThingHost(parsed.hostname)) {
-      return trimmed;
+    // Reject embedded credentials (userinfo). `parsed.hostname` ignores
+    // userinfo, so `https://user@utfs.io/...` would otherwise pass the host
+    // check while persisting an attacker-controlled credential string.
+    const hasUserInfo = parsed.username !== "" || parsed.password !== "";
+    if (
+      parsed.protocol === "https:" &&
+      !hasUserInfo &&
+      isUploadThingHost(parsed.hostname)
+    ) {
+      // Store the parser's canonical serialization so the persisted value is
+      // exactly what we validated, not the raw (possibly odd) input.
+      return parsed.href;
     }
   } catch {
     // Malformed URL — fall through and drop it.

--- a/convex/myFunctions.ts
+++ b/convex/myFunctions.ts
@@ -347,6 +347,34 @@ function normalizeOptionalNumber(value: unknown) {
   return rounded > 0 ? rounded : undefined;
 }
 
+// Hosts that UploadThing serves uploaded files from (mirrors the allowed image
+// hosts in next.config.ts). Anything else is treated as untrusted and dropped.
+function isUploadThingHost(hostname: string): boolean {
+  return (
+    hostname === "utfs.io" ||
+    hostname === "uploadthing.com" ||
+    hostname === "files.uploadthing.com" ||
+    hostname.endsWith(".ufs.sh") ||
+    hostname.endsWith(".utfs.io")
+  );
+}
+
+function sanitizeUploadThingUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "https:" && isUploadThingHost(parsed.hostname)) {
+      return trimmed;
+    }
+  } catch {
+    // Malformed URL — fall through and drop it.
+  }
+  return undefined;
+}
+
 function checkoutPricingMatchesAttempt(
   submitted: CheckoutPricing | undefined,
   attemptPricing: CheckoutPricing,
@@ -1465,6 +1493,7 @@ export const handleCartCheckout = mutation({
     checkoutAttemptId: v.optional(v.id("checkoutAttempts")),
     razorpayOrderId: v.optional(v.string()),
     razorpayPaymentId: v.optional(v.string()),
+    paymentScreenshotUrl: v.optional(v.string()),
   },
 
   handler: async (ctx, args) => {
@@ -1487,6 +1516,11 @@ export const handleCartCheckout = mutation({
     let totalPointsEarnedForOrder = 0;
     let firstPaidEnrollmentId: Id<"enrollments"> | null = null;
     const paymentReference = args.razorpayPaymentId?.trim();
+    // Only persist screenshot URLs that come from the UploadThing CDN. The value
+    // is client-supplied (any authenticated user can call this mutation directly)
+    // and is later rendered into the admin dashboard, so we reject arbitrary URLs
+    // to avoid pointing an admin's browser at attacker-controlled hosts.
+    const paymentScreenshotUrl = sanitizeUploadThingUrl(args.paymentScreenshotUrl);
     let checkoutAttempt: Doc<"checkoutAttempts"> | null = null;
     const consumedAdminCouponCodes = new Set<string>();
     const remainingAdminCouponDiscountByCode = new Map<string, number>();
@@ -1677,6 +1711,8 @@ export const handleCartCheckout = mutation({
           args.razorpayOrderId ?? checkoutAttempt.razorpayOrderId,
         razorpayPaymentId:
           paymentReference ?? checkoutAttempt.razorpayPaymentId,
+        paymentScreenshotUrl:
+          paymentScreenshotUrl ?? checkoutAttempt.paymentScreenshotUrl,
         status: "payment_captured",
         updatedAt: Date.now(),
       });
@@ -1752,6 +1788,7 @@ export const handleCartCheckout = mutation({
         checkoutAttemptId: args.checkoutAttemptId,
         razorpayOrderId: args.razorpayOrderId,
         razorpayPaymentId: paymentReference,
+        paymentScreenshotUrl,
         referrerClerkUserId: args.referrerClerkUserId,
       });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -308,6 +308,7 @@ const publicEnrollmentFields = {
   checkoutAttemptId: v.optional(v.id("checkoutAttempts")),
   razorpayOrderId: v.optional(v.string()),
   razorpayPaymentId: v.optional(v.string()),
+  paymentScreenshotUrl: v.optional(v.string()),
   referrerClerkUserId: v.optional(v.string()),
 };
 
@@ -490,6 +491,7 @@ export default defineSchema({
     validationSummary: v.any(),
     razorpayOrderId: v.optional(v.string()),
     razorpayPaymentId: v.optional(v.string()),
+    paymentScreenshotUrl: v.optional(v.string()),
     buyerUserId: v.optional(v.string()),
     buyerEmail: v.optional(v.string()),
     referrerClerkUserId: v.optional(v.string()),

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -69,6 +69,15 @@ export const authRatelimit = createRateLimiter(
   "@upstash/ratelimit/auth",
 );
 
+// Ratelimiter for buyer-facing file uploads (payment screenshots). Generous
+// enough for a buyer to retry / replace a screenshot a few times, but caps
+// per-user spam of the non-admin upload route. No-ops when Redis is unset.
+export const uploadRatelimit = createRateLimiter(
+  10,
+  "1 m",
+  "@upstash/ratelimit/upload",
+);
+
 // Helper function to get client identifier
 export function getClientIdentifier(req: Request): string {
   // Try to get IP from various headers

--- a/lib/services/checkout.ts
+++ b/lib/services/checkout.ts
@@ -90,6 +90,7 @@ type PaymentSuccessOptions = CheckoutMutationOptions & {
   checkoutAttemptId?: string;
   razorpayOrderId?: string;
   razorpayPaymentId?: string;
+  paymentScreenshotUrl?: string;
 };
 
 type GuestCheckoutUserData = {
@@ -461,6 +462,7 @@ export function handlePaymentSuccessEffect(
           lineItems,
           razorpayOrderId: options.razorpayOrderId,
           razorpayPaymentId: options.razorpayPaymentId,
+          paymentScreenshotUrl: options.paymentScreenshotUrl,
           referrerClerkUserId,
           sessionType,
           studentName,


### PR DESCRIPTION
## Summary

Replaces the "paste your UPI transaction ID" step in the QR checkout with a **required payment-screenshot upload**. Buyers were confused by the transaction-ID step and some enrolled without paying.

Payment is verified **manually** for now — admins review the uploaded screenshot (plus communication with the user). This is a temporary bridge until KYC is complete, after which verification becomes programmatic via a payment API (e.g. PhonePe).

## Changes

| Area | Change |
|------|--------|
| `convex/schema.ts` | Add optional `paymentScreenshotUrl` to enrollments + checkoutAttempts (additive, no migration) |
| `convex/myFunctions.ts` | `handleCartCheckout` accepts, validates (UploadThing CDN host allowlist), and persists the URL |
| `lib/services/checkout.ts` | Thread `paymentScreenshotUrl` through `PaymentSuccessOptions` → mutation args |
| `app/api/uploadthing/core.ts` | New `paymentScreenshotUploader`: signed-in-buyer gated (not admin), image-only, 4MB, per-user rate-limited |
| `lib/rate-limit.ts` | Add `uploadRatelimit` (10/min/user, no-ops without Redis) |
| `components/CartClient.tsx` | Swap text input for `UploadDropzone` (preview + replace); confirm gated until upload completes; dismiss blocked mid-upload |
| `app/admin/enrollments/[enrollmentId]/page.tsx` | Show the screenshot inline for manual verification |

## Intentional tradeoffs (not bugs)

- The cross-attempt duplicate-payment check (`by_razorpayPaymentId` CONFLICT) no longer fires for buyer checkouts since the typed reference is gone. Reuse/fakes are caught by manual review during the manual-verification phase. Per-attempt idempotency (keyed on `checkoutAttemptId` → `finalized`) still holds.
- A screenshot URL is a manual-verification aid, not an automated payment gate.

## Deferred

- Orphaned-screenshot cleanup: unsafe to do naively because course images, worksheets, and screenshots share one UploadThing app with no per-route tag. Needs a dedicated tracking table to be safe; deferred given negligible storage cost for this temporary flow.

## Verification

- `tsc --noEmit` (app + convex) ✅
- `eslint` on changed files ✅
- Adversarial multi-agent review run pre-PR; confirmed findings fixed (URL validation, mid-upload dismiss guard, file-size cap, rate-limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payment screenshot upload functionality for QR/UPI checkout confirmation—users can now upload proof of payment instead of entering a transaction ID
  * Enrollment snapshot section now displays uploaded payment screenshots with thumbnail preview and full-size view options
  * Payment screenshots are securely stored, validated, and persisted with enrollment records to ensure data integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the UPI transaction-ID text field in the QR checkout flow with a required payment-screenshot upload, using UploadThing for file storage and Convex for server-side URL validation before persistence. It is a temporary manual-verification bridge until a payment API is integrated.

- **Schema + mutation**: `paymentScreenshotUrl` is added as an optional field to both `enrollments` and `checkoutAttempts`; a `sanitizeUploadThingUrl` helper enforces HTTPS, no embedded credentials, and an UploadThing CDN host allowlist before writing the URL.
- **Frontend**: `CartClient.tsx` swaps the text `<Input>` for an `UploadDropzone` with upload-state guards (disabled buttons and dismiss prevention while uploading); the admin enrollment page renders the stored screenshot using `next/image` with `unoptimized`.
- **Auth + rate limiting**: The new `paymentScreenshotUploader` UploadThing route is gated to authenticated Clerk users (not admin-only) and per-user rate-limited via `uploadRatelimit` (10/min, no-ops without Redis).

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge. All server-side validation is in place, upload auth is properly gated, and the schema changes are purely additive.

The URL sanitization function correctly enforces HTTPS, strips embedded credentials, checks the UploadThing host allowlist, and returns the parser's canonical href. The upload route requires a valid Clerk session, is rate-limited, and restricts to images under 4 MB. The UI properly prevents checkout confirmation and dialog dismissal during an in-flight upload. Schema changes are optional fields with no migration. Previous review thread findings (canonical href return, next/image in admin page) are both resolved in this diff.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| convex/myFunctions.ts | Adds sanitizeUploadThingUrl (HTTPS + no userinfo + host allowlist, returns parsed.href), threads paymentScreenshotUrl through handleCartCheckout with coalesce onto existing checkoutAttempt value, and persists to enrollment. Well-guarded. |
| components/CartClient.tsx | Replaces UPI text input with UploadDropzone; isUploadingScreenshot flag disables Cancel and Confirm buttons and blocks onOpenChange dismiss during upload. State resets on new checkout initiation. |
| app/api/uploadthing/core.ts | New paymentScreenshotUploader route with authenticatedUserMiddleware (Clerk session + per-user rate limit); image-only, 4 MB cap, single file. Correctly separate from admin-gated imageUploader. |
| convex/schema.ts | Additive optional paymentScreenshotUrl field on both enrollments and checkoutAttempts; no migration required. |
| lib/rate-limit.ts | Adds uploadRatelimit (10 req/min/user) using the same createRateLimiter factory as existing limiters; no-ops gracefully when Redis is absent. |
| lib/services/checkout.ts | PaymentSuccessOptions extended with optional paymentScreenshotUrl and threaded through to the Convex mutation args. Minimal, correct change. |
| app/admin/enrollments/[enrollmentId]/page.tsx | Screenshot displayed using next/image with unoptimized prop (consistent with CartClient and AGENTS.md guidance); wrapped in an anchor for full-size view. No raw img element. |
| AGENTS.md | Documents the new UploadThing URL validation pattern and next/image unoptimized convention for future agents and reviewers. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Buyer as Buyer (CartClient)
    participant UT as UploadThing CDN
    participant UTRoute as /api/uploadthing (core.ts)
    participant Convex as Convex Mutation (handleCartCheckout)
    participant DB as Convex DB

    Buyer->>UTRoute: Drop screenshot file (authenticated Clerk session)
    UTRoute->>UTRoute: "authenticatedUserMiddleware()<br/>Verify Clerk session + uploadRatelimit.limit(userId)"
    UTRoute-->>Buyer: Authorized
    Buyer->>UT: Upload image (max 4MB)
    UT-->>Buyer: "onClientUploadComplete({ serverData: { url } })"
    Buyer->>Buyer: "setPaymentScreenshotUrl(url), isUploadingScreenshot = false"
    Note over Buyer: Confirm payment button enabled
    Buyer->>Convex: "handleCartCheckout({ paymentScreenshotUrl: url, ... })"
    Convex->>Convex: "sanitizeUploadThingUrl(url)<br/>HTTPS only, no credentials, host allowlist, returns parsed.href"
    Convex->>DB: "patch checkoutAttempt { paymentScreenshotUrl }"
    Convex->>DB: "createEnrollment { paymentScreenshotUrl }"
    DB-->>Convex: Enrollment created
    Convex-->>Buyer: Success
    Note over Buyer: Cart emptied, dialog closed
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Buyer as Buyer (CartClient)
    participant UT as UploadThing CDN
    participant UTRoute as /api/uploadthing (core.ts)
    participant Convex as Convex Mutation (handleCartCheckout)
    participant DB as Convex DB

    Buyer->>UTRoute: Drop screenshot file (authenticated Clerk session)
    UTRoute->>UTRoute: "authenticatedUserMiddleware()<br/>Verify Clerk session + uploadRatelimit.limit(userId)"
    UTRoute-->>Buyer: Authorized
    Buyer->>UT: Upload image (max 4MB)
    UT-->>Buyer: "onClientUploadComplete({ serverData: { url } })"
    Buyer->>Buyer: "setPaymentScreenshotUrl(url), isUploadingScreenshot = false"
    Note over Buyer: Confirm payment button enabled
    Buyer->>Convex: "handleCartCheckout({ paymentScreenshotUrl: url, ... })"
    Convex->>Convex: "sanitizeUploadThingUrl(url)<br/>HTTPS only, no credentials, host allowlist, returns parsed.href"
    Convex->>DB: "patch checkoutAttempt { paymentScreenshotUrl }"
    Convex->>DB: "createEnrollment { paymentScreenshotUrl }"
    DB-->>Convex: Enrollment created
    Convex-->>Buyer: Success
    Note over Buyer: Cart emptied, dialog closed
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: harden screenshot URL sanitize + us..."](https://github.com/ayushj1001/mindpoint/commit/2bd18f52520288b5503f4a09d17aaa598f0c828e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38949595)</sub>

<!-- /greptile_comment -->